### PR TITLE
SEP-0001 fixes

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -1,11 +1,11 @@
 ## Preamble
 
 ```
-SEP: <to be assigned>
+SEP: 0001
 Title: Tx Status Endpoint
-Author: <list of authors' names and optionally, email addresses>
+Author: Jed McCaleb
 Status: Draft
-Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+Created: 2017-08-05
 ```
 
 ## Simple Summary
@@ -14,37 +14,46 @@ Simple way to get the status of a payment that has been sent through the complia
 ## Abstract
 In many cases the sender needs to get additional info from the receiver after the payment is sent. To either tell their customer or for their own records. 
 
-After a tx is approved by the compliance protocol and submitted to Stellar,  the sender can call `/tx_status` to learn what happened to the tx.
+After a tx is approved by the compliance protocol and submitted to Stellar, the sender can call `/tx_status` to learn what happened to the tx.
 
 ## Specification
 Endpoint at the URL specified by `AUTH_SERVER` in the stellar.toml file of an institution that receives payments. This endpoint is used to relay the status of payments to the sender or other interested parties. 
 Can be used for simple informational purposes or to convey a code needed by the individual to claim the money on the receiving end. 
 
+### Request
+
 ```
-AUTH_SERVER/tx_status?id=tx_id
-return
+GET AUTH_SERVER/tx_status?id=tx_id
+```
+
+* `id` The Stellar transaction ID of of the payment we are interested in.
+
+### Response
+
+HTTP status code:
+* `404` if tx with a given ID has not been found.
+* `5xx` in case of server error.
+* `200` in other cases.
+
+```
 {
 	status: <status code see below>,
 	recv_code: <arbitrary string>,
 	refund_tx: <tx_hash>,
-    msg: <arbitrary string>
+	msg: <arbitrary string>
 }
 ```
-`id` The Stellar transaction ID of of the payment we are interested in.
 
-`refund_tx` only appears if the status is "refunded". It will be the txID of the tx sending the money back. The address to send the refund to needs to be sent as part of the original payment attachment otherwise the receiver won't know how to refund.
-
-`status` is one of the following codes:
-- `unknown` - what money?
-- `approved` - payment was approved by the receiving FI but the Stellar transaction hasn't been received yet.
-- `not_approved` - Stellar transaction was found but it was never approved by the receiving FI.
-- `pending` - payment was received. we are attempting to deposit it. This also covers scenarios where something could not be deposited via the default method, but may be deposited by another method (i.e. electronic deposit failed, but it may be deposited manually and it will take longer)
-- `failed` - we could not deposit it. `msg` should contain more info.
-- `refunded` - payment was sent back to sending FI. Possible reasons: deposit could not be made, or sending FI decided to cancel the cash pick-up payment (sometimes recipient never picks it up).
-- `claimable` - Mostly used for cash pickup. Cash is ready to be picked up at specified locations
-- `delivered` - Receiver should now have the funds, cash has been picked up, or money has been deposited into the bank account.
-
-
+* `status` is one of the following codes:
+	- `unknown` - what money?
+	- `approved` - payment was approved by the receiving FI but the Stellar transaction hasn't been received yet.
+	- `not_approved` - Stellar transaction was found but it was never approved by the receiving FI.
+	- `pending` - payment was received. we are attempting to deposit it. This also covers scenarios where something could not be deposited via the default method, but may be deposited by another method (i.e. electronic deposit failed, but it may be deposited manually and it will take longer)
+	- `failed` - we could not deposit it. `msg` should contain more info.
+	- `refunded` - payment was sent back to sending FI. Possible reasons: deposit could not be made, or sending FI decided to cancel the cash pick-up payment (sometimes recipient never picks it up).
+	- `claimable` - Mostly used for cash pickup. Cash is ready to be picked up at specified locations
+	- `delivered` - Receiver should now have the funds, cash has been picked up, or money has been deposited into the bank account.
+* `refund_tx` only appears if the status is "refunded". It will be the txID of the tx sending the money back. The address to send the refund to needs to be sent as part of the original payment attachment otherwise the receiver won't know how to refund.
 
 ## Rationale
 Prior discussion was done here https://github.com/stellar/bridge-server/issues/59


### PR DESCRIPTION
I added a small fixes to `SEP-0001` but I wanted to outline some bigger issues:
* `recv_code` is not explained in a doc. Is it a code required to pickup cash?
* Tx Status endpoint does not include any authorization mechanism what means that everyone can check tx status. I think that `recv_code` shouldn't be public and `msg` can contain some private data.
* Not sure why current steps of Compliance protocol are included in a doc. This seems redundant and should be a separate SEP.

Also, can we change this repo settings to require at least one approval from other team member before merging? I think this SEP wasn't ready to be merged. 