### PR TITLE
Add existing protocols and errors to Compliance protocol

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -2,74 +2,164 @@
 
 ```
 SEP: <to be assigned>
-Title: Tx Status Endpoint
+Title: stellar.toml
 Author: <list of authors' names and optionally, email addresses>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 ```
 
 ## Simple Summary
-Simple way to get the status of a payment that has been sent through the compliance protocol from the receiver.
 
-## Abstract
-In many cases the sender needs to get additional info from the receiver after the payment is sent. To either tell their customer or for their own records. 
-
-After a tx is approved by the compliance protocol and submitted to Stellar,  the sender can call `/tx_status` to learn what happened to the tx.
+The `stellar.toml` file is used to provide a common place where the Internet can find information about your domain’s Stellar integration. Any website can publish Stellar network information. You can announce your validation key, your federation server, peers you are running, your quorum set, if you are a anchor, etc.
 
 ## Specification
-Endpoint at the URL specified by `AUTH_SERVER` in the stellar.toml file of an institution that receives payments. This endpoint is used to relay the status of payments to the sender or other interested parties. 
-Can be used for simple informational purposes or to convey a code needed by the individual to claim the money on the receiving end. 
+
+Given the domain `DOMAIN`, the `stellar.toml` will be searched for at the following location:
 
 ```
-AUTH_SERVER/tx_status?id=tx_id
-return
-{
-	status: <status code see below>,
-	recv_code: <arbitrary string>,
-	refund_tx: <tx_hash>,
-    msg: <arbitrary string>
-}
+https://DOMAIN/.well-known/stellar.toml
 ```
-`id` The Stellar transaction ID of of the payment we are interested in.
 
-`refund_tx` only appears if the status is "refunded". It will be the txID of the tx sending the money back. The address to send the refund to needs to be sent as part of the original payment attachment otherwise the receiver won't know how to refund.
+You must enable CORS on the stellar.toml so people can access this file from other sites. The following HTTP header must be set for a HTTP response for `/.well-known/stellar.toml` file request.
 
-`status` is one of the following codes:
-- `unknown` - what money?
-- `approved` - payment was approved by the receiving FI but the Stellar transaction hasn't been received yet.
-- `not_approved` - Stellar transaction was found but it was never approved by the receiving FI.
-- `pending` - payment was received. we are attempting to deposit it. This also covers scenarios where something could not be deposited via the default method, but may be deposited by another method (i.e. electronic deposit failed, but it may be deposited manually and it will take longer)
-- `failed` - we could not deposit it. `msg` should contain more info.
-- `refunded` - payment was sent back to sending FI. Possible reasons: deposit could not be made, or sending FI decided to cancel the cash pick-up payment (sometimes recipient never picks it up).
-- `claimable` - Mostly used for cash pickup. Cash is ready to be picked up at specified locations
-- `delivered` - Receiver should now have the funds, cash has been picked up, or money has been deposited into the bank account.
+```
+Access-Control-Allow-Origin: *
+```
 
+`stellar.toml` is in [TOML](https://github.com/toml-lang/toml) file format.
 
+<<List of fields here>>
 
-## Rationale
-Prior discussion was done here https://github.com/stellar/bridge-server/issues/59
+## Testing
 
-Current steps in a payment that goes through the compliance protocol:
+1. Run a curl command in your terminal similar to the following (replace stellar.org with the hosting location of your stellar.toml file):
 
-1. Alice initiates a payment to bob*bankb.com
-2. Client Endpoint A handles request
-3. Client Endpoint debits Alice's account
-4. Client Endpoint A call Bridge A
-5. Bridge A calls Compliance A
-6. Compliance A loads the stellar.toml B
-7. Compliance A resolves bob*bankb.com from federation server B
-8. Compliance A crafts the stellar tx
-9. Compliance A calls Compliance B
-10. Compliance B checks sanctions and other things
-11. Compliance B replies to Compliance A
-12. Compliance A replies to Bridge A with the stellar tx.
-13. Bridge A submits the stellar tx  to horizon A
-14. horizon A submits the tx to stellar-core A
-15. Stellar network does its thing
-16. horizon B sees the tx applied to the ledger
-17. bridge B receives the applied tx to the ledger 
-18. bridge B checks with Compliance B to verify that the tx was approved
-19. bridge B calls receive hook B to finish the payment
-20. Receive hook B credits bob's account
-21. Receive Hook notifies Bob
-22. Bob has been paid.
+```
+curl --head https://stellar.org/.well-known/stellar.toml
+```
+
+2. Verify the Access-Control-Allow-Origin header is present as shown below.
+
+```
+curl --head https://stellar.org/.well-known/stellar.toml
+HTTP/1.1 200 OK
+Accept-Ranges: bytes
+Access-Control-Allow-Origin: *
+Content-length: 482
+...
+```
+
+3. Also run the command on a page that should not have it and verify the `Access-Control-Allow-Origin` header is missing.
+
+## Example
+
+```toml
+# Sample stellar.toml
+
+#   The endpoint which clients should query to resolve stellar addresses
+#   for users on your domain.
+FEDERATION_SERVER="https://api.stellar.org/federation"
+
+# The endpoint used for the compliance protocol
+AUTH_SERVER="https://api.stellar.org/auth"
+
+# The signing key is used for the compliance protocol
+SIGNING_KEY="GBBHQ7H4V6RRORKYLHTCAWP6MOHNORRFJSDPXDFYDGJB2LPZUFPXUEW3"
+
+# convenience mapping of common names to node IDs.
+# You can use these common names in sections below instead of the less friendly nodeID.
+# This is provided mainly to be compatible with the stellar-core.cfg
+NODE_NAMES=[
+"GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3  lab1",
+"GB6REF5GOGGSEHZ3L2YK6K4T4KX3YDMWHDCPMV7MZJDLHBDNZXEPRBGM  donovan",
+"GBGR22MRCIVW2UZHFXMY5UIBJGPYABPQXQ5GGMNCSUM2KHE3N6CNH6G5  nelisky1",
+"GDXWQCSKVYAJSUGR2HBYVFVR7NA7YWYSYK3XYKKFO553OQGOHAUP2PX2  jianing",
+"GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U  anchor"
+]
+
+#   A list of accounts that are controlled by this domain.
+ACCOUNTS=[
+"$sdf_watcher1",
+"GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
+]
+
+#   Any validation public keys that are declared
+#   to be used by this domain for validating ledgers and are
+#   authorized signers for the domain.
+OUR_VALIDATORS=[
+"$sdf_watcher2",
+"GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
+]
+
+# DESIRED_BASE_FEE (integer)
+# This is what you would prefer the base fee to be. It is in stroops.
+DESIRED_BASE_FEE=100
+
+# DESIRED_MAX_TX_PER_LEDGER (integer)
+# This is how many maximum transactions per ledger you would like to process.
+DESIRED_MAX_TX_PER_LEDGER=400
+
+#   List of IPs of known stellar-core's.
+#   These are IP:port strings.
+#   Port is optional.
+#   By convention, IPs are listed from most to least trusted, if that information is known.
+KNOWN_PEERS=[
+"192.168.0.1",
+"core-testnet1.stellar.org",
+"core-testnet2.stellar.org:11290",
+"2001:0db8:0100:f101:0210:a4ff:fee3:9566"
+]
+
+# list of history archives maintained by this domain
+HISTORY=[
+"http://history.stellar.org/prd/core-live/core_live_001/",
+"http://history.stellar.org/prd/core-live/core_live_002/",
+"http://history.stellar.org/prd/core-live/core_live_003/"
+]
+
+#   This section allows an anchor to declare currencies it currently issues.
+#   Can be used by wallets and clients to trust anchors by domain name
+[[CURRENCIES]]
+code="USD"
+issuer="GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM"
+display_decimals=2 # Specifies how many decimal places should be displayed by clients to end users.
+
+[[CURRENCIES]]
+code="BTC"
+issuer="$anchor"
+display_decimals=7 # Maximum decimal places that can be represented is 7
+
+# asset with meta info
+[[CURRENCIES]]
+code="GOAT"
+issuer="GD5T6IPRNCKFOHQWT264YPKOZAWUMMZOLZBJ6BNQMUGPWGRLBK3U7ZNP"
+display_decimals=2
+name="goat share"
+desc="1 GOAT token entitles you to a share of revenue from Elkins Goat Farm."
+conditions="There will only ever be 10,000 GOAT tokens in existence. We will distribute the revenue share annually on Jan. 15th"
+image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
+
+#   Potential quorum set of this domain's validators.
+[QUORUM_SET]
+VALIDATORS=[
+"$self", "$lab1", "$nelisky1","$jianing",
+"$eno","$donovan"
+]
+
+# optional extra information for humans
+# Useful place for anchors to detail various policies and required info
+
+###################################
+# Required compliance fields:
+#      name=<recipient name>
+#      addr=<recipient address>
+# Federation Format:  
+#        <phone number>*anchor.com
+#        Forwarding supported by sending to: forward*anchor.com
+#           forward_type=bank_account
+#           swift=<swift code of receiving bank>
+#           acct=<recipient account number at receiving bank>
+# Minimum Amount Forward: $2 USD
+# Maximum Amount Forward: $10000 USD
+
+```

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -1,99 +1,89 @@
 ## Preamble
 
 ```
-SEP: 00002
-Title: DEPOSIT_SERVER proposal
-Author: @no, @ant, @manran, @pacngfar
+SEP: <to be assigned>
+Title: Federation protocol
+Author: <list of authors' names and optionally, email addresses>
 Status: Draft
-Created: 2018-08-21
+Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 ```
 
 ## Simple Summary
-It will be more convenient, if we have a protocol that standardizes how a wallet communicates with an anchor to fetch the deposit info, guiding the user through the steps in the wallet, instead of opening the anchor's website to find out.
-In many cases the sender needs to get additional info from the receiver after the payment is sent. To either tell their customer or for their own records. 
 
-## Abstract
-Proposal for a standard protocol that allows wallets to pull deposit info from anchors. The model is very similar to how the federation server works.
-
+The Stellar federation protocol maps Stellar addresses to more information about a given user. It’s a way for Stellar client software to resolve email-like addresses such as `name*yourdomain.com` into account IDs like: `GCCVPYFOHY7ZB7557JKENAX62LUAPLMGIWNZJAFV2MITK6T32V37KEJU`. Stellar addresses provide an easy way for users to share payment details by using a syntax that interoperates across different domains and providers.
 
 ## Specification
 
-The Anchor would add DEPOSIT_SERVER to stellar.toml file
-------
-Add a DEPOSIT_SERVER section to your stellar.toml file that tells the wallet the URL of your deposit server endpoint.
+Stellar addresses are divided into two parts separated by `*`, the username and the domain.
 
-For example: `DEPOSIT_SERVER="https://api.yourdomain.com/deposit"`
+For example: `jed*stellar.org`:
 
-Please note that your deposit server must use https protocol.
+* `jed` is the username,
+* `stellar.org` is the domain.
+The domain can be any valid RFC 1035 domain name. The username is limited to printable UTF-8 with whitespace and the following characters excluded: `*` ,`>` Although of course the domain administrator can place additional restrictions on usernames of its domain.
 
-Step2: Implement deposit url HTTP endpoint
-------
-The deposit URL specified in your stellar.toml file should accept an HTTP GET request and issue responses of the form detailed below.
+Note that the `@` symbol is allowed in the username. This allows for using email addresses in the username of an address. For example: `maria@gmail.com*stellar.org`.
 
-### Requests
+## Federation Request
 
-Wallet can use this endpoint to query deposit info when user want to deposit 
+You can use the federation endpoint to look up an account id if you have a stellar address. You can also do reverse federation and look up a stellar addresses from account ids or transaction ids. This is useful to see who has sent you a payment.
 
-requests are http `GET` requests with the following form:
+Federation requests are HTTP GET requests with the following form:
 
-`?address=<stellar address>&asset=asset_name`
+`?q=<string to look up>&type=<name,id,txid>`
 
-eg.
-`https://api.yourdomain.com/deposit?address=GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD&asset=BTC`
+Supported types:
 
-### Response
+* `name`: returns the federation record for the given Stellar address. Example request:
+`https://FEDERATION_SERVER/federation?q=jed*stellar.org&type=name`
+* `forward`: Used for forwarding the payment on to a different network or different financial institution. The other parameters of the query will vary depending on what kind of institution is the ultimate destination of the payment and what you as the forwarding anchor supports. Your `stellar.toml` file should specify what parameters you expect in a forward federation request. If you are unable to forward or the other parameters in the request are incorrect you should return an error to this effect. Example request:
+`https://FEDERATION_SERVER/federation?type=forward&forward_type=bank_account&swift=BOPBPHMM&acct=2382376`
+* `id`: returns the federation record of the Stellar address associated with the given account ID. In some cases this is ambiguous. For instance if an anchor sends transactions on behalf of its users the account id will be of the anchor and the federation server won’t be able to resolve the particular user that sent the transaction. In cases like that you may need to use txid instead. Example: https://YOUR_FEDERATION_SERVER/federation?q=GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD&type=id
+* `txid`: returns the federation record of the sender of the transaction if known by the server. Example:
+`https://YOUR_FEDERATION_SERVER/federation?q=c1b368c00e9852351361e07cc58c54277e7a6366580044ab152b8db9cd8ec52a&type=txid`
 
-The deposit server should respond with an appropriate HTTP status code, headers and a JSON response.
+## Federation Response
 
-You must enable CORS on the deposit server so clients can send requests from other sites. The following HTTP header must be set for all deposit server responses.
+The federation server should respond with an appropriate HTTP status code, headers and a JSON response.
+
+You must enable CORS on the federation server so clients can send requests from other sites. The following HTTP header must be set for all federation server responses.
 ```
 Access-Control-Allow-Origin: *
 ```
 
-When a record has been found the response should return `200 OK` http status code and the following JSON body:
-```
+When a record has been found the response should return `200 OK` HTTP status code and the JSON body with following fields:
+
+* `stellar_address` - stellar address
+* `account_id` - Stellar public key / account ID
+* `memo_type` - [optional] type of memo to attach to transaction, one of `text`, `id` or `hash`
+* `memo` - [optional] value of memo to attach to transaction, for `hash` this should be base64-encoded.
+
+Example:
+```json
 {
-  "stellar_address": <wallet provided>,
-  "asset": <asset_name>
-  "deposit_info": <deposit info for this address>,
-  "extra_info": <extra info for deposit or notice.> *optional*
+  "stellar_address": "jed*stellar.org",
+  "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
+  "memo_type": "id",
+  "memo": "123"
 }
 ```
 
+If a redirect is needed the federation server should return `3xx` HTTP status code and immediately redirect the user to the correct URL using the `Location` header.
 
-eg.
-```
+When a record has not been found `404 Not Found` HTTP status code should be returned.
+
+Every other HTTP status code will be considered an error. The body should contain error details:
+```json
 {
-  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD",
-  "asset": "BTC",
-  "deposit_info": "1NMaF4xm4pTHQJbU85PNCGqRVhz8Yp8ibE",
-  "extra_info": "3 confirmations needed. This is a long term available address."
-}
-```
-```
-{
-  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD",
-  "asset": "CNY",
-  "deposit_info": "go to https://ripplefox.taobao.com and buy any items you like and leave your address in "leave message to seller' textarea',
-  "extra_info": ""
+   "error": "extra details provided by the federation server"
 }
 ```
 
-```
-{
-  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4ABLAH",
-  "asset": "EURT",
-  "deposit_info": "PAY OUT TO EUROZONE COUNTRIES FREE via SEPA ACCOUNT, CIS COUNTRIES @1.2%  CASH, FR & DE CASH @1%",
-  "extra_info": ""
-}
+Federation responses should not be cached. Some organizations may generate random IDs to protect their users’ privacy. Those IDs may change over time.
 
+## Reference implementations
 
-```
-
-
-Every other http status code will be considered an error. The body should contain error details:
-```
-{
-   "message": "extra details provided by the deposit server"
-}
-```
+* [Reference Federation server](https://github.com/stellar/go/tree/master/services/federation) developed by Stellar Development Foundation.
+* [Go federation client](https://github.com/stellar/go/tree/master/clients/federation)
+* [JavaScript federation client](http://stellar.github.io/js-stellar-sdk/FederationServer.html)
+* [Federation structures](https://github.com/stellar/go/blob/master/protocols/federation/main.go)

--- a/ecosystem/sep-0003.md
+++ b/ecosystem/sep-0003.md
@@ -1,0 +1,139 @@
+## Preamble
+
+```
+SEP: <to be assigned>
+Title: Compliance protocol
+Author: <list of authors' names and optionally, email addresses>
+Status: Draft
+Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+```
+
+## Simple Summary
+Complying with Anti-Money Laundering (AML) laws requires financial institutions (FIs) to know not only who their customers are sending money to but who their customers are receiving money from. In some jurisdictions banks are able to trust the AML procedures of other licensed banks. In other jurisdictions each bank must do its own sanction checking of both the sender and the receiver. The Compliance Protocol handles all these scenarios.
+
+## Abstract
+The customer information that is exchanged between FIs is flexible but the typical fields are:
+
+* Full Name
+* Date of birth
+* Physical address
+
+The Compliance Protocol is an additional step after federation. In this step the sending FI contacts the receiving FI to get permission to send the transaction. To do this the receiving FI creates an `AUTH_SERVER` and adds its location to the `stellar.toml` of the FI.
+
+## Specification
+
+To send transaction data to the receiving organization, send HTTP POST to `AUTH_SERVER` with `Content-Type` equal `application/x-www-form-urlencoded` and the following body:
+```
+data=<data value>&sig=<sig value>
+```
+
+`data` is a block of JSON that contains the following fields:
+
+Name | Data Type | Description
+-----|-----------|------------
+`sender` | string | The payment address of the customer that is initiating the send. Ex. `bob*bank.com`
+`need_info` | boolean | If the caller needs the recipient's AML info in order to send the payment.
+`tx` | string: base64 encoded [xdr.Transaction](https://github.com/stellar/stellar-core/blob/4961b8bb4a64c68838632c5865389867e9f02840/src/xdr/Stellar-transaction.x#L297-L322) | The transaction that the sender would like to send in XDR format. This transaction is unsigned and it's sequence number should be equal `0`.
+`attachment` | string | The full text of the attachment. The hash of this attachment is included as a memo in the transaction. The **attachment** field follows the [Stellar Attachment Convention](./attachment.md) and should contain at least enough information of the sender to allow the receiving FI to do their sanction check.
+
+**sig** is the signature of the data block made by the sending FI. The receiving institution should check that this signature is valid against the public signature key that is posted in the sending FI's [stellar.toml](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) (`SIGNING_KEY` field).
+
+Example request body (please note it contains both parameters `data` and `sig`):
+```
+data=%7B%22sender%22%3A%22aldi%2AbankA.com%22%2C%22need_info%22%3Atrue%2C%22tx%22%3A%22AAAAAEhAArfpmUJYq%2FQ9SFAH3YDzNLJEBI9i9TXmJ7s608xbAAAAZAAMon0AAAAJAAAAAAAAAAPUg1%2FwDrMDozn8yfiCA8LLC0wF10q5n5lo0GiFQXpPsAAAAAEAAAAAAAAAAQAAAADdvkoXq6TXDV9IpguvNHyAXaUH4AcCLqhToJpaG6cCyQAAAAAAAAAAAJiWgAAAAAA%3D%22%2C%22attachment%22%3A%22%7B%5C%22nonce%5C%22%3A%5C%221488805458327055805%5C%22%2C%5C%22transaction%5C%22%3A%7B%5C%22sender_info%5C%22%3A%7B%5C%22address%5C%22%3A%5C%22678+Mission+St%5C%22%2C%5C%22city%5C%22%3A%5C%22San+Francisco%5C%22%2C%5C%22country%5C%22%3A%5C%22US%5C%22%2C%5C%22first_name%5C%22%3A%5C%22Aldi%5C%22%2C%5C%22last_name%5C%22%3A%5C%22Dobbs%5C%22%7D%2C%5C%22route%5C%22%3A%5C%221%5C%22%2C%5C%22note%5C%22%3A%5C%22%5C%22%2C%5C%22extra%5C%22%3A%5C%22%5C%22%7D%2C%5C%22operations%5C%22%3Anull%7D%22%7D&sig=KgvyQTZsZQoaMy8jdwCUfLayfgfFMUdZJ%2B0BIvEwiH5aJhBXvhV%2BipRok1asjSCUS%2FUaGeGKDoizS1%2BtFiiyAA%3D%3D
+
+```
+
+After decoding the `data` parameter it has a following form:
+
+```json
+{
+  "sender": "aldi*bankA.com",
+  "need_info": true,
+  "tx": "AAAAAEhAArfpmUJYq/Q9SFAH3YDzNLJEBI9i9TXmJ7s608xbAAAAZAAMon0AAAAJAAAAAAAAAAPUg1/wDrMDozn8yfiCA8LLC0wF10q5n5lo0GiFQXpPsAAAAAEAAAAAAAAAAQAAAADdvkoXq6TXDV9IpguvNHyAXaUH4AcCLqhToJpaG6cCyQAAAAAAAAAAAJiWgAAAAAA=",
+  "attachment": "{\"nonce\":\"1488805458327055805\",\"transaction\":{\"sender_info\":{\"address\":\"678 Mission St\",\"city\":\"San Francisco\",\"country\":\"US\",\"first_name\":\"Aldi\",\"last_name\":\"Dobbs\"},\"route\":\"1\",\"note\":\"\",\"extra\":\"\"},\"operations\":null}"
+}
+```
+
+Please note that the memo value of `tx` is a sha256 hash of the attachment.
+
+`AUTH_SERVER` will return a JSON object with the following fields:
+
+Name | Data Type | Description
+-----|-----------|------------
+`info_status` | `ok`, `denied`, `pending` | If this FI is willing to share AML information or not.
+`tx_status` | `ok`, `denied`, `pending` | If this FI is willing to accept this transaction.
+`dest_info` | string | *(only present if `info_status` is `ok`)* Marshalled JSON of the recipient's AML information.
+`error` | string | *(only present if `info_status` or `tx_status` is `error` or for internal server errors)* Error message
+`pending` | integer | *(only present if `info_status` or `tx_status` is `pending`)* Estimated number of seconds till the sender can check back for a change in status. The sender should just resubmit this request after the given number of seconds.
+
+HTTP status code must be equal:
+* `200 OK` if both `info_status` and `tx_status` are `ok`.
+* `202 Accepted` if both statuses are `pending` or one is `pending` and second `ok`.
+* `400 Bad Request` if data sent by the sender is invalid.
+* `403 Forbidden` if any of `info_status` and `tx_status` are `denied`.
+* `500 Internal Server Error` for server side errors.
+
+Examples:
+
+```
+200 OK
+```
+```json
+{
+    "info_status": "ok",
+    "tx_status": "ok",
+    "dest_info": "{\"name\": \"John Doe\"}"
+}
+```
+---
+```
+202 Accepted
+```
+```json
+{
+    "info_status": "ok",
+    "tx_status": "pending",
+    "dest_info": "{\"name\": \"John Doe\"}",
+    "pending": 3600
+}
+```
+---
+```
+400 Bad Request
+```
+```json
+{
+    "info_status": "ok",
+    "tx_status": "error",
+    "error": "Invalid country code."
+}
+```
+---
+```
+403 Forbidden
+```
+```json
+{
+    "info_status": "deny",
+    "tx_status": "ok"
+}
+```
+---
+```
+500 Internal Server Error
+```
+```json
+{
+    "error": "Internal server error"
+}
+```
+
+## Test Cases
+
+Use [GoStellar](https://gostellar.org/) application to check if Compliance protocol was implemented correctly.
+
+## Reference implementations
+
+* [Reference Compliance server](https://github.com/stellar/bridge-server/blob/master/readme_compliance.md) developed by Stellar Development Foundation.
+* [Compliance structures](https://github.com/stellar/go/tree/master/protocols/compliance).

--- a/ecosystem/sep-0004.md
+++ b/ecosystem/sep-0004.md
@@ -1,0 +1,75 @@
+## Preamble
+
+```
+SEP: <to be assigned>
+Title: Tx Status Endpoint
+Author: <list of authors' names and optionally, email addresses>
+Status: Draft
+Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+```
+
+## Simple Summary
+Simple way to get the status of a payment that has been sent through the compliance protocol from the receiver.
+
+## Abstract
+In many cases the sender needs to get additional info from the receiver after the payment is sent. To either tell their customer or for their own records. 
+
+After a tx is approved by the compliance protocol and submitted to Stellar,  the sender can call `/tx_status` to learn what happened to the tx.
+
+## Specification
+Endpoint at the URL specified by `AUTH_SERVER` in the stellar.toml file of an institution that receives payments. This endpoint is used to relay the status of payments to the sender or other interested parties. 
+Can be used for simple informational purposes or to convey a code needed by the individual to claim the money on the receiving end. 
+
+```
+AUTH_SERVER/tx_status?id=tx_id
+return
+{
+	status: <status code see below>,
+	recv_code: <arbitrary string>,
+	refund_tx: <tx_hash>,
+    msg: <arbitrary string>
+}
+```
+`id` The Stellar transaction ID of of the payment we are interested in.
+
+`refund_tx` only appears if the status is "refunded". It will be the txID of the tx sending the money back. The address to send the refund to needs to be sent as part of the original payment attachment otherwise the receiver won't know how to refund.
+
+`status` is one of the following codes:
+- `unknown` - what money?
+- `approved` - payment was approved by the receiving FI but the Stellar transaction hasn't been received yet.
+- `not_approved` - Stellar transaction was found but it was never approved by the receiving FI.
+- `pending` - payment was received. we are attempting to deposit it. This also covers scenarios where something could not be deposited via the default method, but may be deposited by another method (i.e. electronic deposit failed, but it may be deposited manually and it will take longer)
+- `failed` - we could not deposit it. `msg` should contain more info.
+- `refunded` - payment was sent back to sending FI. Possible reasons: deposit could not be made, or sending FI decided to cancel the cash pick-up payment (sometimes recipient never picks it up).
+- `claimable` - Mostly used for cash pickup. Cash is ready to be picked up at specified locations
+- `delivered` - Receiver should now have the funds, cash has been picked up, or money has been deposited into the bank account.
+
+
+
+## Rationale
+Prior discussion was done here https://github.com/stellar/bridge-server/issues/59
+
+Current steps in a payment that goes through the compliance protocol:
+
+1. Alice initiates a payment to bob*bankb.com
+2. Client Endpoint A handles request
+3. Client Endpoint debits Alice's account
+4. Client Endpoint A call Bridge A
+5. Bridge A calls Compliance A
+6. Compliance A loads the stellar.toml B
+7. Compliance A resolves bob*bankb.com from federation server B
+8. Compliance A crafts the stellar tx
+9. Compliance A calls Compliance B
+10. Compliance B checks sanctions and other things
+11. Compliance B replies to Compliance A
+12. Compliance A replies to Bridge A with the stellar tx.
+13. Bridge A submits the stellar tx  to horizon A
+14. horizon A submits the tx to stellar-core A
+15. Stellar network does its thing
+16. horizon B sees the tx applied to the ledger
+17. bridge B receives the applied tx to the ledger 
+18. bridge B checks with Compliance B to verify that the tx was approved
+19. bridge B calls receive hook B to finish the payment
+20. Receive hook B credits bob's account
+21. Receive Hook notifies Bob
+22. Bob has been paid.

--- a/ecosystem/sep-0005.md
+++ b/ecosystem/sep-0005.md
@@ -1,0 +1,99 @@
+## Preamble
+
+```
+SEP: 0005
+Title: DEPOSIT_SERVER proposal
+Author: @no, @ant, @manran, @pacngfar
+Status: Draft
+Created: 2018-08-21
+```
+
+## Simple Summary
+It will be more convenient, if we have a protocol that standardizes how a wallet communicates with an anchor to fetch the deposit info, guiding the user through the steps in the wallet, instead of opening the anchor's website to find out.
+In many cases the sender needs to get additional info from the receiver after the payment is sent. To either tell their customer or for their own records. 
+
+## Abstract
+Proposal for a standard protocol that allows wallets to pull deposit info from anchors. The model is very similar to how the federation server works.
+
+
+## Specification
+
+The Anchor would add DEPOSIT_SERVER to stellar.toml file
+------
+Add a DEPOSIT_SERVER section to your stellar.toml file that tells the wallet the URL of your deposit server endpoint.
+
+For example: `DEPOSIT_SERVER="https://api.yourdomain.com/deposit"`
+
+Please note that your deposit server must use https protocol.
+
+Step2: Implement deposit url HTTP endpoint
+------
+The deposit URL specified in your stellar.toml file should accept an HTTP GET request and issue responses of the form detailed below.
+
+### Requests
+
+Wallet can use this endpoint to query deposit info when user want to deposit 
+
+requests are http `GET` requests with the following form:
+
+`?address=<stellar address>&asset=asset_name`
+
+eg.
+`https://api.yourdomain.com/deposit?address=GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD&asset=BTC`
+
+### Response
+
+The deposit server should respond with an appropriate HTTP status code, headers and a JSON response.
+
+You must enable CORS on the deposit server so clients can send requests from other sites. The following HTTP header must be set for all deposit server responses.
+```
+Access-Control-Allow-Origin: *
+```
+
+When a record has been found the response should return `200 OK` http status code and the following JSON body:
+```
+{
+  "stellar_address": <wallet provided>,
+  "asset": <asset_name>
+  "deposit_info": <deposit info for this address>,
+  "extra_info": <extra info for deposit or notice.> *optional*
+}
+```
+
+
+eg.
+```
+{
+  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD",
+  "asset": "BTC",
+  "deposit_info": "1NMaF4xm4pTHQJbU85PNCGqRVhz8Yp8ibE",
+  "extra_info": "3 confirmations needed. This is a long term available address."
+}
+```
+```
+{
+  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD",
+  "asset": "CNY",
+  "deposit_info": "go to https://ripplefox.taobao.com and buy any items you like and leave your address in "leave message to seller' textarea',
+  "extra_info": ""
+}
+```
+
+```
+{
+  "stellar_address": "GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4ABLAH",
+  "asset": "EURT",
+  "deposit_info": "PAY OUT TO EUROZONE COUNTRIES FREE via SEPA ACCOUNT, CIS COUNTRIES @1.2%  CASH, FR & DE CASH @1%",
+  "extra_info": ""
+}
+
+
+```
+
+
+Every other http status code will be considered an error. The body should contain error details:
+```
+{
+   "message": "extra details provided by the deposit server"
+}
+```


### PR DESCRIPTION
* Moving existing protocols here:
  * `SEP-0001` - Stellar.toml
  * `SEP-0002` - Federation protocol
  * `SEP-0003` - Compliance protocol
* Existing `SEP`s were moved to `SEP-0004` and `SEP-0005`.
* Added errors in Compliance protocol (https://github.com/stellar/bridge-server/issues/70).
* Added more examples and reference implementations.

Questions:
* Do we have a list of allowed fields in stellar.toml? This should be in: `<<List of fields here>>`.