### PR TITLE
Require memo field to be a string in Federation protocol

### DIFF
--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -56,7 +56,7 @@ When a record has been found the response should return `200 OK` HTTP status cod
 * `stellar_address` - stellar address
 * `account_id` - Stellar public key / account ID
 * `memo_type` - [optional] type of memo to attach to transaction, one of `text`, `id` or `hash`
-* `memo` - [optional] value of memo to attach to transaction, for `hash` this should be base64-encoded.
+* `memo` - [optional] value of memo to attach to transaction, for `hash` this should be base64-encoded. This field should always be of type `string` (even when `memo_type` is equal `id`) to support parsing value in languages that don't support big numbers.
 
 Example:
 ```json


### PR DESCRIPTION
Ex. Javascript will parse big (int64) integers incorrectly.