### PR TITLE
SEP-0006: add transaction history endpoint

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -139,7 +139,7 @@ Name | Type | Description
 `asset_code` | string | The code of the asset of interest. E.g. BTC,ETH,USD,INR,etc
 `account` | string | The stellar account ID involved in the transactions
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time
-`n` | int | (optional) the response should contain at most `n` transactions
+`limit` | int | (optional) the response should contain at most `limit` transactions
 `paging_id` | string | (optional) the response should contain transactions starting prior to this ID (exclusive)
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
@@ -159,7 +159,7 @@ Name | Type | Description
 `amount` | float | (optional) Amount of deposit/withdrawal
 `started_at` | UTC ISO 8601 string | (optional) start date and time of transaction
 `completed_at` | UTC ISO 8601 string | (optional) completion date and time of transaction
-`stellar_operation_id` | string | (optional) operation_id on Stellar network of transfer that either completed the deposit or started the withdrawal
+`stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal
 
 `status` should be one of:

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -10,10 +10,12 @@ Updated: 2018-05-01
 ```
 
 ## Simple Summary
+
 It will be easier for users if wallets and other clients can interact with anchors directly without the user having to leave the wallet to go to the anchor's site. This SEP is intended to create a standard way that anchors allow this to be done.
 
 ## Abstract
-Proposal for a standard protocol that allows wallets to deposit and withdraw funds info from anchors.
+
+Proposal for a standard protocol that allows wallets to deposit and withdraw funds from anchors. It also allows wallets to check status of ongoing deposit/withdrawals and display a history of past transactions with an anchor.
 
 ## Specification
 
@@ -34,15 +36,10 @@ Name | Type | Description
 `account` | string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) type of memo to attach to transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
-`deposit_info` | string | (optional) One of `none`, `pending`, `all`. Types of past deposits that should be detailed in the response.
-`n` | int | (optional) the response should contain at most `n` deposits (if `deposit_info` is not `none`).
-`paging_token` | string | (optional) the response should contain deposits starting prior to this ID.
 
 If the given `account` doesn't exist yet then the anchor will fund and thus create the account with at least enough lumens for the minimum reserve and the trust line. It is suggested that the anchor take some of the asset that is sent in to pay for these lumens. The anchor doesn't have the account's secret key so the trust line must still be created by the client before the anchor can send the remaining asset tokens to the give account. The anchor should listen to see when the client has established this trust line. Once the trust line is there the anchor should send the asset tokens to the account in Stellar.
 
 If the anchor won't create new accounts for users then it should return an error if the given account doesn't exist yet.
-
-The `deposit_info` argument allows wallets to provide a better experience for users. With it, wallets can display the status of deposits while they process and a history of past deposits to your anchor.
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
@@ -55,62 +52,13 @@ Name | Type | Description
 `fee_fixed` | float | (optional) If there is a fee for deposit. In units of the deposited asset.
 `fee_percent` | float | (optional) If there is a percent fee for deposit. 
 `extra_info` | object | (optional) Any additional data needed as an input for this deposit, example: Bank Name
-`deposits` | array | (optional) List of deposits as requested by the client, sorted in time descending order
 
-Each object in the deposit array should have the following fields:
-
-Name | Type | Description
------|------|------------
-`id` | string | Unique, anchor-generated id for the deposit
-`status` | string | Processing status of deposit.
-`status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`amount` | float | (optional) Amount of deposit.
-`started_at` | string | (optional) ISO 8601 datetime of start of transaction.
-`completed_at` | string | (optional) ISO 8601 datetime of completion of transaction.
-`stellar_operation_id` | string | (optional) operation_id on Stellar network of transfer that completed the deposit.
-`external_transaction_id` | string | (optional) ID of transaction on external network that initiated the deposit.
-
-`status` should be one of:
-
-* `completed` -- deposit completed, deposit fully transferred to user Stellar account
-* `pending_receipt` -- deposit is transferring to anchor, but has not been received by anchor yet. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction.
-* `pending_anchor` -- deposit is being processed internally by anchor
-* `pending_stellar` -- deposit has been transferred to user Stellar account, but Stellar transfer is not yet complete.
-
-Basic Example:
+Example:
 
 ```json
 {
   "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
   "fee_fixed" : 0.0002
-}
-```
-
-Example with deposit info:
-
-```json
-{
-  "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
-  "fee_fixed" : 0.0002,
-  "deposits": [
-    {
-      "id": "82fhs729f63dh0v4",
-      "status": "pending_receipt",
-      "status_eta": 3600,
-      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "amount": 18.34,
-      "started_at": "2017-03-20T17:05:32"
-    },
-    {
-      "id": "82fhs729f63dh0v4",
-      "status": "completed",
-      "amount": 500,
-      "started_at": "2017-03-20T17:00:02",
-      "completed_at": "2017-03-20T17:09:58Z",
-      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "operation_id": "75141217347727390",
-    }
-  ]
 }
 ```
 
@@ -151,7 +99,7 @@ Name | Type | Description
 `min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
 `max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
 `fee_fixed` | float | (optional) If there is a fee for withdraw. In units of the withdrawn asset.
-`fee_percent` | float | (optional) If there is a percent fee for withdraw. 
+`fee_percent` | float | (optional) If there is a percent fee for withdraw.
 `extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name
 
 Example:
@@ -164,7 +112,88 @@ Example:
 }
 ```
 
-Every other HTTP status code will be considered an error. The body should contain error details. 
+Every other HTTP status code will be considered an error. The body should contain error details.
+For example:
+
+```json
+{
+   "error": "This anchor doesn't support the given currency code: ETH"
+}
+```
+
+### Transaction History
+
+The transaction history endpoint helps anchors enable a better experience for users using an external wallet. With it, wallets can display the status of deposits and withdrawals while they process and a history of past transactions with the anchor. It's only for transactions that are deposits to or withdrawals from the anchor.
+
+Endpoint: `DEPOSIT_SERVER/transactions`<br>
+Purpose: Get status of current and past deposits/withdrawals.<br>
+Method: GET<br>
+Request parameters
+
+Name | Type | Description
+-----|------|------------
+`asset_code` | string | The code of the asset of interest. E.g. BTC,ETH,USD,INR,etc
+`account` | string | The stellar account ID involved in the transactions
+`no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time
+`n` | int | (optional) the response should contain at most `n` transactions
+`paging_id` | string | (optional) the response should contain transactions starting prior to this ID (exclusive)
+
+On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
+
+Name | Type | Description
+-----|------|------------
+`transactions` | array | List of transactions as requested by the client, sorted in time-descending order
+
+Each object in the `transactions` array should have the following fields:
+
+Name | Type | Description
+-----|------|------------
+`id` | string | Unique, anchor-generated id for the deposit/withdrawal
+`kind` | string | `deposit` or `withdrawal`
+`status` | string | Processing status of deposit/withdrawal
+`status_eta` | number | (optional) Estimated number of seconds until a status change is expected
+`amount` | float | (optional) Amount of deposit/withdrawal
+`started_at` | UTC ISO 8601 string | (optional) start date and time of transaction
+`completed_at` | UTC ISO 8601 string | (optional) completion date and time of transaction
+`stellar_operation_id` | string | (optional) operation_id on Stellar network of transfer that either completed the deposit or started the withdrawal
+`external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal
+
+`status` should be one of:
+
+* `completed` -- deposit/withdrawal fully completed
+* `pending_external` -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
+* `pending_anchor` -- deposit/withdrawal is being processed internally by anchor
+* `pending_stellar` -- deposit/withdrawal operation has been submitted to Stellar network, but is not yet confirmed
+
+Example response:
+
+```json
+{
+  "transactions": [
+    {
+      "id": "82fhs729f63dh0v4",
+      "kind": "deposit",
+      "status": "pending_external",
+      "status_eta": 3600,
+      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "amount": 18.34,
+      "started_at": "2017-03-20T17:05:32Z"
+    },
+    {
+      "id": "82fhs729f63dh0v4",
+      "kind": "withdrawal",
+      "status": "completed",
+      "amount": 500,
+      "started_at": "2017-03-20T17:00:02Z",
+      "completed_at": "2017-03-20T17:09:58Z",
+      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "operation_id": "75141217347727390",
+    }
+  ]
+}
+```
+
+Every other HTTP status code will be considered an error. An empty transaction list is *not* an error. The body should contain error details.
 For example:
 
 ```json

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -19,6 +19,10 @@ Proposal for a standard protocol that allows wallets to deposit and withdraw fun
 
 ## Specification
 
+* [Deposit](#deposit)
+* [Withdraw](#withdraw)
+* [Transaction History](#transaction-history)
+
 ### Deposit
 
 This is the user getting a token from the anchor. Deposits will be a new endpoint on the federation server. It will just return the accountId where we should send the currency that we specified. We will get the equivalent Asset issued by the anchor in return.
@@ -187,7 +191,7 @@ Example response:
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "operation_id": "75141217347727390",
+      "operation_id": "75141217347727390"
     }
   ]
 }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,6 +6,7 @@ Title: Anchor/Client interoperability
 Author: stellar.org
 Status: Accepted
 Created: 2017-10-30
+Updated: 2018-05-01
 ```
 
 ## Simple Summary
@@ -14,9 +15,7 @@ It will be easier for users if wallets and other clients can interact with ancho
 ## Abstract
 Proposal for a standard protocol that allows wallets to deposit and withdraw funds info from anchors.
 
-
 ## Specification
-
 
 ### Deposit
 
@@ -35,10 +34,15 @@ Name | Type | Description
 `account` | string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) type of memo to attach to transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
+`deposit_info` | string | (optional) One of `none`, `pending`, `all`. Types of past deposits that should be detailed in the response.
+`n` | int | (optional) the response should contain at most `n` deposits (if `deposit_info` is not `none`).
+`paging_token` | string | (optional) the response should contain deposits starting prior to this ID.
 
 If the given `account` doesn't exist yet then the anchor will fund and thus create the account with at least enough lumens for the minimum reserve and the trust line. It is suggested that the anchor take some of the asset that is sent in to pay for these lumens. The anchor doesn't have the account's secret key so the trust line must still be created by the client before the anchor can send the remaining asset tokens to the give account. The anchor should listen to see when the client has established this trust line. Once the trust line is there the anchor should send the asset tokens to the account in Stellar.
 
 If the anchor won't create new accounts for users then it should return an error if the given account doesn't exist yet.
+
+The `deposit_info` argument allows wallets to provide a better experience for users. With it, wallets can display the status of deposits while they process and a history of past deposits to your anchor.
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
@@ -51,23 +55,73 @@ Name | Type | Description
 `fee_fixed` | float | (optional) If there is a fee for deposit. In units of the deposited asset.
 `fee_percent` | float | (optional) If there is a percent fee for deposit. 
 `extra_info` | object | (optional) Any additional data needed as an input for this deposit, example: Bank Name
+`deposits` | array | (optional) List of deposits as requested by the client, sorted in time descending order
 
-Example:
+Each object in the deposit array should have the following fields:
+
+Name | Type | Description
+-----|------|------------
+`id` | string | Unique, anchor-generated id for the deposit
+`status` | string | Processing status of deposit.
+`status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
+`amount` | float | (optional) Amount of deposit.
+`started_at` | string | (optional) ISO 8601 datetime of start of transaction.
+`completed_at` | string | (optional) ISO 8601 datetime of completion of transaction.
+`stellar_operation_id` | string | (optional) operation_id on Stellar network of transfer that completed the deposit.
+`external_transaction_id` | string | (optional) ID of transaction on external network that initiated the deposit.
+
+`status` should be one of:
+
+* `completed` -- deposit completed, deposit fully transferred to user Stellar account
+* `pending_receipt` -- deposit is transferring to anchor, but has not been received by anchor yet. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction.
+* `pending_anchor` -- deposit is being processed internally by anchor
+* `pending_stellar` -- deposit has been transferred to user Stellar account, but Stellar transfer is not yet complete.
+
+Basic Example:
+
 ```json
 {
-    "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
-    "fee_fixed" : 0.0002
+  "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
+  "fee_fixed" : 0.0002
 }
 ```
 
-Every other HTTP status code will be considered an error. The body should contain error details. 
+Example with deposit info:
+
+```json
+{
+  "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
+  "fee_fixed" : 0.0002,
+  "deposits": [
+    {
+      "id": "82fhs729f63dh0v4",
+      "status": "pending_receipt",
+      "status_eta": 3600,
+      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "amount": 18.34,
+      "started_at": "2017-03-20T17:05:32"
+    },
+    {
+      "id": "82fhs729f63dh0v4",
+      "status": "completed",
+      "amount": 500,
+      "started_at": "2017-03-20T17:00:02",
+      "completed_at": "2017-03-20T17:09:58Z",
+      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "operation_id": "75141217347727390",
+    }
+  ]
+}
+```
+
+Every HTTP status code other than `200 OK` will be considered an error. The body should contain error details.
 For example:
+
 ```json
 {
-   "error": "This anchor doesn't support the given currency code: ETH"
+  "error": "This anchor doesn't support the given currency code: ETH"
 }
 ```
-
 
 ### Withdraw
 
@@ -86,7 +140,6 @@ Name | Type | Description
 `dest` | string | (for crypto) The account you want to withdraw to.
 `dest_extra` | string | (optional) If needed for other networks that might need a memo in addition to the `dest` address.
 
-
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
 Name | Type | Description
@@ -102,6 +155,7 @@ Name | Type | Description
 `extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name
 
 Example:
+
 ```json
 {
   "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
@@ -112,6 +166,7 @@ Example:
 
 Every other HTTP status code will be considered an error. The body should contain error details. 
 For example:
+
 ```json
 {
    "error": "This anchor doesn't support the given currency code: ETH"


### PR DESCRIPTION
Add a transaction history endpoint to SEP-0006. This allows wallets to display status of pending deposit/withdrawals, as well as a history of transactions involving the anchor for a given Stellar account.