### PR TITLE
improve transactions endpoint

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -156,7 +156,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`
 `status` | string | Processing status of deposit/withdrawal
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected
-`amount` | float | (optional) Amount of deposit/withdrawal
+`amount` | string | (optional) Amount of deposit/withdrawal as a string with up to 7 decimals
 `started_at` | UTC ISO 8601 string | (optional) start date and time of transaction
 `completed_at` | UTC ISO 8601 string | (optional) completion date and time of transaction
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal
@@ -168,6 +168,7 @@ Name | Type | Description
 * `pending_external` -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
 * `pending_anchor` -- deposit/withdrawal is being processed internally by anchor
 * `pending_stellar` -- deposit/withdrawal operation has been submitted to Stellar network, but is not yet confirmed
+* `pending_user` -- deposit operation requires a trustline to be processed. Withdrawal operation requires some additional data from user, for bank transfer, for example.
 
 Example response:
 
@@ -180,14 +181,14 @@ Example response:
       "status": "pending_external",
       "status_eta": 3600,
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "amount": 18.34,
+      "amount": "18.34",
       "started_at": "2017-03-20T17:05:32Z"
     },
     {
       "id": "82fhs729f63dh0v4",
       "kind": "withdrawal",
       "status": "completed",
-      "amount": 500,
+      "amount": "500",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",


### PR DESCRIPTION
In general I can raise many questions for discussion:
- why mixing dates and paging_id, 
- why there is no `order` parameter when querying transactions. 
- shouldn't we be able to fetch transaction by specific `stellar_transaction_id` or `external_transaction_id`
- what is `operation_id` parameter in withdrawal response and why is it not documented?

But in my current PR I tried to be productive and included only things that are a MUST.

I believe that [@fritz](https://stellar-public.slack.com/messages/@fritz/) also had an opinion on that endpoint, you should check with him if he has something to add to the conversation.