### PR TITLE
Actually specify the process followed for submiting CAPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Stellar Protocol
 This repository contains **Core Advancement Proposals** (CAPs) and **Stellar Ecosystem Proposals** (SEPs). 
 Similarly to [BIPs](https://github.com/bitcoin/bips) and [EIPs](https://github.com/ethereum/EIPs), CAPs and SEPs are the proposals of standards to improve Stellar protocol and related client APIs.
 
-CAPs deal changes to the core protocol of the Stellar network. 
+CAPs deal with changes to the core protocol of the Stellar network.
 
 SEPs deal with changes to the standards, protocols, and methods used in the ecosystem built on top of the Stellar network. 
 
@@ -44,9 +44,15 @@ Example repository structure:
 
 ## Process
 
-1. Write your CAP or SEP using `cap-template.md` or `sep-template.md` (`DRAFT`).
+### CAP proposals
+
+See [the core section](core/readme.md)
+
+### SEP proposals
+
+1. Write your SEP using `sep-template.md` (`DRAFT`).
 2. Place it in the /drafts directory.
 2. Create a PR in this repository.
-3. CAP or SEP number assigned (`ACCEPTED`) or CAP or SEP rejected (`REJECTED`).
+3. SEP number assigned (`ACCEPTED`) or SEP rejected (`REJECTED`).
 4. Discussion and changes.
-5. CAP or SEP merged (`FINAL`) or CAP or SEP rejected (`REJECTED`).
+5. SEP merged (`FINAL`) or SEP rejected (`REJECTED`).

--- a/cap-template.md
+++ b/cap-template.md
@@ -8,6 +8,7 @@ Title: <CAP title>
 Author: <list of authors' names and optionally, email addresses>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+Discussion: <link to where discussion for this CAP is taking place>
 ```
 
 ## Simple Summary

--- a/core/readme.md
+++ b/core/readme.md
@@ -1,0 +1,33 @@
+# Contributing CAPs
+
+ 1. Review [CAP-0001](cap-0001.md).
+ 2. Fork the repository by clicking "Fork" in the top right.
+ 3. Add your CAP to your fork of the repository. There is a [template CAP here](../cap-template.md).
+ 4. Add a link to your CAP proposal in this document, linking to the appropriate `/core/cap-XXXX.md`
+ 4. Submit a Pull Request to Stellar's [protocol repository](https://github.com/stellar/protocol).
+
+Your first PR should be a first draft of the CAP. It must follow the template.
+
+An editor will review the PR for a new CAP and ensure that its number is valid before before merging it.
+A simple way to avoid conflicts with CAP numbers is to simply use the PR number as CAP number (requiring to add a new commit with the number when known).
+
+Make sure you include a `Discussion` header with the URL to an open GitHub issue where people can discuss the CAP as a whole - typically an [issue](https://github.com/stellar/stellar-protocol/issues) in the protocol repository.
+
+If your CAP requires images or other supporting files, they should be included in a subdirectory of the `contents` folder for that CAP as follows: `contents/cap-X` (for CAP **X**). Links should be relative, for example a link to an image from CAP-X would be `../contents/cap-X/image.png`.
+
+For subsequent changes to your CAP, editors will only merge your PR after one of the CAP owners gives approval to do so (allowing for code review when needed).
+
+When you believe your CAP is mature and ready to progress past the draft phase, you should open a PR changing the state of your CAP to 'Accepted'. An editor will review your draft and ask if anyone objects to accepting it. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the CAP - they may close the PR and request that you fix the issues in the draft before trying again.
+
+Once a CAP is implemented, a PR should be submitted to update its status to 'Final'.
+
+# CAP status terms
+* **Draft** - a CAP that is open for consideration.
+* **Accepted** - a CAP that is planned for immediate adoption, i.e. expected to be included in a next version of the protocol.
+* **Final** - a CAP that has been implemented (ie, changes fully merged into `stellar-core/master`).
+
+# Summary list of all CAP proposals
+
+Number             | Title                                 | Owner                 |   Status
+------------------ | ------------------------------------- | --------------------- | -------------
+[0001](cap-0001.md)| Bump Sequence                         | Nicolas Barry         |   Final


### PR DESCRIPTION
## This PR specifies the process followed through the life cycle of a CAP.

This is a first step towards having all significant changes going into the core network go through an open process.
 
It's mostly the same thing than the EIP process except that I had to gut some of the governance as we are not there yet (we need more contributors to reach critical mass).

## Out of scope for now
I didn't modified or tried to specify the process used for SEPs as it doesn't have the same requirements.
