### PR TITLE
Specify when `nonce` should be the same

### DIFF
--- a/ecosystem/sep-0003.md
+++ b/ecosystem/sep-0003.md
@@ -55,7 +55,10 @@ After decoding the `data` parameter it has a following form:
 }
 ```
 
-Please note that the memo value of `tx` is a sha256 hash of the attachment.
+A few things to note:
+
+- *memo* value of `tx` is a sha256 hash of the attachment
+- *nonce* is unique to each individual transaction. When a transaction on the receiving end is `pending`, the same `nonce` should be sent to fetch updates about the `pending` transaction
 
 `AUTH_SERVER` will return a JSON object with the following fields:
 


### PR DESCRIPTION
The nonce should be the same when requesting information on a specific transaction.

Currently, the `nonce` functionality that is implemented by bridge does not support fetching information of a transaction that had already been submitted because the `nonce` sent is different every time.