### PR TITLE
Add instructions on `recipient_info`

### DIFF
--- a/ecosystem/sep-0003.md
+++ b/ecosystem/sep-0003.md
@@ -59,6 +59,7 @@ A few things to note:
 
 - *memo* value of `tx` is a sha256 hash of the attachment
 - *nonce* is unique to each individual transaction. When a transaction on the receiving end is `pending`, the same `nonce` should be sent to fetch updates about the `pending` transaction
+- *recipient_info* may be added in the same level (sibling) as `sender_info`, in the scenario when the receiving FI is a forwarder (and therefore does not have information on the recipient)
 
 `AUTH_SERVER` will return a JSON object with the following fields:
 


### PR DESCRIPTION
When the receiving FI is a forwarder, it does not have information on the recipient. The sending FI needs to provide this. This commit describes where this should be.