### PR TITLE
Add is_asset_anchored to sep-0001.md

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -115,6 +115,7 @@ image | url | URL to image representing token
 fixed_number | int | Fixed number of tokens, if the number of tokens issued will never change
 max_number | int | Max number of tokens, if there will never be more than `max_number` tokens
 is_unlimited | bool | The number of tokens is dilutable at the issuer's discretion
+is_asset_anchored | string | `true` if token can be redeemed for underlying asset, otherwise `false`
 anchor_asset_type | string | Type of asset anchored. Can be `fiat`, `crypto`, `stock`, `bond`, `commodity`, `realestate`, or `other`.
 anchor_asset | string | If anchored token, asset that token is anchored to. E.g. USD, BTC, SBUX, Address of real-estate investment property.
 redemption_instructions | string | If anchored token, these are instructions to redeem the underlying asset from tokens.


### PR DESCRIPTION
Add is_asset_anchored field to Currency Documentation to allow issuers to state explicitly whether their asset is or is not anchored.  This change would facilitate market interface filtering by asset type.