### PR TITLE
A few fixes and improvements for SEP-0010

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -41,7 +41,7 @@ Field | Requirements | Description
 FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) federation protocol
 AUTH_SERVER | uses `https://` | The endpoint used for [SEP-3](sep-0003.md) Compliance Protocol
 TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anchor/Client interoperability
-WEB_AUTH_SERVER | uses `https://` | The server used for [SEP-10](sep-0010.md) Web Authentication
+WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
 SIGNING_KEY | Stellar public key | The signing key is used for the compliance protocol
 NODE_NAMES | list of `"G... name"` strings | convenience mapping of common names to node IDs. You can use these common names in sections below instead of the less friendly nodeID. This is provided mainly to be compatible with the stellar-core.cfg
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain. Names defined in `NODE_NAMES` can be used as well, prefixed with `$`.

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -3,7 +3,7 @@
 ```
 SEP: 0010
 Title: Stellar Web Authentication
-Author: stellar.org
+Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Accepted
 Created: 2018-07-31
 Updated: 2018-07-31
@@ -12,68 +12,68 @@ Version 1.0.0
 
 ## Simple Summary
 
-This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with an anchor, for example, to upload KYC information in an authenticated way as described in [SEP-6](sep-0006.md).
+This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-6](sep-0006.md).
 
 ## Abstract
 
+This protocol is a variation of mutual challenge-response, which uses Stellar transactions to encode challenges and responses.
+
 The authentication flow is as follows:
 
-1. The client visits the `/challenge` endpoint to request an invalid transaction to be signed
+1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
 1. The client signs the transaction with their Stellar account's secret key
-1. The client transmits the signed transaction back to the server via the `/jwt` endpoint
+1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. If the signature checks out, the server responds with a [JWT](jwt.io) that represents the user's session
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
 
 The flow achieves several things:
 
+* Both client and server part can be implemented using well-established Stellar libraries
 * The client can verify that the server holds the secret key to a particular account
 * The server can verify that the client holds the secret key to their account
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
 
-## Transfer Server
+## Authentication Endpoint
 
-This protocol requires the anchor or other party wishing to authenticate users implement endpoints on their `WEB_AUTH_SERVER`, specified in their [`stellar.toml`](sep-0001.md) file. This is how a wallet knows where to find the authorization server.
+A web service indicates that it supports user authentication via this protocol by specifying `WEB_AUTH_ENDPOINT` in their [`stellar.toml`](sep-0001.md) file. This is how a wallet knows where to find the authentication server. A web server is required to implement the following behaviour for the web authentication endpoint:
 
-## API Endpoints
+* [`GET <WEB_AUTH_ENDPOINT>`](#challenge): request a challenge (step 1)
+* [`POST <WEB_AUTH_ENDPOINT>`](#token): exchange a signed challenge for session JWT (step 2)
 
-* [`GET /challenge`](#challenge): optional, but necessary for authentication (step 1)
-* [`GET /jwt`](#jwt): optional, but necessary for authentication (step 2)
+### Challenge
 
-## Challenge
+This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
 
-This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to `/jwt` to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's `stellar.toml`.
-
-### Request
+#### Request
 
 ```
-GET WEB_AUTH_SERVER/challenge
+GET <WEB_AUTH_ENDPOINT>
 ```
 
 Request Parameters:
 
-Name | Type | Description
------|------|------------
+Name      | Type          | Description
+----------|---------------|------------
 `account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
 
 Example:
 
 ```
-GET https://api.example.com/challenge?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
+GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
 ```
 
-### Response
+#### Response
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with a `transaction` field containing an XDR-encoded Stellar transaction with the following:
 
-* source account set to server's account
-* invalid sequence number (set to 0)
+* source account set to server's signing account
+* invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
 * time bounds: `{min: now(), max: now() + 300 }` (we recommend expiration of 5 minutes to give user time to sign transaction)
 * operations: `manage_data(source: client_account, key: '<anchor name> auth', value: random_nonce())`
   * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
   * The value must be a 64 byte long base64 encoded cryptographic-quality random string
-* invalid sequence number (so the transaction cannot be run on the Stellar network)
-* signature by the anchor
+* signature by the web service signing account
 
 Example:
 ```
@@ -92,43 +92,42 @@ Every other HTTP status code will be considered an error. For example:
 }
 ```
 
-## JWT
+### Token
 
-This endpoint accepts a signed challenge transaction (that was previously returned by the `/challenge` endpoint). If the client's signature is valid, it responds with a [JSON Web Token](https://jwt.io/) authenticating the user. A server can pick its own expiration period for the token, however 24 hours is recommended.
+This endpoint accepts a signed challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint). If the client's signature is valid, it responds with a [JSON Web Token](https://jwt.io/) authenticating the user. A server can pick its own expiration period for the token, however 24 hours is recommended.
 
-### Request
+#### Request
 
 ```
-GET WEB_AUTH_SERVER/jwt
+POST <WEB_AUTH_ENDPOINT>
 ```
 
 Request Parameters:
 
-Name | Type | Description
------|------|------------
-`transaction` | string | base64 encoded signed challenge transaction
-
-Note that since `transaction` is base64 encoded.
+Name          | Type   | Description
+--------------|--------|------------
+`transaction` | string | base64 encoded signed challenge transaction XDR
 
 Example:
 
 ```
-GET https://api.example.com/jwt?transaction=AAAAAAVvtc2vNsygpxOUKCQKkmSJSQItaJ0LxMot3%2F9ups4%2FAAAAZAAAAAAAAAAAAAAAAQAAAABbV2YRAAAAAFtXZz0AAAAAAAAAAQAAAAEAAAAAoOOOGwQOwcfc0Wkr%2Fb5MvcKvpqBuuP2CKfo1s%2FBCaN4AAAAKAAAAEGV4YW1wbGUuY29tIGF1dGgAAAABAAAAQEdaRUx1aU4zbHRjemdFR2xGU24yU2ZVVGFDVnkxMXM1aWNiMkxCSXc0dUZvd2lnQnliNFRUOFdoeklGdXdybmsAAAAAAAAAAm6mzj8AAABAXnnkROpP31vlXYpoa942wXIV7m9CrB3M%2B8TvJg5Fv%2BnVNEHABbwnxjKBnGidx2OmhhXLkyoYK0BPxe3RI7nbDfBCaN4AAABAUXBXcDtzjrKjNcQ%2FMLYPTHkh6%2F5VXhMQ6LIbX2cpHwwNqi%2FugsnXLkVCcmSrhSaxZ1OZF38VVWObu%2BhDYj4SAw%3D%3D
+POST https://auth.example.com/
+transaction=AAAAAAVvtc2vNsygpxOUKCQKkmSJSQItaJ0LxMot3%2F9ups4%2FAAAAZAAAAAAAAAAAAAAAAQAAAABbV2YRAAAAAFtXZz0AAAAAAAAAAQAAAAEAAAAAoOOOGwQOwcfc0Wkr%2Fb5MvcKvpqBuuP2CKfo1s%2FBCaN4AAAAKAAAAEGV4YW1wbGUuY29tIGF1dGgAAAABAAAAQEdaRUx1aU4zbHRjemdFR2xGU24yU2ZVVGFDVnkxMXM1aWNiMkxCSXc0dUZvd2lnQnliNFRUOFdoeklGdXdybmsAAAAAAAAAAm6mzj8AAABAXnnkROpP31vlXYpoa942wXIV7m9CrB3M%2B8TvJg5Fv%2BnVNEHABbwnxjKBnGidx2OmhhXLkyoYK0BPxe3RI7nbDfBCaN4AAABAUXBXcDtzjrKjNcQ%2FMLYPTHkh6%2F5VXhMQ6LIbX2cpHwwNqi%2FugsnXLkVCcmSrhSaxZ1OZF38VVWObu%2BhDYj4SAw%3D%3D
 ```
 
-### Response
+#### Response
 
-If the anchor sees that the transaction meets the following conditions, it replies with a JWT authenticating the user.
+If the web service sees that the transaction meets the following conditions, it replies with a JWT authenticating the user.
 
-* properly signed by anchor
-* properly signed by user
-* not expired (within time bounds)
+* properly signed with a web service signing key (`tx.source_account`)
+* properly signed by user account (`tx.operations[0].source_account`)
+* not expired according to time bounds (`tx.time_bounds.min <= now() <= tx.time_bounds.max`)
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
-Name | Type | Description
------|------|------------
-`jwt` | string | The JWT that a user can use to authenticate future endpoint calls with the anchor
+Name    | Type   | Description
+--------|--------|------------
+`token` | string | The JWT that a user can use to authenticate future endpoint calls with the anchor
 
 Example:
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -94,7 +94,14 @@ Every other HTTP status code will be considered an error. For example:
 
 ### Token
 
-This endpoint accepts a signed challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint). If the client's signature is valid, it responds with a [JSON Web Token](https://jwt.io/) authenticating the user. A server can pick its own expiration period for the token, however 24 hours is recommended.
+This endpoint accepts a signed challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint). If the client's signature is valid, it responds with a [JSON Web Token](https://jwt.io/) authenticating the user.
+
+It is recommended to include the following claims in JWT:
+* `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — the URI of the web service (`https://example.com`)
+* `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
+* `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
+* `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
+* `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
 
 #### Request
 


### PR DESCRIPTION
Some updates for SEP-0010: Stellar Web Authentication (based on a work started in #136):
- [x] use a single auth endpoint (GET the challenge, POST the response)
- [x] generalise text from an `anchor` to a `web service`
- [x] a few minor updates and clarifications
- [x] add recommendations for JWT claims and signing scheme (either symmetric HMAC-based, in which case a client should consider a token opaque, or via Ed25519 which allows a client or third-party to verify the issued JWT)

/cc @tomquisel 