### PR TITLE
SEP-0010: document validation steps, update examples

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Accepted
 Created: 2018-07-31
-Updated: 2018-08-09
-Version 1.0.0
+Updated: 2018-08-14
+Version 1.0.1
 ```
 
 ## Simple Summary
@@ -78,11 +78,11 @@ On success the endpoint should return `200 OK` HTTP status code and a JSON objec
 Example:
 ```json
 {
-  "transaction": "AAAAAAVvtc2vNsygpxOUKCQKkmSJSQItaJ0LxMot3/9ups4/AAAAZAAAAAAAAAAAAAAAAQAAAABbV2YRAAAAAFtXZz0AAAAAAAAAAQAAAAEAAAAAoOOOGwQOwcfc0Wkr/b5MvcKvpqBuuP2CKfo1s/BCaN4AAAAKAAAAEGV4YW1wbGUuY29tIGF1dGgAAAABAAAAQEdaRUx1aU4zbHRjemdFR2xGU24yU2ZVVGFDVnkxMXM1aWNiMkxCSXc0dUZvd2lnQnliNFRUOFdoeklGdXdybmsAAAAAAAAAAW6mzj8AAABAXnnkROpP31vlXYpoa942wXIV7m9CrB3M+8TvJg5Fv+nVNEHABbwnxjKBnGidx2OmhhXLkyoYK0BPxe3RI7nbDQ=="
+  "transaction": "AAAAAGjeCRajN67nRkVtYO+lpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ+dp4m4QfWntHbOq0hxRCLGI+2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL/Ha0YGVrAF6t0UEKP/0Q/NDUymciQBA/CXzYMVlEx2KcHrq3MkpQ9+9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAABL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D/zpd6TNPvcMgUsQd6cDHzjNk+/00P8M5bHP4rIpFTm7MwN"
 }
 ```
 
-You can examine the example transaction in the [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAAVvtc2vNsygpxOUKCQKkmSJSQItaJ0LxMot3%2F9ups4%2FAAAAZAAAAAAAAAAAAAAAAQAAAABbV2YRAAAAAFtXZz0AAAAAAAAAAQAAAAEAAAAAoOOOGwQOwcfc0Wkr%2Fb5MvcKvpqBuuP2CKfo1s%2FBCaN4AAAAKAAAAEGV4YW1wbGUuY29tIGF1dGgAAAABAAAAQEdaRUx1aU4zbHRjemdFR2xGU24yU2ZVVGFDVnkxMXM1aWNiMkxCSXc0dUZvd2lnQnliNFRUOFdoeklGdXdybmsAAAAAAAAAAW6mzj8AAABAXnnkROpP31vlXYpoa942wXIV7m9CrB3M%2B8TvJg5Fv%2BnVNEHABbwnxjKBnGidx2OmhhXLkyoYK0BPxe3RI7nbDQ%3D%3D&type=TransactionEnvelope).
+You can examine the example challenge transaction in the [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAGjeCRajN67nRkVtYO%2Blpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ%2Bdp4m4QfWntHbOq0hxRCLGI%2B2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL%2FHa0YGVrAF6t0UEKP%2F0Q%2FNDUymciQBA%2FCXzYMVlEx2KcHrq3MkpQ9%2B9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAABL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D%2Fzpd6TNPvcMgUsQd6cDHzjNk%2B%2F00P8M5bHP4rIpFTm7MwN&type=TransactionEnvelope&network=test).
 
 Every other HTTP status code will be considered an error. For example:
 
@@ -94,9 +94,24 @@ Every other HTTP status code will be considered an error. For example:
 
 ### Token
 
-This endpoint accepts a signed challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint). If the client's signature is valid, it responds with a [JSON Web Token](https://jwt.io/) authenticating the user.
+This endpoint accepts a signed challenge transaction, validates it and responds with a session [JSON Web Token](https://jwt.io/) authenticating the user.
 
-It is recommended to include the following claims in JWT:
+Client submits a challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint) as a HTTP POST request to `WEB_AUTH_ENDPOINT` using one of the following formats (both should be equally supported by the server):
+
+* Content-Type: `application/x-www-form-urlencoded`, body: `transaction=<signed XDR (URL-encoded)>`)
+* Content-Type: `application/json`, body: `{"transaction": "<signed XDR>"}`
+
+To validate the challenge transaction the following steps are performed by the server. If any of the listed steps fail, then the authentication request must be rejected — that is, treated by the application as an invalid input.
+
+* decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
+* verify that transaction source account is equal to the server's signing key;
+* verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
+* verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and it's source account is not null;
+* verify that transaction envelope has a correct signature by server's signing key;
+* verify that transaction envelope has a correct signature by the operation's source account;
+* use operations's source account to determine the authenticating client and perform any additional service-specific validations.
+
+Upon successful validation service responds with a session JWT, containing the following claims:
 
 * `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — the URI of the web service (`https://example.com`)
 * `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
@@ -120,18 +135,16 @@ Example:
 
 ```
 POST https://auth.example.com/
-transaction=AAAAAAVvtc2vNsygpxOUKCQKkmSJSQItaJ0LxMot3%2F9ups4%2FAAAAZAAAAAAAAAAAAAAAAQAAAABbV2YRAAAAAFtXZz0AAAAAAAAAAQAAAAEAAAAAoOOOGwQOwcfc0Wkr%2Fb5MvcKvpqBuuP2CKfo1s%2FBCaN4AAAAKAAAAEGV4YW1wbGUuY29tIGF1dGgAAAABAAAAQEdaRUx1aU4zbHRjemdFR2xGU24yU2ZVVGFDVnkxMXM1aWNiMkxCSXc0dUZvd2lnQnliNFRUOFdoeklGdXdybmsAAAAAAAAAAm6mzj8AAABAXnnkROpP31vlXYpoa942wXIV7m9CrB3M%2B8TvJg5Fv%2BnVNEHABbwnxjKBnGidx2OmhhXLkyoYK0BPxe3RI7nbDfBCaN4AAABAUXBXcDtzjrKjNcQ%2FMLYPTHkh6%2F5VXhMQ6LIbX2cpHwwNqi%2FugsnXLkVCcmSrhSaxZ1OZF38VVWObu%2BhDYj4SAw%3D%3D
+Content-Type: application/json
+
+{"transaction": "AAAAAGjeCRajN67nRkVtYO+lpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ+dp4m4QfWntHbOq0hxRCLGI+2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL/Ha0YGVrAF6t0UEKP/0Q/NDUymciQBA/CXzYMVlEx2KcHrq3MkpQ9+9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAACL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D/zpd6TNPvcMgUsQd6cDHzjNk+/00P8M5bHP4rIpFTm7MwNbQ/oQwAAAEAz+6EANIKAAR8G62OkGzbnkxgyYuFwbbCwvbDbkk8db31I/EyR0gRpcxv7zzBAkn8g48N6x1huJhTUO0CPl28M"}
 ```
+
+You can examine the example signed challenge transaction in the [XDR Viewer](https://www.stellar.org/laboratory/#xdr-viewer?input=AAAAAGjeCRajN67nRkVtYO%2Blpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ%2Bdp4m4QfWntHbOq0hxRCLGI%2B2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL%2FHa0YGVrAF6t0UEKP%2F0Q%2FNDUymciQBA%2FCXzYMVlEx2KcHrq3MkpQ9%2B9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAACL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D%2Fzpd6TNPvcMgUsQd6cDHzjNk%2B%2F00P8M5bHP4rIpFTm7MwNbQ%2FoQwAAAEAz%2B6EANIKAAR8G62OkGzbnkxgyYuFwbbCwvbDbkk8db31I%2FEyR0gRpcxv7zzBAkn8g48N6x1huJhTUO0CPl28M&type=TransactionEnvelope&network=test).
 
 #### Response
 
-If the web service sees that the transaction meets the following conditions, it replies with a JWT authenticating the user.
-
-* properly signed with a web service signing key (`tx.source_account`)
-* properly signed by user account (`tx.operations[0].source_account`)
-* not expired according to time bounds (`tx.time_bounds.min <= now() <= tx.time_bounds.max`)
-
-On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
+If the web service successfully validates the submitted challenge transaction, the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
 Name    | Type   | Description
 --------|--------|------------
@@ -141,9 +154,11 @@ Example:
 
 ```json
 {
-  "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+  "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQTZVSVhYUEVXWUZJTE5VSVdBQzM3WTRRUEVaTVFWREpIREtWV0ZaSjJLQ1dVQklVNUlYWk5EQSIsImp0aSI6IjE0NGQzNjdiY2IwZTcyY2FiZmRiZGU2MGVhZTBhZDczM2NjNjVkMmE2NTg3MDgzZGFiM2Q2MTZmODg1MTkwMjQiLCJpc3MiOiJodHRwczovL2ZsYXBweS1iaXJkLWRhcHAuZmlyZWJhc2VhcHAuY29tLyIsImlhdCI6MTUzNDI1Nzk5NCwiZXhwIjoxNTM0MzQ0Mzk0fQ.8nbB83Z6vGBgC1X9r3N6oQCFTBzDiITAfCJasRft0z0"
 }
 ```
+
+Check the example session token on [JWT.IO](https://jwt.io/#debugger-io?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQTZVSVhYUEVXWUZJTE5VSVdBQzM3WTRRUEVaTVFWREpIREtWV0ZaSjJLQ1dVQklVNUlYWk5EQSIsImp0aSI6IjE0NGQzNjdiY2IwZTcyY2FiZmRiZGU2MGVhZTBhZDczM2NjNjVkMmE2NTg3MDgzZGFiM2Q2MTZmODg1MTkwMjQiLCJpc3MiOiJodHRwczovL2ZsYXBweS1iaXJkLWRhcHAuZmlyZWJhc2VhcHAuY29tLyIsImlhdCI6MTUzNDI1Nzk5NCwiZXhwIjoxNTM0MzQ0Mzk0fQ.8nbB83Z6vGBgC1X9r3N6oQCFTBzDiITAfCJasRft0z0).
 
 Every other HTTP status code will be considered an error. For example:
 


### PR DESCRIPTION
- [x] More detailed description of challenge transaction validation steps
- [x] Specify that `POST /auth` should accept both `application/x-www-form-urlencoded` and `application/json` inputs
- [x] Update the example transaction XDRs and JWT to follow the spec
- [x] Minor fixes

/cc @tomquisel 