### PR TITLE
Refine interactive SEP-6 flow

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -214,7 +214,7 @@ Name | Type | Description
 `type` | string | Always set to `interactive_customer_info_needed`
 `url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe.
 
-If the wallet wants to be notified that the user has completed the required actions via the URL, it can add an extra `callback` parameter to the value of `url` before opening the browser window. If the `callback` value is a URL, the anchor should `POST` to it with a JSON message as the body once the user has successfully completed the process. If `callback=postMessage` is passed, the anchor should post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method.
+If the wallet wants to be notified that the user has completed the required actions via the URL, it can add an extra `callback` parameter to the value of `url` before opening the browser window. If the `callback` value is a URL, the anchor should `POST` to it with a JSON message as the body once the user has successfully completed the process. If `callback=postMessage` is passed, the anchor should post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message should be posted to `window.parent` instead.
 
 In either case, the JSON message should the same as the [Customer Information Status](#4-customer-information-status) response format, with one change. Since it's possible that the anchor is `POST`ing or `postMessaging` a success result, the `status` field make also be set to `success`.
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: stellar.org
 Status: Accepted
 Created: 2017-10-30
-Updated: 2018-08-09
-Version 2.0.0
+Updated: 2018-08-20
+Version 2.1.0
 ```
 
 ## Simple Summary
@@ -212,9 +212,13 @@ The response body should be a JSON object with the following fields:
 Name | Type | Description
 -----|------|------------
 `type` | string | Always set to `interactive_customer_info_needed`
-`url` | string | URL hosted by the anchor. The wallet should pop up a browser window to this URL.
+`url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe.
 
-If the wallet wants to be notified that the user has completed the required actions via the URL, it can add an extra `callback` parameter to the value of `url` before opening the browser window. If the `callback` value is a URL, the anchor should visit it once the user has successfully completed the process. If `callback=postMessage` is passed, the anchor should post `success` to `window.opener` via the Javascript `Window.postMessage` method. Alternately, the wallet can always poll the original deposit or withdrawal endpoint until a success, status `denied`, or error response is returned.
+If the wallet wants to be notified that the user has completed the required actions via the URL, it can add an extra `callback` parameter to the value of `url` before opening the browser window. If the `callback` value is a URL, the anchor should `POST` to it with a JSON message as the body once the user has successfully completed the process. If `callback=postMessage` is passed, the anchor should post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method.
+
+In either case, the JSON message should the same as the [Customer Information Status](#4-customer-information-status) response format, with one change. Since it's possible that the anchor is `POST`ing or `postMessaging` a success result, the `status` field make also be set to `success`.
+
+Alternatively, the wallet can always poll the original deposit or withdrawal endpoint until a success, status `denied`, or error response is returned.
 
 Example:
 
@@ -233,18 +237,20 @@ An anchor should use this response if customer information was submitted for the
 
 Name | Type | Description
 -----|------|------------
-`type` | string | Always set to "customer_info_status"
+`type` | string | Always set to `customer_info_status`
 `status` | string | Status of customer information processing. One of: `pending`, `denied`
 `more_info_url` | string | (optional) A URL the user can visit if they want more information about their account / status.
 `eta` | int | (optional) Estimated number of seconds until the deposit status will update.
 
 If the anchor decides that more customer information is needed after receiving some information and processing it, it can respond again with a response of type `interactive_customer_info_needed` or `non_interactive_customer_info_needed`. In the case of a `denied` request, an anchor can use the `more_info_url` to explain to the user the issue with their request and give them a way to rectify it manually. A wallet should show the `more_info_url` to the user when explaining that the request was denied.
 
+Note: this status response should never be used in the case that the user's KYC request succeeds. In that case, the anchor should respond with a deposit / withdrawal address as described by those endpoints.
+
 Example:
 
 ```json
 {
-  "type": "status",
+  "type": "customer_info_status",
   "status": "denied",
   "more_info_url": "https://api.example.com/kycstatus?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI"
 }


### PR DESCRIPTION
Provide clearer description of the callback / `postMessage` that occurs at the end of an interactive SEP-6 flow. See the changes in [the interactive response section](https://github.com/stellar/stellar-protocol/blob/sep0006-minor-fixes/ecosystem/sep-0006.md#3-customer-information-needed-interactive) of the SEP.