### PR TITLE
SEP-6: Add a type field to /deposit

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: stellar.org
 Status: Accepted
 Created: 2017-10-30
-Updated: 2018-08-20
-Version 2.1.0
+Updated: 2018-09-11
+Version 2.2.0
 ```
 
 ## Simple Summary
@@ -61,6 +61,7 @@ Name | Type | Description
 `memo_type` | string | (optional) type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
+`type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`.
 
 Example:
 
@@ -300,7 +301,11 @@ The response should be a JSON object like:
           "optional": true
         },
         "amount" : {
-          "description": "amount in USD that you plan to deposit",
+          "description": "amount in USD that you plan to deposit"
+        },
+        "type" : {
+          "description": "type of deposit to make",
+          "choices": ["SEPA", "SWIFT", "cash"]
         }
       }
     },
@@ -357,7 +362,13 @@ For each withdrawal asset, it contains:
 
 The `fields` object allows an anchor to describe fields that are passed into `/deposit` and `/withdraw`. It can explain standard fields like `dest` and `dest_extra` for withdrawal, and it can also specify extra fields that should be passed into `/deposit` or `/withdraw` such as an email address or bank name. If a field is part of the KYC/AML flow handled by `/customer` or the field is handled by your interactive deposit/withdrawal flow, there's no need to list it in `/info`. Only fields that are passed to `/deposit` or `/withdraw` need appear here.
 
-The `fields` object contains a key for each field and an object with `description`, and `optional` attributes as the value. The wallet should display a form to the user to fill out any extra fields or standard fields with unknown values as part of the deposit/withdrawal flow. Fields default to `"optional": false`.
+The `fields` object contains a key for each field name and an object with the following fields as the value:
+
+* `description`: description of field to show to user
+* `optional`: if field is optional. Defaults to `false`.
+* `choices`: list of possible values for the field.
+
+The wallet should display a form to the user to fill out any fields with unknown values as part of the deposit/withdrawal flow. Each field should be an text `input`, unless `choices` is specified, in which case a dropdown should be used.
 
 An anchor should also specify if they support the `/transactions` endpoint under the `"transactions"` key.
 


### PR DESCRIPTION
Changes:

* Added a `type` field to [SEP-6 Deposit Request](https://github.com/tomquisel/stellar-protocol/blob/85d28a60c15f76814c26ee541f777afb3b7ed4b0/ecosystem/sep-0006.md#request) to support anchors like Tempo that have multiple deposit types
* Added a `choices` field to the field objects in [`/info`](https://github.com/tomquisel/stellar-protocol/blob/85d28a60c15f76814c26ee541f777afb3b7ed4b0/ecosystem/sep-0006.md#response-2) to support fields with a handful of possible values like `type`