### PR TITLE
SEP-6: support interactive customer info flows that include deposit

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: stellar.org
 Status: Accepted
 Created: 2017-10-30
-Updated: 2018-08-20
-Version 2.1.0
+Updated: 2018-09-11
+Version 2.2.0
 ```
 
 ## Simple Summary
@@ -213,6 +213,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Always set to `interactive_customer_info_needed`
 `url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe.
+`interactive_deposit` | boolean | (optional) Flag indicating that depositing is also handled in the anchor's interactive customer info flow. The wallet need not make additional requests to `/deposit` to complete the deposit. Defaults to `false`. Only relevant for responses to `/deposit` requests.
 
 If the wallet wants to be notified that the user has completed the required actions via the URL, it can add an extra `callback` parameter to the value of `url` before opening the browser window. If the `callback` value is a URL, the anchor should `POST` to it with a JSON message as the body once the user has successfully completed the process. If `callback=postMessage` is passed, the anchor should post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message should be posted to `window.parent` instead.
 
@@ -225,7 +226,8 @@ Example:
 ```json
 {
   "type": "interactive_customer_info_needed",
-  "url" : "https://api.example.com/kycflow?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI"
+  "url" : "https://api.example.com/kycflow?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI",
+  "interactive_deposit": true
 }
 ```
 


### PR DESCRIPTION
Add `interactive_deposit` flag to the [`interactive_customer_info_needed` response](https://github.com/tomquisel/stellar-protocol/blob/bf4931dd09c556f9e62b96d99f44f504b96c48bf/ecosystem/sep-0006.md#3-customer-information-needed-interactive) to `/deposit`.

This is needed for anchors such as AnchorUSD that both collect KYC info and initiate the deposit from within their interactive iframe flow for deposits. It allows the anchor to communicate to the wallet that the wallet does not need to make any more requests to `/deposit` to complete the deposit, as is normally the case.