### PR TITLE
Adds asset_issuer to /deposit and /withdraw endpoints

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -57,6 +57,7 @@ Request Parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset the user is wanting to deposit with the anchor. Ex BTC,ETH,USD,INR,etc
+`asset_issuer` | string | The account id of the issuing account
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -128,6 +129,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `asset_code` | string | Code of the asset the user wants to withdraw
+`asset_issuer` | string | The account id of the issuing account
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.


### PR DESCRIPTION
We should add the asset_issuer to these endpoints. Clients should be required to specify exactly which asset they are referring to. Anchors can decide whether or not to make use of the asset_issuer provided.