### PR TITLE
Cap0005 updates

### DIFF
--- a/core/cap-0005.md
+++ b/core/cap-0005.md
@@ -159,7 +159,7 @@ When a standalone transaction is received by a validator, the transaction gets
 added to the source's account's transaction queue if:
 1. the sequence numbers are valid.
 2. it replaces an existing transaction with the same sequence number but has a
-higher `fee`.
+higher `fee` by at least `baseFee`.
 3. the account can pay for all fees.
 4. the transaction is valid (signatures are valid, the transaction and its
 operations are valid)
@@ -183,6 +183,7 @@ future.
 ## Backwards Compatibility
 
 ### Transaction subsystem
+
 The change is backward compatible with existing transactions and will be
 transparent to clients.
 

--- a/core/cap-0005.md
+++ b/core/cap-0005.md
@@ -37,9 +37,8 @@ fee transactions.
 
 Fairness is also achieved by attempting to _reduce_ the fee charged to accounts.
 
-This is achieved by associating a value `baseFee` to each
-transaction set (greater than `ledgerHeader.baseFee`), and using that base fee
-to compute the actual fee charged.
+This is achieved by associating a value `baseFee` to each transaction set
+(greater than `ledgerHeader.baseFee`), and using that base fee to compute the actual fee charged.
 With this change, `tx.fee` becomes an upper bound instead of being the actual
 fee deducted from the source account.
 
@@ -69,64 +68,19 @@ specified fee is bigger than needed.
 
 ## Specification
 
-### Transaction set `baseFee`
-
-A new value gets associated to each transaction set during consensus: `txSetBaseFee`.
+In the following specification, we'll use `StellarValue v` with its associated
+`TransactionSet txSet` and `LedgerHeader ledgerHeader`.
 
 ### XDR representation
-The corresponding xdr looks like this:
-```c++
-struct StellarValueV1
-{
-    int64 txSetBaseFee; // base fee for the transaction set
 
-    // reserved for future use
-    union switch (int v)
-    {
-    case 0:
-        void;
-    }
-    ext;
-};
-
-struct StellarValue
-{
-    Hash txSetHash;   // transaction set to apply to previous ledger
-    uint64 closeTime; // network close time
-
-    // upgrades to apply to the previous ledger (usually empty)
-    // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop
-    // unknown steps during consensus if needed.
-    // see notes below on 'LedgerUpgrade' for more detail
-    // max size is dictated by number of upgrade types (+ room for future)
-    UpgradeType upgrades<6>;
-
-    union switch (int v)
-    {
-    case 0:
-        void;
-    case 1:
-        StellarValueV1 v1;
-    }
-    ext;
-};
-
-struct LedgerHeader
-{
-//...
-    // (was maxTxSetSize)
-    uint32 txSetSize; // maximum size a transaction set can be
-//...
-};
-```
+No changes in XDR
 
 ### Construction of the pair (`txSetBaseFee`, `txSet`)
 #### Repurposing `ledgerHeader.maxTxSetSize`
 
-The network level setting `maxTxSetSize` gets renamed to `txSetSize`.
-
-This setting controls the maximum number of _operations_ allowed in a
-transaction set (currently it controls the number of _transactions_).
+For ledgers with a protocolVersion supporting CAP0005, this setting controls
+the maximum number of _operations_ allowed in a transaction set (currently it
+controls the number of _transactions_ in the transaction set).
 
 #### Updated "surge pricing" algorithm
 
@@ -139,7 +93,7 @@ the transaction holding tank.
     * the fee rate (descending) of the first transaction in each queue (so that the queue
 whose first transaction has the highest fee rate is on top of the heap)
      * account ID Xored with S (ascending)
-4. `nb_operations_to_add = txSetSize`
+4. `nb_operations_to_add = maxTxSetSize`
 5. while (`nb_operations_to_add > 0 && !heap.empty()`)
    * queue = heap.pop()
    * if nb_operations(first transaction "tx" from queue)  <= nb_operations_to_add
@@ -149,49 +103,40 @@ whose first transaction has the highest fee rate is on top of the heap)
      * if queue non empty, push it into the heap
  6. if `(!heap.empty())` // surge pricing in effect
     * queue = heap.peek()
-    * set `txSetBaseFee` to the fee rate of the first transaction from queue
-    else do not set `txSetBaseFee` (`value.v == 0`)
 
-Note: if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`,
-* step 4 becomes `nb_operations_to_add = txSetSize*100`
-* in step 6, `txSetBaseFee` is not set (leave `value.v == 0`)
+NB: if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`,
+* step 4 becomes `nb_operations_to_add = maxTxSetSize*100`
 
-### Validity and usage of `txSetBaseFee`
+### Validity and usage of the effective base fee
 
-`StellarValue` is considered valid if the following conditions are met:
-1. the effective base fee is valid
-  * `value.v() == 0` (use `ledgerHeader.baseFee`) or
-  * `value.v() == 1` and
-    * `ledgerHeader.ledgerVersion >= CAP_0005.protocolVersion` // supported
-    * `value.v1().txSetBaseFee >= ledgerHeader.baseFee`
-2. The transaction set is valid given the effective base fee
-  * for each transaction ensure that `tx.fee >= computedFee(effectiveBaseFee)`, with:
-    * if `ledgerHeader.ledgerVersion >= CAP_0005.protocolVersion`
-        * `computedFee(tx, effectiveBaseFee) = effectiveBaseFee * tx.ops.length()`
-    * otherwise (current)
-        * `computedFee(tx, effectiveBaseFee) = tx.fee`
-  * each source account has a sufficient balance to cover the combined computed
-fees of that account's transactions.
+#### Computation of the associated effective base fee
 
-When applying a transaction set, each transaction collects a fee equal
-to `computedFee(tx, effectiveBaseFee)`.
+The effective base fee is defined as follows:
 
-There is a question of what a valid base fee is (step 1), in addition to what
-is described here: without any other limitation, a (bad) validator can nominate
-the same value with `txSetBaseFee` set to its highest possible value.
-The highest possible value is the highest base fee that the last transaction can
-pay for.
+1. if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`
+    * effectiveBaseFee = ledgerHeader.baseFee
+2. else if `nb_operations(txSet) < ledgerHeader.maxTxSetSize`
+    * surge pricing not in effect
+        * effectiveBaseFee = ledgerHeader.baseFee
+3. else, we use the smallest possible base fee for that transaction set
+        * effectiveBaseFee = `min(baseFeeForTx(for(tx in txSet)))`
 
-As the value nominated by a given validator is considered by other validators with
-some probability, a good mitigation could be to cap increases in base fee, and not
-have a cap on decreases:
-* assuming that most of the time values come from well behaved validators, this
-will lower the base fee to the desired (smaller) value
-* increases in base fee will be conditioned by a maximum rate of increase (let's
- say a maximum factor of 2)
- 
-In addition to this, historical votes of the various validators should be available
-for review as to identify mis behaving validators.
+Where `baseFeeForTx` is defined as `tx.fee / tx.ops.length()` rounded up.
+
+#### Computation of the fee charged per transaction
+
+The computation of `fee = computedFee(tx, effectiveBaseFee)` is done as:
+
+1. if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`
+    * fee = `tx.fee`
+2. else
+    * fee = `min(tx.fee, effectiveBaseFee*tx.ops.length())`
+
+#### Validity of a `txSet`
+
+From a fee point of view, the only requirement is that each source account has
+a balance sufficient to cover the combined computed fees of that account's
+transactions included in `txSet`.
 
 ### Ballot protocol changes
 
@@ -200,14 +145,13 @@ the nomination protocol.
 
 For older versions of the protocol, we do not change this function, ie we keep
 the transaction set with the highest number of transactions, and break ties
- by comparing the hash of transaction sets (xored to pseudo-randomize).
+ by comparing the hash of transaction sets (XORed to pseudo-randomize).
 
 For newer versions of the protocol, we'll be following a similar scheme by
 picking the highest value sorted in order by:
 * highest number of operations
-* highest base fee
-* highest txset hash (xored by the hash of all value as before)
-
+* highest total fee (sum of fees charged)
+* highest txset hash (XORed by the hash of all value as before)
 
 ### Changes to transaction submission
 
@@ -220,8 +164,8 @@ higher `fee`.
 4. the transaction is valid (signatures are valid, the transaction and its
 operations are valid)
 
-Implementation note: there might be a way to implicitely perform steps 1..3 by
-chosing a good datastructure.
+Implementation note: there might be a way to implicitly perform steps 1..3 by
+choosing a good data structure.
 
 ## Rationale
 
@@ -233,7 +177,7 @@ transactions (where there is no rational way of putting a high bound on fees),
 or for more complex client side fee control strategies.
 
 This proposal assumes that there is no inherent incentive in validators
-profiting from the rise of fees which probably stays true for the foreseable
+profiting from the rise of fees which probably stays true for the foreseeable
 future.
 
 ## Backwards Compatibility
@@ -246,29 +190,33 @@ The only breaking change is that accounts may have a higher balance than
 expected if `fee` is higher than the minimum fee.
 
 Smart contracts typically don't rely on exact balances and use `mergeAccountOp`
-as part of their cleanup.
+as part of their cleanup that doesn't depend on having a predetermined balance.
+
+### Surge pricing implementation
+
+The exact value generated by surge pricing doesn't need to match even when
+the network is still operating on an older version of the protocol.
+
+As such, there is no concern to try to preserve the existing behavior.
 
 ### Network
 
-Validators must run a version of the software that supports this new model.
+The behavior is entirely driven by the value of the protocol version, the
+change is therefore backward compatible.
 
-To avoid nominating values that would not be compatible with other nodes on the
-network, validators will only set `txSetBaseFee` when the network has already
-upgraded to a version of the protocol compatible with this CAP.
-
-After the network upgrades to the new protocol version the value of `txSetSize`
-will be smaller than desired (as the raw value will not represent transactions
-but operations instead); A subsequent vote by validators will be need to be
-coordinated in order to adjust it to a new desired value.
+After the network upgrades to the new protocol version the value of
+`maxTxSetSize` will be smaller than desired (as the raw value will not
+represent transactions but operations instead); A subsequent vote by validators
+will be need to be coordinated in order to adjust it to a new desired value.
 
 Practically speaking the disruption should be minimal:
 * Most transactions are single operation transactions and won't be effected.
-* Disruption will be mostly for transactions with more operations
-than `txSetSize`. As of this writing, this network parameter is set to `50` on
+* Disruption will be mostly for transactions with more operations than
+`maxTxSetSize`. As of this writing, this network parameter is set to `50` on
 the public network, which means that transactions with more than `50` operations
-will not be accepted by the network during the two upgrades.
+will not be accepted by the network between the two upgrades.
 * Validators can coordinate a "double upgrade", where both the protocol version
-and the `txSetSize` field gets updated.
+and the `maxTxSetSize` field gets updated.
 
 ## Test Cases
 


### PR DESCRIPTION
I simplified how the "effective base fee" is managed (use of derived value instead of parameter going through consensus), this closes potential abuse vectors while simplifying the implementation quite a bit.

I also added a new requirement to allow "replace by fee" to take place.
