### PR TITLE
[SEP-6] Clarify asset codes

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -56,7 +56,7 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the asset the user is wanting to deposit with the anchor. Ex BTC,ETH,USD,INR,etc
+`asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC,ETH,USD,INR,etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be `BTC`.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -127,7 +127,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
-`asset_code` | string | Code of the asset the user wants to withdraw
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex when withdrawing MyBTC tokens for BTC, the asset code must be MyBTC. 
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -56,7 +56,7 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC,ETH,USD,INR,etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be `BTC`.
+`asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC,ETH,USD,INR,etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be BTC.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -127,7 +127,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex when withdrawing MyBTC tokens for BTC, the asset code must be MyBTC. 
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC. 
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.


### PR DESCRIPTION
Some assets are issued with a different asset code than what they anchor (e.g. WSD and USDT for USD), the language used left it ambiguous which code should be used. 