### PR TITLE
Update sep-0006.md

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -91,7 +91,7 @@ Name | Type | Description
 `max_amount` | float | (optional) Maximum amount of asset that a user can deposit.
 `fee_fixed` | float | (optional) Fixed fee (if any). In units of the deposited asset.
 `fee_percent` | float | (optional) Percentage fee (if any). In units of percentage points.
-`extra_info` | object | (optional) Any additional data needed as an input for this deposit, example: Bank Name
+`extra_info` | object or string | (optional) Any additional data needed as an input for this deposit, example: Bank Name
 
 Example:
 


### PR DESCRIPTION
Modifies `how` parameter in `deposit` response to be an object or string. The motivation here is to allow anchors to return a string response that can easily be formatted by client apps (e.g. "depositing more than 10 BTC will require manual confirmation that may take up to 24 hours" or similar).