### PR TITLE
SEP-0006: clarify deposit response

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -7,7 +7,7 @@ Author: stellar.org
 Status: Accepted
 Created: 2017-10-30
 Updated: 2018-11-07
-Version 2.2.1
+Version 2.3.0
 ```
 
 ## Simple Summary
@@ -85,15 +85,21 @@ The response body should be a JSON object with the following fields:
 
 Name | Type | Description
 -----|------|------------
-`how` | string | Instructions for how to deposit the asset. In the case of cryptocurrency it is just an address to which the deposit should be sent.
+`how` | string | Terse but complete instructions for how to deposit the asset. In the case of most cryptocurrencies it is just an address to which the deposit should be sent.
 `eta` | int | (optional) Estimate of how long the deposit will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can deposit.
 `max_amount` | float | (optional) Maximum amount of asset that a user can deposit.
 `fee_fixed` | float | (optional) Fixed fee (if any). In units of the deposited asset.
 `fee_percent` | float | (optional) Percentage fee (if any). In units of percentage points.
-`extra_info` | object | (optional) Any additional data needed as an input for this deposit, example: Bank Name
+`extra_info` | object | (optional) JSON object with additional information about the deposit process.
 
-Example:
+`extra_info` fields:
+
+Name | Type | Description
+-----|------|------------
+`message` | string | (optional) Additional details about the deposit process.
+
+Examples:
 
 ```json
 {
@@ -101,6 +107,18 @@ Example:
   "fee_fixed" : 0.0002
 }
 ```
+
+```json
+{
+  "how" : "Ripple address: rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrHGbf tag: 88",
+  "eta": 60,
+  "fee_percent" : 0.1,
+  "extra_info": {
+    "message": "You must include the tag. If the amount is more than 1000 XRP, deposit will take 24h to complete."
+  }
+}
+```
+
 
 If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use `create_account` to create the account with at least enough XLM for the minimum reserve and a trust line (2.01 XLM is recommended). The anchor should take some of the asset that is sent in to pay for the XLM. The anchor should not list this minimal funding as a fee because the user still receives the value of the XLM in their account. The anchor should detect if the account has been created before returning deposit information, and adjust the `min_amount` in the response to be at least the amount needed to create the account.
 


### PR DESCRIPTION
* Better wording for description of `how`
* clarify `extra_info` field description
* add explicit `message` field to `extra_info`
* add more illustrative example of `/deposit` response