### PR TITLE
Add min/max to /info response

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -127,7 +127,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC. 
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
@@ -297,6 +297,8 @@ The response should be a JSON object like:
       "enabled": true,
       "fee_fixed": 5,
       "fee_percent": 1,
+      "min_amount": 0.1,
+      "max_amount": 1000,
       "fields": {
         "email_address" : {
           "description": "your email address for transaction status updates",
@@ -322,6 +324,8 @@ The response should be a JSON object like:
       "enabled": true,
       "fee_fixed": 5,
       "fee_percent": 0,
+      "min_amount": 0.1,
+      "max_amount": 1000,
       "types": {
         "bank_account": {
           "fields": {
@@ -354,12 +358,16 @@ For each deposit asset, it contains:
 
 * `enabled`: set if SEP-6 deposit for this asset is supported
 * The fee structure
+* `min_amount`: Optional minimum amount. No limit if not specified.
+* `max_amount`: Optional maximum amount. No limit if not specified.
 * `fields` object as explained below.
 
 For each withdrawal asset, it contains:
 
 * `enabled`: set if SEP-6 withdrawal for this asset is supported
 * The fee structure
+* `min_amount`: Optional minimum amount. No limit if not specified.
+* `max_amount`: Optional maximum amount. No limit if not specified.
 * a `types` field with each type of withdrawal supported for that asset as a key. Each type can specify a `fields` object as below explaining what fields are needed and what they do.
 
 The `fields` object allows an anchor to describe fields that are passed into `/deposit` and `/withdraw`. It can explain standard fields like `dest` and `dest_extra` for withdrawal, and it can also specify extra fields that should be passed into `/deposit` or `/withdraw` such as an email address or bank name. If a field is part of the KYC/AML flow handled by SEP-12 or the field is handled by your interactive deposit/withdrawal flow, there's no need to list it in `/info`. Only fields that are passed to `/deposit` or `/withdraw` need appear here.


### PR DESCRIPTION
The current specification only provides `min_amount` or `max_amount` after requesting `/withdraw` or `/deposit`. Since that happens at the end of the user flow, we don't have access to those values for validation at the time the amount is entered. It would simplify implementation if these were provided as part of `/info`.