### PR TITLE
Update sep-0012.md

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -41,6 +41,7 @@ Field | Requirements | Description
 FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) federation protocol
 AUTH_SERVER | uses `https://` | The endpoint used for [SEP-3](sep-0003.md) Compliance Protocol
 TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anchor/Client interoperability
+KYC_SERVER | uses `https://` | The server used for [SEP-12](sep-0012.md) Anchor/Client customer info transfer
 WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
 SIGNING_KEY | Stellar public key | The signing key is used for the compliance protocol
 NODE_NAMES | list of `"G... name"` strings | convenience mapping of common names to node IDs. You can use these common names in sections below instead of the less friendly nodeID. This is provided mainly to be compatible with the stellar-core.cfg

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -28,7 +28,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Prerequisites
 
-* An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server. A client will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
+* An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a client app knows where to find the anchor's server. A client app will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
 
 ## API Endpoints

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -28,7 +28,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Prerequisites
 
-* An anchor must define the location of their `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
+* An anchor must define the location of their `KYC_ENDPOINT` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server. A client will send KYC requests to the `KYC_ENDPOINT` if it is specified, otherwise to the `TRANSFER-SERVER`.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
 
 ## API Endpoints

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -28,7 +28,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Prerequisites
 
-* An anchor must define the location of their `KYC_ENDPOINT` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server. A client will send KYC requests to the `KYC_ENDPOINT` if it is specified, otherwise to the `TRANSFER-SERVER`.
+* An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server. A client will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
 
 ## API Endpoints
@@ -41,7 +41,7 @@ To support this protocol an anchor acts as a server and implements the specified
 Upload customer information to an anchor in an authenticated and idempotent fashion.
 
 ```
-PUT TRANSFER_SERVER/customer
+PUT [KYC_SERVER || TRANSFER_SERVER]/customer
 Content-Type: multipart/form-data
 ```
 
@@ -78,7 +78,7 @@ Delete all personal information that the anchor has stored about a given custome
 ### Request
 
 ```
-DELETE TRANSFER_SERVER/customer/[account]
+DELETE [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
 ```
 
 ### DELETE Responses


### PR DESCRIPTION
Adds the option to add a `KYC_SERVER` to send SEP-12 client requests to so that anchor services can split apart apart KYC and TRANSFER functions between web services if desired.