### PR TITLE
Update sep-0006.md

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -147,6 +147,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
+`account` | `G...` string | The stellar account ID of the user that wants to withdraw. The tokens MUST be sent from this account for the withdrawal to be processed.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.


### PR DESCRIPTION
Upon doing the work on integrating SEP12, I have noticed what seems to me, an inconsistency within this SEP.  

The SEP states that upon using the `/withdrawal` endpoint, a transfer server has the right to return a demand for KYC. However, how is the the anchor going to know if KYC is needed or not if they do not have a Stellar account to associate the request with?

Throughout SEP6, SEP10 and SEP12, KYC is associated with a Stellar account. It is not possible by using the SEPs directly to associate KYC info with an outside destination because there is currently no standard way of proving a user's rights to that withdrawal destination.

Instead, we are associating KYC with a Stellar account (like Coinbase associates KYC info with a Coinbase account). If so, the Stellar account needs to come in with the request to withdraw.

I hope that is clear...