### PR TITLE
Support multisig in SEP-10, SEP-12 authentication

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,12 +7,12 @@ Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.co
 Status: Accepted
 Created: 2018-07-31
 Updated: 2018-08-14
-Version 1.0.1
+Version 1.1.1
 ```
 
 ## Simple Summary
 
-This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-6](sep-0006.md).
+This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md).
 
 ## Abstract
 
@@ -21,7 +21,7 @@ This protocol is a variation of mutual challenge-response, which uses Stellar tr
 The authentication flow is as follows:
 
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
-1. The client signs the transaction using the secret key for the user's Stellar account
+1. The client signs the transaction using one or more secret keys associated with the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. If the signature checks out, the server responds with a [JWT](jwt.io) that represents the user's session
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
@@ -30,7 +30,7 @@ The flow achieves several things:
 
 * Both client and server part can be implemented using well-established Stellar libraries
 * The client can verify that the server holds the secret key to a particular account
-* The server can verify that the client holds the secret key to their account
+* The server can verify that the client holds one or more secret keys. Protocols built on SEP-10 can use the JWT to verify that the user has sufficient signing weight for their Stellar account.
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
 
@@ -43,7 +43,7 @@ A web service indicates that it supports user authentication via this protocol b
 
 ### Challenge
 
-This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
+This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction with one or more keys associated with the user's account via standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
 
 #### Request
 
@@ -56,11 +56,12 @@ Request Parameters:
 Name      | Type          | Description
 ----------|---------------|------------
 `account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
+`signers` | comma-separated list of public keys | (optional) The list of public keys that the client will be signing the challenge with. If not present, server assumes `signers` = `account`
 
 Example:
 
 ```
-GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
+GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ&signers=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ,GBADQN7PIARO5CLBAB4A5WCBW4REZ37FNFJK74JEXJUS2EAKNK7DA3E5
 ```
 
 #### Response
@@ -70,7 +71,9 @@ On success the endpoint should return `200 OK` HTTP status code and a JSON objec
 * source account set to server's signing account
 * invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
 * time bounds: `{min: now(), max: now() + 300 }` (we recommend expiration of 5 minutes to give user time to sign transaction)
-* operations: `manage_data(source: client_account, key: '<anchor name> auth', value: random_nonce())`
+* operations: `manage_data(source: signer_public_key, key: '<anchor name> auth', value: random_nonce())`
+  * One operation per public key in the `signers` list, plus an operation for `account` if it does not appear in `signers`
+  * The `account` operation must come first in the transaction
   * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
   * The value must be a 64 byte long base64 encoded cryptographic-quality random string
 * signature by the web service signing account
@@ -106,9 +109,9 @@ To validate the challenge transaction the following steps are performed by the s
 * decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
 * verify that transaction source account is equal to the server's signing key;
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
-* verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and it's source account is not null;
+* verify that transaction contains at least one [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation with non-null source public key
 * verify that transaction envelope has a correct signature by server's signing key;
-* verify that transaction envelope has a correct signature by the operation's source account;
+* verify that transaction envelope has one correct signature for the source public key of each Manage Data operation;
 * use operations's source account to determine the authenticating client and perform any additional service-specific validations.
 
 Upon successful validation service responds with a session JWT, containing the following claims:
@@ -118,6 +121,9 @@ Upon successful validation service responds with a session JWT, containing the f
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
 * `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
+* `signers` (optional unless the transaction was not signed by the user account's private key) (JSON list of public keys) - the user's public key(s) with which they signed the transaction
+
+NOTE: The server will issue a JWT for account A even if it has been signed only by the private key for account B. It is essential that protocols built on top of this SEP verify the JWT by checking either that `A = B` or that B is a signing key (or set of signing keys) for account A with sufficient weight. The exact check depends on the application, but it **must not** blindly trust a JWT without checking the details.
 
 #### Request
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -30,6 +30,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 * An anchor must define the location of their `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
+  * The anchor must verify that the user's authentication JWT is signed by signer(s) with weight at least equal to the user account's [medium threshold](https://www.stellar.org/developers/guides/concepts/multi-sig.html#thresholds)
 
 ## API Endpoints
 


### PR DESCRIPTION
An alternative to #226 for supporting multisig in SEP-10. @nebolsin @istrau2 let me know your thoughts.

It goes the route of supporting multiple signers on JWTs, and leaving authorization to SEPs that build on it.

One possible addition would be to have the ability to encode a permissions list into the transaction so multiple signers could see exactly which permissions are being requested. That adds complexity, though.