### PR TITLE
Fix a bug where zero-length vectors could not be represented.

### DIFF
--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -116,7 +116,7 @@ Most XDR types are rendered using C syntax. Specifically:
 
   - `string` values are represented as double-quoted interpreted string literals, in which non-ASCII bytes are represented with hex escapes (`"\xff"`), the `"` and `\` characters can be escaped with another `\` (e.g., `"\\"`), and `\n` designates a newline.
 
-  - `opaque` values are represented as an unquoted hexadecimal string (using lower-case case `a`...`f`)
+  - `opaque` values are represented as an unquoted hexadecimal string (using lower-case case `a`...`f`) with an even number of digits.  An exception is that the 0-length opaque vector is represented as "0" (a single digit).  Implementations are encouraged to add the comment bytes so that it reads "0 bytes" to further distinguish the 0-length vector from the vector with a single byte 0x00 (rendered "00").
 
 A few aggregate values are special-cased:
 
@@ -124,7 +124,7 @@ A few aggregate values are special-cased:
 
   - `PublicKey` and `SignerKey` are rendered as unquoted strings in strkey format, described below.
 
-Any fields in the XDR `TransactionEnvelope` structure that are not specified in a txrep description are to be interpreted as false (for `bool` and `_present` pseudoselectors), zero (for numeric values, enums, fixed-length `opaque`), or zero-length (for strings, variable-length arrays, and variable-length `opaque`).
+Any fields in the XDR `TransactionEnvelope` structure that are not specified in a txrep description are to be interpreted as false for `bool`, zero (for numeric values, enums, fixed-length `opaque`), or zero-length (for strings, variable-length arrays, and variable-length `opaque`).  The `_present` pseudo-selector, if unspecified, defaults to true if any field or value of the pointer's data structure is specified, and otherwise defaults to `_false`.
 
 ### Strkey format
 


### PR DESCRIPTION
Also, Relax the default for _present to be true if fields/values present.
This still allows transactions a pointer to be made unambiguously NULL
with _present: false, but also means that values can be excerpted
without showing tons of _present: true and still be pastable into
a txrep.