### PR TITLE
Add optional `amount` argument to SEP-0006

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -60,6 +60,7 @@ Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC,ETH,USD,INR,etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be BTC.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
+`amount` | string | (optional) The amount of the given asset to deposit. The anchor can use this to reject requests that are outside their supported range.
 `memo_type` | string | (optional) type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`
 `memo` | string | (optional) value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
@@ -149,6 +150,7 @@ Name | Type | Description
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
+`amount` | string | (optional) The amount of the given asset to withdraw. The anchor can use this to reject requests that are outside their supported range.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.


### PR DESCRIPTION
I realized that anchors have no insight into how much users are attempting to withdraw or deposit, leaving validation of min/max entirely up to the wallet initiating the transfer. This seems less than ideal, the anchor should have an opportunity to enforce their limits as well.