### PR TITLE
SEP-0008 update/replace: Generalize "Regulated Asset" to "Automated Co-Signing"

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -41,15 +41,15 @@ Implementing automated co-signing consists of these parts:
     5. *Rejected?* Wallet should display given error message to the user.
 
 ## Stellar.toml
-Co-signers will advertise the location of their Approval Service through their stellar.toml file. This is done in the [OUR_SIGNERS] section.
-[OUR_SIGNERS] is an array of strings that contain the signers public key and the corresponding Approval Service URL separated with a space.
+Co-signers will advertise the location of their Approval Service through their stellar.toml file. This is done in the` OUR_SIGNERS` array of strings that contain the signers public key and the corresponding Approval Service URL separated with a space.
 The keyword ALL instead of a public key may be used to refer to an Approval Service for any signer if not specified otherwise.
 
 ### Example
 ```toml
-[OUR_SIGNERS]
-    "ALL https://goat.io/tx_approve"
+OUR_SIGNERS = [
+    "ALL https://goat.io/tx_approve",
     "GB75YSNJQ6NTS2OIMWEXPRAW2EEKMCBO6WS5EPDCM2TM3CIDVFTY6TBE https://sep8.sui.li/tx_approve"
+]
 ````
 
 ## Approval Server

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0008
-Title: Regulated Assets
+Title: Automated Co-Signing
 Author: Interstellar.com
 Status: Accepted
 Created: 2018-08-22
@@ -11,7 +11,7 @@ Version 1.0.0
 
 ## Simple Summary
 
-Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval. 
+Automated Co-Signing provides ecosystem support for accounts that require a delegated third party’s approval (such as a licensed securities exchange or multisignature services in general) on a per-transaction basis. It standardizes the identification of such accounts as well as defines the protocol for performing compliance checks and requesting co-signers approval. 
 
 **Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
 
@@ -21,17 +21,17 @@ Stellar aims to be an ideal platform for issuing securities. As such, it must pr
 
 ## Overview
 
-Implementing a Regulated Asset consists of these parts:
-- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+Implementing automated co-signing consists of these parts:
+- **Stellar.toml**: Co-signers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
 - **Approval Server**: HTTP protocol for transaction signing. 
-- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/> 
-**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented. 
+- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by third party co-signers, rather than the wallet end user. Furthermore the accounts will have to set their `home_domain` accordingly to refer to a stellar.toml containing the needed informations.<br/> 
+**Note**: this step may not be required for regulated asset scenarios once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented. 
 
-## Regulated Assets Approval Flow
+## Automated Co-signing Flow
 
 1. User creates and signs a transaction.
-2. Wallet resolves asset information and detects that it's a regulated asset.
-3. Wallet sends the transaction to the approval server.
+2. Wallet tries to resolve Approval Server from users home_domain if (count(account.signers) > 1).
+3. Wallet sends the transaction to the Approval Server.
 4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
 5. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
@@ -41,24 +41,16 @@ Implementing a Regulated Asset consists of these parts:
     5. *Rejected?* Wallet should display given error message to the user.
 
 ## Stellar.toml
-Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
-
-### Fields:
-
-- `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
-- `approval_server` is the url of an approval service that signs validated transactions.
-- `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
+Co-signers will advertise the location of their Approval Service through their stellar.toml file. This is done in the [OUR_SIGNERS] section.
+[OUR_SIGNERS] is an array of strings that contain the signers public key and the corresponding Approval Service URL separated with a space.
+The keyword ALL instead of a public key may be used to refer to an Approval Service for any signer if not specified otherwise.
 
 ### Example
-
 ```toml
-[[CURRENCIES]]
-code="GOAT"
-issuer="GD5T6IPRNCKFOHQWT264YPKOZAWUMMZOLZBJ6BNQMUGPWGRLBK3U7ZNP"
-regulated=true
-approval_server="https://goat.io/tx_approve"
-approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
-```
+[OUR_SIGNERS]
+    "ALL https://goat.io/tx_approve"
+    "GB75YSNJQ6NTS2OIMWEXPRAW2EEKMCBO6WS5EPDCM2TM3CIDVFTY6TBE https://sep8.sui.li/tx_approve"
+````
 
 ## Approval Server
 The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
@@ -151,6 +143,9 @@ error|string|A human readable string explaining why the transaction is not compl
 Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval. 
 
 In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
+
+## Implementation
+A sample implementation can be found [here](https://sep8.sui.li).
 
 ## Discussion
 


### PR DESCRIPTION
@tomerweller 

I've just implemented a sample SEP-0008 wallet + approval server ( https://github.com/sui77/stellar-sep8-example ) and came to the conclusion that in one point SEP-0008 is conceptually flawed. It should be updated/replaced to reflect a more generic "Automated Co-Signing" instead of "Regulated Asset" procedure.


## What's the issue?

A stellar multisig account that has one anchor as co-signer requires approvals for any transaction (other anchors asset payments, XLM native payments, non-payment operations) but the required metadata is located in the [[CURRENCIES]] section of the stellar.toml at the home domain of one trustline. Any non primary anchor asset related transaction would require to look up every trustlines stellar.toml and walk through all found approval services in a trial and error fashion. 

One could argue, that in most cases this specific setup will have a single anchor cosigner only, accounts will be managed by that anchor, the first found approval_server will be the right one almost every time and the anchor is not interested in XML transactions. Nevertheless it feels wrong and bugs me.

If you think about it, co-signing isn't even directly related to an asset but obviously related to the signers. And it's not specifically about asset regulation by an anchor but more generally about account management by a 3rd party. I could think of these other use cases:

- I could give my kids a co-signed account and my approval server would restrict their daily pocket money budgets.
- Web wallets could manage accounts without being able to access user funds but being able to help securing non tech savvy users with additional 2fa or transaction limits. Even on standardized 3rd party wallets.
- Multisig services could gather all signatures of a m-of-n account in a standardized way (ok, that might need additional protocol definition, but on a good base)


## What to change? Options to be discussed.

The one thing to change is the location of metadata.

### Option 1:
- Set up user account.home_domain
- Look up users account.home_domain/stellar.toml instead of issuers account.
- Locate approval_server in a new generic [OUR_SIGNERS] section instead of the [[CURRENCIES]] section.

Simple and my favorite one. I've updated the document to reflect this option.

### Option 2:
- Set up every signers account.home_domain
- Look up every signers account.home_domain => stellar.toml 
- Locate approval_server in a new generic [OUR_SIGNERS] section instead of the [[CURRENCIES]] section.

Would be more flexible, but requires every signer to have an account, more lookups and adds too much complexity for my taste.

### Option 3:
- Use data entries to refer to each signers home_domain

Found this idea when I stumbled over the [Multisig Coordination proposal](https://github.com/stellar/stellar-protocol/blob/4da1e71cda4fb1a287f2f49263ac7a340e04c6df/drafts/draft-0005.md) ). 
Thought it's cool at first sight but I don't like the idea of refering to a stellar.toml different than the accounts home_domain. (Btw: Still I don't support the request for [deprecating data entries](https://github.com/stellar/stellar-protocol/issues/221) )

## Backwards Compatibility
This would be a major change that would not be compatible with existing implementations. But since SEP-0008 is pretty new I think nobody has implemented it yet anyways (other than maybe using it as a guideline for specific closed solutions). I've crawled all accessable stellar.tomls and could only find two approval_server entries on testnet (one is me and the other links to a disfunctional endpoint) and none on mainnet.