### PR TITLE
Add CORS note to SEP-0006

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -42,6 +42,14 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /transactions`](#transaction-history): optional, but strongly recommended
 * [`GET /transaction`](#single-historical-transaction): optional, but strongly recommended
 
+## Cross-Origin Headers
+
+Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.
+
+```
+Access-Control-Allow-Origin: *
+```
+
 ## Deposit
 
 A deposit is when a user sends an external token (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by an anchor. In turn, the anchor sends an equal amount of tokens on the Stellar network (minus fees) to the user's Stellar account.


### PR DESCRIPTION
Extending the spec by a note about CORS headers, since they are vital for web clients to use the anchor's endpoints.

As briefly discussed with @tomquisel.