### PR TITLE
Cap005 updates (post prototyping)

### DIFF
--- a/core/cap-0005.md
+++ b/core/cap-0005.md
@@ -101,8 +101,8 @@ whose first transaction has the highest fee rate is on top of the heap)
      * nb_operations_to_add = nb_operations_to_add - nb_operations(tx)
      * pop tx from queue
      * if queue non empty, push it into the heap
- 6. if `(!heap.empty())` // surge pricing in effect
-    * queue = heap.peek()
+6. if `count_ops(txSet) > max(0, ledgerHeader.maxTxSetSize-100)`
+   * surge pricing in effect
 
 NB: if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`,
 * step 4 becomes `nb_operations_to_add = maxTxSetSize*100`
@@ -112,17 +112,17 @@ NB: if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`,
 
 #### Computation of the associated effective base fee
 
-The effective base fee is defined as follows:
+The effective base fee for protocol supporting CAP_0005 is defined as follows:
 
-1. if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`
-    * effectiveBaseFee = ledgerHeader.baseFee
-2. else if `nb_operations(txSet) < ledgerHeader.maxTxSetSize`
+1. if `nb_operations(txSet) <= max(0, ledgerHeader.maxTxSetSize-100)`
     * surge pricing not in effect
-        * effectiveBaseFee = ledgerHeader.baseFee
-3. else, we use the smallest possible base fee for that transaction set
+        * effectiveBaseFee = `ledgerHeader.baseFee`
+2. else, we use the smallest possible base fee for that transaction set
         * effectiveBaseFee = `min(baseFeeForTx(for(tx in txSet)))`
 
 Where `baseFeeForTx` is defined as `tx.fee / tx.ops.length()` rounded up.
+
+NB: Surge pricing is triggered as soon as we can't assume that a transaction was not included in the transaction set given the limit `ledgerHeader.maxTxSetSize`, which comes to `ledgerHeader.maxTxSetSize-100`.
 
 #### Computation of the fee charged per transaction
 

--- a/core/cap-0005.md
+++ b/core/cap-0005.md
@@ -158,20 +158,6 @@ picking the highest value sorted in order by:
 * highest total fee (sum of fees charged)
 * highest txset hash (XORed by the hash of all value as before)
 
-### Changes to transaction submission
-
-When a standalone transaction is received by a validator, the transaction gets
-added to the source's account's transaction queue if:
-1. the sequence numbers are valid.
-2. it replaces an existing transaction with the same sequence number but has a
-higher `fee` by at least `baseFee`.
-3. the account can pay for all fees.
-4. the transaction is valid (signatures are valid, the transaction and its
-operations are valid)
-
-Implementation note: there might be a way to implicitly perform steps 1..3 by
-choosing a good data structure.
-
 ## Rationale
 
 Implementing this proposal should greatly increase the chances of transactions

--- a/core/cap-0005.md
+++ b/core/cap-0005.md
@@ -92,7 +92,7 @@ the transaction holding tank.
 3. construct a heap of those queues, sorted by:
     * the fee rate (descending) of the first transaction in each queue (so that the queue
 whose first transaction has the highest fee rate is on top of the heap)
-     * account ID Xored with S (ascending)
+     * first transaction hash Xored with S (ascending)
 4. `nb_operations_to_add = maxTxSetSize`
 5. while (`nb_operations_to_add > 0 && !heap.empty()`)
    * queue = heap.pop()
@@ -106,6 +106,7 @@ whose first transaction has the highest fee rate is on top of the heap)
 
 NB: if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion`,
 * step 4 becomes `nb_operations_to_add = maxTxSetSize*100`
+* step 5 defaults `nb_operations(tx)` to `100` 
 
 ### Validity and usage of the effective base fee
 
@@ -137,6 +138,10 @@ The computation of `fee = computedFee(tx, effectiveBaseFee)` is done as:
 From a fee point of view, the only requirement is that each source account has
 a balance sufficient to cover the combined computed fees of that account's
 transactions included in `txSet`.
+
+if `ledgerHeader.ledgerVersion < CAP_0005.protocolVersion` we enforce that `txSet.length() <= maxTxSetSize`.
+
+Otherwise we enforce that `nb_operations(txSet) <= maxTxSetSize`
 
 ### Ballot protocol changes
 


### PR DESCRIPTION
This PR makes a few changes to CAP005 after a first take on an implementation.

1. Removes mention of replace by fee: the version mentioned here was weak (overlay) and was later deemed insufficient.
2. Replaces the way transactions are randomized during surge pricing, making it "more random"
3. Clarifies when surge pricing actually happens, previous version didn't account for the impossibility of filling up transaction sets
