### PR TITLE
rename @p2p to atp3

### DIFF
--- a/ecosystem/sep-0016.md
+++ b/ecosystem/sep-0016.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0016
-Title: Account Transfer Permissionless Payment Protocol (@p2p)
+Title: Account Transfer Permissionless Payment Protocol (atp3)
 Author: Jeremy Rubin
 Status: Draft
 Created: 2018-11-07
@@ -10,7 +10,7 @@ Created: 2018-11-07
 
 ## Simple Summary
 
-Account Transfer Permissionless Payment Protocol (@p2p) is used to make a
+Account Transfer Permissionless Payment Protocol (atp3) is used to make a
 payment to another party by effectively creating a non-custodial temporary
 account on their behalf.  It can be used in contexts where the recipient does
 not yet have an account or must take some action in order to finalize their
@@ -19,7 +19,7 @@ payment.
 
 ## Abstract
 
-@p2p introduces an asynchronous protocol which allows senders to trustlessly
+Atp3 introduces an asynchronous protocol which allows senders to trustlessly
 transfer funds to a recipient. In contrast to other proposals to accomplish this
 goal, it does not require a core protocol change.
 
@@ -28,18 +28,18 @@ goal, it does not require a core protocol change.
 Currently, it is impossible to make a payment to a user who does not yet have an
 account, or has not set up the requisite trust lines. Because setting up a
 trustlines requires the approval and online-ness of the recipient, this makes
-it difficult to push payments. @p2p is a suite of techniques that can be used to
+it difficult to push payments. Atp3 is a suite of techniques that can be used to
 address this issue without requiring any core protocol changes.
 
-@p2p can also be used in the future with Deterministic Accounts (CAP-0007) to
+Atp3 can also be used in the future with Deterministic Accounts (CAP-0007) to
 great effect.
 
-@p2p also makes conditional transfers possible, which are demonstrated as a
+Atp3 also makes conditional transfers possible, which are demonstrated as a
 call-option contract.
 
 
 ## Specification
-The general setup of @p2p is a sender (Sarah) wanting to make a payment to a
+The general setup of atp3 is a sender (Sarah) wanting to make a payment to a
 specific recipient (Robert).
 
 We consider a few cases:
@@ -296,18 +296,18 @@ FunBucks.
 
 ## Rationale
 
-The @p2p design is proposed as an alternative to the Balance's proposal offered
+The atp3 design is proposed as an alternative to the Balance's proposal offered
 by Jed McCaleb on the Stellar-Dev mailing list on October 24th, 2018 and in issue
 [188](https://github.com/stellar/stellar-protocol/issues/188).
 
-In contrast to 188, @p2p does not require any changes to the core consensus
+In contrast to 188, atp3 does not require any changes to the core consensus
 protocol. This ensures that it is fully backwards and forwards compatible and
 does not break or change any existing behavior.
 
 It is also a more flexible foundation for future protocols as it supports new
 contracts like covered options.
 
-If a proposal similar to CAP-7 is finalized, a @p2p like protocol can be made
+If a proposal similar to CAP-7 is finalized, a atp3 like protocol can be made
 much more efficient as the steps Sarah has to take could be collapsed into a
 single step. Furthermore, with CAP-7, O(n) outbound payments from Sarah could be
 confirmed in a single transaction of constant size, and redeemed later. This


### PR DESCRIPTION
@p2p is a confusing name, because @ generally prefixes a person's
handle and p2p often stands for peer-to-peer.