### PR TITLE
make offerID int64, as implemented

### DIFF
--- a/core/cap-0006.md
+++ b/core/cap-0006.md
@@ -49,7 +49,7 @@ struct ManageBuyOfferOp
                      // selling
 
     // 0=create a new offer, otherwise edit an existing offer
-    uint64 offerID;
+    int64 offerID;
 };
 
 /******* ManageBuyOffer Result ********/


### PR DESCRIPTION
`offerID` was made `int64` [https://github.com/stellar/stellar-core/pull/2044)](here), to make it less error prone in languages that don’t support uint64.

 Update the value here to reduce confusion for implementers.