### PR TITLE
Mark `dest` as optional in SEP-0006 withdraw

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active
 Created: 2017-10-30
-Updated: 2019-01-08
-Version 2.4.0
+Updated: 2019-06-21
+Version 2.5.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -156,7 +156,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
-`dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
+`dest` | string | (optional) The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.  This may be optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -365,7 +365,10 @@ The response should be a JSON object like:
         },
         "cash": {
           "fields": {
-            "dest": { "description": "your email address. Your cashout PIN will be sent here." }
+            "dest": { 
+              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
+              "optional": true
+            }
           }
         }
       }


### PR DESCRIPTION
If an anchor is requiring interactive customer information, it may be possible to omit `dest` in the initial withdraw API call.  The reason being that the anchor can collect the dest information interactively while they collect the customer information.

I would propose that anchors that want to declare that dest is required should do so via the Info endpoint.