### PR TITLE
Change how sep1 presents validator information

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -150,7 +150,7 @@ These fields go in the `stellar.toml` `[[VALIDATORS]]` list, one set of fields f
 
 Field | Requirements | Description
 ------|--------------|------------
-ALIAS | string | A name for display in stellar-core configs that conforms to `^[a-z0-9-]+$`
+ALIAS | string | A name for display in stellar-core configs that conforms to `^[a-z0-9-]{2,16}$`
 DISPLAY_NAME | string | A human-readable name for display in quorum explorers and other interfaces
 PUBLIC_KEY | `G...` string | The Stellar account associated with the node
 HOST | string | The IP:port or domain:port peers can use to connect to the node

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -150,7 +150,7 @@ These fields go in the `stellar.toml` `[[VALIDATORS]]` list, one set of fields f
 
 Field | Requirements | Description
 ------|--------------|------------
-ALIAS | string | A name for the node (containing no spaces) for display in stellar-core configs
+ALIAS | string | A name for display in stellar-core configs that conforms to `^[a-z0-9-]+$`
 DISPLAY_NAME | string | A human-readable name for display in quorum explorers and other interfaces
 PUBLIC_KEY | `G...` string | The Stellar account associated with the node
 HOST | string | The IP:port or domain:port peers can use to connect to the node
@@ -247,23 +247,23 @@ image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
 fixed_number=10000
 
 [[VALIDATORS]]
-ID="domain.au"
+ALIAS="domain-au"
 DISPLAY_NAME="Domain Australia"
-ADDRESS="core-au.domain.com:11625"
+HOST="core-au.domain.com:11625"
 PUBLIC_KEY="GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3"
 HISTORY="http://history.domain.com/prd/core-live/core_live_001/"
 
 [[VALIDATORS]]
-ID="domain.sg"
+ALIAS="domain-sg"
 DISPLAY_NAME="Domain Singapore"
-ADDRESS="core-sg.domain.com:11625"
+HOST="core-sg.domain.com:11625"
 PUBLIC_KEY="GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
 HISTORY="http://history.domain.com/prd/core-live/core_live_002/"
 
 [[VALIDATORS]]
-ID="domain.us"
+ALIAS="domain-us"
 DISPLAY_NAME="Domain United States"
-ADDRESS="core-us.domain.com:11625"
+HOST="core-us.domain.com:11625"
 PUBLIC_KEY="GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
 HISTORY="http://history.domain.com/prd/core-live/core_live_003/"
 

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -150,10 +150,10 @@ These fields go in the `stellar.toml` `[[VALIDATORS]]` list, one set of fields f
 
 Field | Requirements | Description
 ------|--------------|------------
-ID | string | A friendly mapping for display in stellar-core configs (alphanumeric only; no spaces)
+ALIAS | string | A name for the node (containing no spaces) for display in stellar-core configs
 DISPLAY_NAME | string | A human-readable name for display in quorum explorers and other interfaces
 PUBLIC_KEY | `G...` string | The Stellar account associated with the node
-ADDRESS | string | The IP:port or domain:port peers can use to connect to the node
+HOST | string | The IP:port or domain:port peers can use to connect to the node
 HISTORY | uri | The location of the history archive published by this validator
 
 ## Testing

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -12,7 +12,7 @@ Version: 2.0.0
 
 ## Simple Summary
 
-The `stellar.toml` file is used to provide a common place where the Internet can find information about your domain’s Stellar integration. By setting the homedomain of your Stellar account to the domain that hosts your `stellar.toml`, you can create a definitive link between this information and that account. Any website can publish Stellar network information, and the `stellar.toml` is designed to be readable by both humans and machines.
+The `stellar.toml` file is used to provide a common place where the Internet can find information about your organization’s Stellar integration. By setting the homedomain of your Stellar account to the domain that hosts your `stellar.toml`, you can create a definitive link between this information and that account. Any website can publish Stellar network information, and the `stellar.toml` is designed to be readable by both humans and machines.
 
 If you are an anchor or issuer, the `stellar.toml` file serves a very important purpose: it allows you to publish information about your organization and token(s) that help to legitimize your offerings. Clients and exchanges can use this information to decide whether a token should be listed. Fully and truthfully disclosing contact and business information is an essential step in responsible token issuance.
 
@@ -52,6 +52,7 @@ TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anc
 KYC_SERVER | uses `https://` | The server used for [SEP-12](sep-0012.md) Anchor/Client customer info transfer
 WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
 SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.md) Compliance Protocol
+HORIZON_URL | URL string | Location of public-facing Horizon instance (if you offer one)
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
 VERSION | string | The version of SEP-1 your `stellar.toml` adheres to.  This helps parsers know which fields to expect.
 
@@ -149,9 +150,11 @@ These fields go in the `stellar.toml` `[[VALIDATORS]]` list, one set of fields f
 
 Field | Requirements | Description
 ------|--------------|------------
-NODE_PUBLIC_KEY | `G...` string | The Stellar account associated with the node
-NODE_NAME | string | A human-readable name to make your node easier to identify 
-HISTORY | URL string | The location of the history archive published by this validator
+ID | string | A friendly mapping for display in stellar-core configs (alphanumeric only; no spaces)
+DISPLAY_NAME | string | A human-readable name for display in quorum explorers and other interfaces
+PUBLIC_KEY | `G...` string | The Stellar account associated with the node
+ADDRESS | string | The peer:port associated with the node
+HISTORY | URI string | The location of the history archive published by this validator
 
 ## Testing
 
@@ -183,12 +186,15 @@ FEDERATION_SERVER="https://api.domain.com/federation"
 AUTH_SERVER="https://api.domain.com/auth"
 TRANSFER_SERVER="https://api.domain.com"
 SIGNING_KEY="GBBHQ7H4V6RRORKYLHTCAWP6MOHNORRFJSDPXDFYDGJB2LPZUFPXUEW3"
+HORIZON_URL="https://horizon.domain.com"
 
 ACCOUNTS=[
 "GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3",
 "GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7",
 "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
 ]
+
+VERSION="2.0.0"
 
 [DOCUMENTATION]
 ORG_NAME="Organization Name"
@@ -241,18 +247,24 @@ image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
 fixed_number=10000
 
 [[VALIDATORS]]
-NODE_PUBLIC_KEY="GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3"
-NODE_NAME="Domain 1"
+ID="domain.au"
+DISPLAY_NAME="Domain Australia"
+ADDRESS="core-au.domain.com:11625"
+PUBLIC_KEY="GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3"
 HISTORY="http://history.domain.com/prd/core-live/core_live_001/"
 
 [[VALIDATORS]]
-NODE_PUBLIC_KEY="GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
-NODE_NAME="Domain 2"
+ID="domain.sg"
+DISPLAY_NAME="Domain Singapore"
+ADDRESS="core-sg.domain.com:11625"
+PUBLIC_KEY="GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
 HISTORY="http://history.domain.com/prd/core-live/core_live_002/"
 
 [[VALIDATORS]]
-NODE_PUBLIC_KEY="GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
-NODE_NAME="Domain 3"
+ID="domain.us"
+DISPLAY_NAME="Domain United States"
+ADDRESS="core-us.domain.com:11625"
+PUBLIC_KEY="GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
 HISTORY="http://history.domain.com/prd/core-live/core_live_003/"
 
 # optional extra information for humans

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -52,7 +52,7 @@ TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anc
 KYC_SERVER | uses `https://` | The server used for [SEP-12](sep-0012.md) Anchor/Client customer info transfer
 WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
 SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.md) Compliance Protocol
-HORIZON_URL | URL string | Location of public-facing Horizon instance (if you offer one)
+HORIZON_URL | url | Location of public-facing Horizon instance (if you offer one)
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
 VERSION | string | The version of SEP-1 your `stellar.toml` adheres to.  This helps parsers know which fields to expect.
 
@@ -153,8 +153,8 @@ Field | Requirements | Description
 ID | string | A friendly mapping for display in stellar-core configs (alphanumeric only; no spaces)
 DISPLAY_NAME | string | A human-readable name for display in quorum explorers and other interfaces
 PUBLIC_KEY | `G...` string | The Stellar account associated with the node
-ADDRESS | string | The peer:port associated with the node
-HISTORY | URI string | The location of the history archive published by this validator
+ADDRESS | string | The IP:port or domain:port peers can use to connect to the node
+HISTORY | uri | The location of the history archive published by this validator
 
 ## Testing
 

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -7,14 +7,16 @@ Author: stellar.org
 Status: Active
 Created: 2017-10-30
 Updated: 2018-09-11
-Version: 1.4.0
+Version: 2.0.0
 ```
 
 ## Simple Summary
 
-The `stellar.toml` file is used to provide a common place where the Internet can find information about your domain’s Stellar integration. Any website can publish Stellar network information. You can announce your validation key, your federation server, peers you are running, your quorum set, if you are an anchor, etc.
+The `stellar.toml` file is used to provide a common place where the Internet can find information about your domain’s Stellar integration. By setting the homedomain of your Stellar account to the domain that hosts your `stellar.toml`, you can create a definitive link between this information and that account. Any website can publish Stellar network information, and the `stellar.toml` is designed to be readable by both humans and machines.
 
-If you are an anchor or issuer, the `stellar.toml` file serves a very important purpose. It allows you to publish information about your organization and token(s) that help to legitimize your offerings. Clients and exchanges can use this information to decide whether a token should be listed. Fully and truthfully disclosing contact and business information is an essential step in responsible token issuance.
+If you are an anchor or issuer, the `stellar.toml` file serves a very important purpose: it allows you to publish information about your organization and token(s) that help to legitimize your offerings. Clients and exchanges can use this information to decide whether a token should be listed. Fully and truthfully disclosing contact and business information is an essential step in responsible token issuance.
+
+If you are a validator, the `stellar.toml` file allows you to declare your node(s) to other network participants, which improves discoverability, and contributes to the health and decentralization of the network as a whole. 
 
 ## Specification
 
@@ -24,7 +26,7 @@ Given the domain `DOMAIN`, the `stellar.toml` will be searched for at the follow
 https://DOMAIN/.well-known/stellar.toml
 ```
 
-You must enable CORS on the `stellar.toml` so people can access this file from other sites. The following HTTP header must be set for a HTTP response for `/.well-known/stellar.toml` file request.
+You must enable CORS on the `stellar.toml` so people can access this file from other sites. The following HTTP header must be set for an HTTP response for `/.well-known/stellar.toml` file request.
 
 ```
 Access-Control-Allow-Origin: *
@@ -44,20 +46,14 @@ These are global fields in the `stellar.toml` file.
 
 Field | Requirements | Description
 ------|--------------|------------
-FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) federation protocol
+FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) Federation Protocol
 AUTH_SERVER | uses `https://` | The endpoint used for [SEP-3](sep-0003.md) Compliance Protocol
 TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anchor/Client interoperability
 KYC_SERVER | uses `https://` | The server used for [SEP-12](sep-0012.md) Anchor/Client customer info transfer
 WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
-SIGNING_KEY | Stellar public key | The signing key is used for the compliance protocol
-NODE_NAMES | list of `"G... name"` strings | convenience mapping of common names to node IDs. You can use these common names in sections below instead of the less friendly nodeID. This is provided mainly to be compatible with the stellar-core.cfg
-ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain. Names defined in `NODE_NAMES` can be used as well, prefixed with `$`.
-OUR_VALIDATORS | list of `G...` strings | A list of validator public keys that are declared to be used by this domain for validating ledgers. They are authorized signers for the domain. Names defined in `NODE_NAMES` can be used as well, prefixed with `$`.
-ASSET_VALIDATOR | `G...` string | The validator through which the issuer pledges to honor redemption transactions, and which therefore maintains the authoritative ownership records for assets issued by this organization.  Specified as a public key `G...` or `NODE_NAME` prefixed with `$`. This field may also contain a list of validators.  In this case, transactions must be processed by _all_ listed validators.  In the event that this field specifies multiple validators and they do not all agree, then the authoritative ownership records will be the last ledger number on which all validators agree.
-DESIRED_BASE_FEE | int | Your preference for the Stellar network base fee, expressed in stroops
-DESIRED_MAX_TX_PER_LEDGER | int | Your preference for max number of transactions per ledger close
-KNOWN_PEERS | list of strings | List of known Stellar core servers, listed from most to least trusted if known. Can be `IP:port`, `IPv6:port`, or `domain:port` with the `:port` optional.
-HISTORY | list of URL strings | List of history archives maintained by this domain
+SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.md) Compliance Protocol
+ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
+VERSION | string | The version of SEP-1 your `stellar.toml` adheres to.  This helps parsers know which fields to expect.
 
 ### Issuer Documentation
 
@@ -149,11 +145,13 @@ Alternately, `stellar.toml` can link out to a separate TOML file for each curren
 
 ### Validator Information
 
-These fields go in the `stellar.toml` `[QUORUM_SET]` table.
+These fields go in the `stellar.toml` `[[VALIDATORS]]` list, one set of fields for each node your organization runs.  Combined with the steps outlined in [SEP-20](sep-0020.md), this section allows you to declare your node(s), and to let others know the location of any public archives you maintain.   Complete all applicable fields, and exclude any that don't apply.  
 
 Field | Requirements | Description
 ------|--------------|------------
-VALIDATORS | list of `G...` strings | List of authoritative validators for organization. This can potentially be a quorum set. Names defined in `NODE_NAMES` can be used as well, prefixed with `$`.
+NODE_PUBLIC_KEY | `G...` string | The Stellar account associated with the node
+NODE_NAME | string | A human-readable name to make your node easier to identify 
+HISTORY | URL string | The location of the history archive published by this validator
 
 ## Testing
 
@@ -186,39 +184,10 @@ AUTH_SERVER="https://api.domain.com/auth"
 TRANSFER_SERVER="https://api.domain.com"
 SIGNING_KEY="GBBHQ7H4V6RRORKYLHTCAWP6MOHNORRFJSDPXDFYDGJB2LPZUFPXUEW3"
 
-
-NODE_NAMES=[
-"GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3  lab1",
-"GB6REF5GOGGSEHZ3L2YK6K4T4KX3YDMWHDCPMV7MZJDLHBDNZXEPRBGM  donovan",
-"GBGR22MRCIVW2UZHFXMY5UIBJGPYABPQXQ5GGMNCSUM2KHE3N6CNH6G5  nelisky1",
-"GDXWQCSKVYAJSUGR2HBYVFVR7NA7YWYSYK3XYKKFO553OQGOHAUP2PX2  jianing",
-"GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U  anchor"
-]
-
 ACCOUNTS=[
-"$lab1",
-"GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
-]
-
-OUR_VALIDATORS=[
-"$nelisky1",
-"GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
-]
-
-DESIRED_BASE_FEE=100
-DESIRED_MAX_TX_PER_LEDGER=400
-
-KNOWN_PEERS=[
-"192.168.0.1",
-"core-testnet1.stellar.org",
-"core-testnet2.stellar.org:11290",
-"2001:0db8:0100:f101:0210:a4ff:fee3:9566"
-]
-
-HISTORY=[
-"http://history.stellar.org/prd/core-live/core_live_001/",
-"http://history.stellar.org/prd/core-live/core_live_002/",
-"http://history.stellar.org/prd/core-live/core_live_003/"
+"GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3",
+"GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7",
+"GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
 ]
 
 [DOCUMENTATION]
@@ -271,12 +240,20 @@ conditions="There will only ever be 10,000 GOAT tokens in existence. We will dis
 image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
 fixed_number=10000
 
-#   Potential quorum set of this domain's validators.
-[QUORUM_SET]
-VALIDATORS=[
-"$self", "$lab1", "$nelisky1","$jianing",
-"$eno","$donovan"
-]
+[[VALIDATORS]]
+NODE_PUBLIC_KEY="GD5DJQDDBKGAYNEAXU562HYGOOSYAEOO6AS53PZXBOZGCP5M2OPGMZV3"
+NODE_NAME="Domain 1"
+HISTORY="http://history.domain.com/prd/core-live/core_live_001/"
+
+[[VALIDATORS]]
+NODE_PUBLIC_KEY="GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7"
+NODE_NAME="Domain 2"
+HISTORY="http://history.domain.com/prd/core-live/core_live_002/"
+
+[[VALIDATORS]]
+NODE_PUBLIC_KEY="GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
+NODE_NAME="Domain 3"
+HISTORY="http://history.domain.com/prd/core-live/core_live_003/"
 
 # optional extra information for humans
 # Useful place for anchors to detail various policies and required info


### PR DESCRIPTION
This proposal streamlines the stellar.toml specification in the wake of SEP20, essentially implementing a suggestion @MonsieurNicolas made in the discussion of that SEP.

Rather than expressing attributes of validators independently in the Account Information global fields, organizations would create a list of validators (really an array of tables) similar to the Currency Documentation section.

Each validator an organization runs would get its own entry, and relevant info would be presented per validator.  This change will make it easier to add new properties to validators (if we want to), and to write tools like automated configuration generation.

This proposal also gets rid of fields that no longer match stellar core configurations (such as DESIRED_BASE_FEE and DESIRED_MAX_TX_PER_LEDGER), as well as quorum information that is more reliably discovered via SCP or via a quorum explorer like stellarbeat.  There’s a tendency for that info to be out of date since organizations often update their configuration without amending their stellar.toml.

Since this is a breaking change, this proposal also adds version information as a global field to help crawlers know what fields to expect in a stellar.toml.

If adopted, this proposal would also require amending SEP20, which currently assumes nodes are declared in the Account Information global fields.

Specifically, we’d remove the following:
NODE_NAMES
OUR_VALIDATORS
ASSET_VALIDATOR
DESIRED_BASE_FEE
DESIRED_MAX_TX_PER_LEDGER
KNOWN_PEERS
HISTORY
[QUORUM_SET]

And add:
VERSION
[[VALIDATORS]]
NODE_PUBLIC_KEY
NODE_NAME
HISTORY

In addition this PR fixes https://github.com/stellar/stellar-protocol/issues/307.