### PR TITLE
Update SEP-6 to clarify the trust line creation flow on /deposit

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -149,7 +149,7 @@ The deposit flow can only be fulfilled if the Stellar `Account` has established 
 2. If `Account` doesn't have enough funds, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough funds for a trust line.
 3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Issuer` then starts listening for trust line creations for that `Account`.
 4. `Wallet` detects the arrival of funds in the `Account`, and establishes a trust line.
-5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` either approves the new trust line, or returns any of the `customer_info_needed` responses until KYC conditions are met.
+5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
 6. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -147,7 +147,7 @@ The deposit flow can only be fulfilled if the Stellar `Account` has established 
 
 1. `Wallet` checks if `Account` has enough funds to create a trust line. If it does, skip to step `4`.
 2. If `Account` doesn't have enough funds, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough funds for a trust line.
-3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Issuer` then starts listening for trust line creations for that `Account`.
+3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `Account`.
 4. `Wallet` detects the arrival of funds in the `Account`, and establishes a trust line.
 5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
 6. `Anchor` proceeds with the deposit flow.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active
 Created: 2017-10-30
-Updated: 2019-01-08
-Version 2.4.0
+Updated: 2019-05-27
+Version 2.5.0
 ```
 
 ## Simple Summary
@@ -55,6 +55,9 @@ Access-Control-Allow-Origin: *
 A deposit is when a user sends an external token (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by an anchor. In turn, the anchor sends an equal amount of tokens on the Stellar network (minus fees) to the user's Stellar account.
 
 The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to deposit.
+
+If the given account does not exist, or if the account doesn't have a trust line for that specific asset, see the [Special Cases](#special-cases) section below.
+
 
 ### Request
 
@@ -129,6 +132,8 @@ Examples:
 }
 ```
 
+##### Special Cases
+###### Stellar account does not exist
 
 If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use `create_account` to create the account with at least enough XLM for the minimum reserve and a trust line (2.01 XLM is recommended). The anchor should take some of the asset that is sent in to pay for the XLM. The anchor should not list this minimal funding as a fee because the user still receives the value of the XLM in their account. The anchor should detect if the account has been created before returning deposit information, and adjust the `min_amount` in the response to be at least the amount needed to create the account.
 
@@ -136,7 +141,16 @@ Since the anchor doesn't have the user account's secret key, the user must creat
 
 If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
-In the case where the account has already been created, the wallet or client should ensure that the user has already trusted the asset before initiating the deposit flow.
+###### Stellar account doesn't trust asset
+
+The deposit flow can only be fulfilled if the Stellar `Account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `Account` has a trust line for the given asset. If it doesn't:
+
+1. `Wallet` checks if `Account` has enough funds to create a trust line. If it does, skip to step `4`.
+2. If `Account` doesn't have enough funds, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough funds for a trust line.
+3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Issuer` then starts listening for trust line creations for that `Account`.
+4. `Wallet` detects the arrival of funds in the `Account`, and establishes a trust line.
+5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` either approves the new trust line, or returns any of the `customer_info_needed` responses until KYC conditions are met.
+6. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw
 


### PR DESCRIPTION
This PR fixes #309. 

The goal is to detail the steps that should be taken during the deposit flow, when the given Stellar account doesn't have a trust line for the asset that is being deposited.