### PR TITLE
SEP-6: allow anchors to indicate auth required

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -398,7 +398,7 @@ The response should be a JSON object like:
     },
     "ETH": {
       "enabled": true,
-      "authorization_required": false,
+      "authentication_required": false,
       "fee_fixed": 0.002,
       "fee_percent": 0
     }
@@ -439,7 +439,8 @@ The response should be a JSON object like:
     "authentication_required": true
   },
   "transaction": {
-    "enabled": false
+    "enabled": false,
+    "authentication_required": true
   }
 }
 ```
@@ -476,11 +477,10 @@ The `fields` object contains a key for each field name and an object with the fo
 
 The wallet should display a form to the user to fill out any fields with unknown values as part of the deposit/withdrawal flow. Each field should be an text `input`, unless `choices` is specified, in which case a dropdown should be used.
 
-An anchor should also indicate in the `/info` response if they support the following optional endpoints and if they require authentication:
+An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 
-* `transactions`
-* `transaction`
-* `fee`
+* `enabled`: `true` if the endpoint is available.
+*  `authentication_required`:`true` if client must be [authenticated](#authentication) before accessing the endpoint.
 
 ## Fee
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active
 Created: 2017-10-30
-Updated: 2019-05-27
-Version 2.5.0
+Updated: 2019-06-04
+Version 2.6.0
 ```
 
 ## Simple Summary
@@ -44,7 +44,12 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Authentication
 
-As stated, Anchors may support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups. In cases where authentication is required, clients should submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints. The JWT should be included in all requests as request header:
+As stated, Anchors may support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups. In cases where authentication is required:
+
+1. anchors must set the `authentication_required` field in their [info endpoint](#info)
+1. clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints.
+
+The JWT should be included in all requests as request header:
 ```
 Authorization: Bearer <JWT>
 ```
@@ -96,9 +101,9 @@ GET https://api.example.com/deposit?asset_code=ETH&account=GACW7NONV43MZIFHCOKCQ
 
 ### Response
 
-There are five possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
+There are several possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
 
-The first response, the success response, is explained below. The other four possible responses are shared with the withdrawal endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section below.
+The first response, the success response, is explained below. The other possible responses are shared with the withdrawal endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section below.
 
 #### 1. Success: no additional information needed
 
@@ -207,9 +212,9 @@ GET https://api.example.com/withdraw?asset_code=ETH&dest=0xde0B295669a9FD93d5F28
 
 ### Response
 
-There are five possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
+There are several possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
 
-The first response, the success response, is explained below. The other four possible responses are shared with the deposit endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section directly below.
+The first response, the success response, is explained below. The other possible responses are shared with the deposit endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section directly below.
 
 #### 1. Success: no additional information needed
 
@@ -324,7 +329,19 @@ Example:
 }
 ```
 
-### 5. Error
+### 5. Authentication required
+
+Response code: `403 Forbidden`
+
+This endpoint requires [authentication](#authentication).
+
+```json
+{
+  "type": "authentication_required"
+}
+```
+
+### 6. Error
 
 Every other HTTP status code will be considered an error. The body should contain error details.
 For example:
@@ -360,6 +377,7 @@ The response should be a JSON object like:
   "deposit": {
     "USD": {
       "enabled": true,
+      "authentication_required": true,
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
@@ -380,6 +398,7 @@ The response should be a JSON object like:
     },
     "ETH": {
       "enabled": true,
+      "authorization_required": false,
       "fee_fixed": 0.002,
       "fee_percent": 0
     }
@@ -387,6 +406,7 @@ The response should be a JSON object like:
   "withdraw": {
     "USD": {
       "enabled": true,
+      "authentication_required": true,
       "fee_fixed": 5,
       "fee_percent": 0,
       "min_amount": 0.1,
@@ -415,7 +435,8 @@ The response should be a JSON object like:
     "enabled": false
   },
   "transactions": {
-    "enabled": true
+    "enabled": true, 
+    "authentication_required": true
   },
   "transaction": {
     "enabled": false
@@ -425,20 +446,20 @@ The response should be a JSON object like:
 
 The JSON object contains an entry for each asset that the anchor supports for SEP6 deposit and/or withdrawal.
 
-For each deposit asset, it contains:
+#### For each deposit asset, response contains:
 
-* `enabled`: set if SEP-6 deposit for this asset is supported
-* The fee structure
+* `enabled`: `true` if SEP-6 deposit for this asset is supported
+* `authentication_required`: Optional. `true` if client must be [authenticated](#authentication) before accessing the deposit endpoint for this asset. `false` if not specified.
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
 * `fields` object as explained below.
 
-For each withdrawal asset, it contains:
+#### For each withdrawal asset, response contains:
 
-* `enabled`: set if SEP-6 withdrawal for this asset is supported
-* The fee structure
+* `enabled`: `true` if SEP-6 withdrawal for this asset is supported
+* `authentication_required`: Optional. `true` if client must be [authenticated](#authentication) before accessing the deposit endpoint for this asset. `false` if not specified.
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for withdraw. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
@@ -455,7 +476,7 @@ The `fields` object contains a key for each field name and an object with the fo
 
 The wallet should display a form to the user to fill out any fields with unknown values as part of the deposit/withdrawal flow. Each field should be an text `input`, unless `choices` is specified, in which case a dropdown should be used.
 
-An anchor should also indicate in the `/info` response if they support the following optional endpoints:
+An anchor should also indicate in the `/info` response if they support the following optional endpoints and if they require authentication:
 
 * `transactions`
 * `transaction`

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -480,7 +480,7 @@ The wallet should display a form to the user to fill out any fields with unknown
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 
 * `enabled`: `true` if the endpoint is available.
-*  `authentication_required`:`true` if client must be [authenticated](#authentication) before accessing the endpoint.
+* `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the endpoint.
 
 ## Fee
 


### PR DESCRIPTION
Provide a mechanism in  SEP-6 that anchors can use to indicate that their deposit, withdrawal, and transaction endpoints require [SEP-10](sep-0010.md) authentication.