### PR TITLE
Clarify choice of passphrase in SEP-10

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,13 +6,13 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Active
 Created: 2018-07-31
-Updated: 2018-08-14
-Version 1.0.1
+Updated: 2019-07-09
+Version 1.1.0
 ```
 
 ## Simple Summary
 
-This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-6](sep-0006.md).
+This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md).
 
 ## Abstract
 
@@ -65,20 +65,23 @@ GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDI
 
 #### Response
 
-On success the endpoint should return `200 OK` HTTP status code and a JSON object with a `transaction` field containing an XDR-encoded Stellar transaction with the following:
+On success the endpoint must return `200 OK` HTTP status code and a JSON object with these fields:
 
-* source account set to server's signing account
-* invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
-* time bounds: `{min: now(), max: now() + 300 }` (we recommend expiration of 5 minutes to give user time to sign transaction)
-* operations: `manage_data(source: client_account, key: '<anchor name> auth', value: random_nonce())`
-  * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
-  * The value must be a 64 byte long base64 encoded cryptographic-quality random string
-* signature by the web service signing account
+* `transaction`: an XDR-encoded Stellar transaction with the following:
+  * source account set to server's signing account
+  * invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
+  * time bounds: `{min: now(), max: now() + 300 }` (we recommend expiration of 5 minutes to give user time to sign transaction)
+  * operations: `manage_data(source: client_account, key: '<anchor name> auth', value: random_nonce())`
+    * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
+    * The value must be a 64 byte long base64 encoded cryptographic-quality random string
+  * signature by the web service signing account
+* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing.
 
 Example:
 ```json
 {
-  "transaction": "AAAAAGjeCRajN67nRkVtYO+lpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ+dp4m4QfWntHbOq0hxRCLGI+2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL/Ha0YGVrAF6t0UEKP/0Q/NDUymciQBA/CXzYMVlEx2KcHrq3MkpQ9+9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAABL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D/zpd6TNPvcMgUsQd6cDHzjNk+/00P8M5bHP4rIpFTm7MwN"
+  "transaction": "AAAAAGjeCRajN67nRkVtYO+lpxax9gvitX9FxhZYGXQvs16hAAAAZAAAAAAAAAAAAAAAAQAAAABbcutKAAAAAFty7HYAAAAAAAAAAQAAAAEAAAAAVIx5odtAgqQ+dp4m4QfWntHbOq0hxRCLGI+2Sm0P6EMAAAAKAAAAC01vYml1cyBhdXRoAAAAAAEAAABAG01TL/Ha0YGVrAF6t0UEKP/0Q/NDUymciQBA/CXzYMVlEx2KcHrq3MkpQ9+9sCbCiOYa7wCtusa1tHKygvZRSwAAAAAAAAABL7NeoQAAAEC9v5jdxReIxoCcCXw90dVsIpXwHXkSHUUthCs98D/zpd6TNPvcMgUsQd6cDHzjNk+/00P8M5bHP4rIpFTm7MwN",
+  "network_passphrase": "Public Global Stellar Network ; September 2015"
 }
 ```
 
@@ -167,6 +170,17 @@ Every other HTTP status code will be considered an error. For example:
    "error": "The provided transaction is not valid"
 }
 ```
+
+## A convention for signatures
+
+Signatures in Stellar involve both the secret key of the signer and the passphrase of the network. SEP-10 clients and servers must use the following convention when deciding what network passphrase to use for signing and verifying signatures in SEP-10:
+
+- If the server is for testing purposes or interacts with the Stellar testnet, use the Stellar testnet passphrase.
+- Otherwise, use the Stellar pubnet passphrase.
+
+This convention ensures that SEP-10 clients and servers can use the same passphrase as they're using for interacting with the Stellar network. 
+
+The client can examine the `network_passphrase` (if defined) that the server includes in its response from the challenge endpoint to be sure it's using the correct passphrase and is connecting to the server that it expected.
 
 ## Implementations
 


### PR DESCRIPTION
* Clarify choice of passphrase for signatures in SEP-10
* Also add an optional response parameter to the challenge endpoint: `network_passphrase` to make debugging signature issues easier.
* Replace outdated reference to SEP-6 with reference to SEP-12

Addresses problem mentioned in https://github.com/stellar/go/pull/1468
Closes #339 

@nebolsin I'd love your feedback.