### PR TITLE
SEP6: make withdraw type optional

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -252,8 +252,8 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
-`type` | string | (optional) Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
-`dest` | string | (optional) The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.  This may be optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
+`type` | string | (optional if interactive) Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values. Optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
+`dest` | string | (optional if interactive) The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address. Optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -251,8 +251,8 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
+`type` | string | (optional) Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values
 `dest` | string | (optional) The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.  This may be optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.


### PR DESCRIPTION
Interactive withdraws can facilitate multiple types so no need for the wallet to know in advance.