### PR TITLE
Allow 404 /transaction responses

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -111,7 +111,9 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
     * We recommend you use the [interactive flow](#3-customer-information-needed-interactive). It's flexible and simple to integrate.
     * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
+    * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction  when the user visits the URL.
     * We recommend you use [SEP-10 authentication](#authentication) in the interactive flow and do not separately prompt for password to achieve a good user experience (although asking for MFA when confirming a transaction or requiring email confirmation is reasonable). Be sure to accept the [`jwt` parameter](#adding-parameters-to-the-url) so the user does not have to re-login. Support the `callback` parameter as well.
+    * Test your interactive flows on mobile. They should be easy to use on all devices: make them responsive, handle auto-fill well, and do smart keyboard management on mobile devices.
 * **Interactive deposit**
     * Your interactive deposit popup will do everything needed to initiate the deposit without the user needing to interact with the wallet further. It should either directly initiate the deposit, or handle displaying information (such as reference number or bank account number) that the user will need to complete their deposit.
 * **Interactive withdrawal**
@@ -385,11 +387,14 @@ If the anchor's deposit or withdrawal endpoints require [SEP-10](sep-0010.md) au
 
 In the case of an interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
-To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `interactive_customer_info_needed` response from the anchor until the necessary information is available, or register a callback with the anchor as described above. Either way, the anchor's response will contain the transaction fields described in the [/transactions](#transaction-history) endpoint.
+To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `interactive_customer_info_needed` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
+
+In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
+
+When a successful response comes back (either from polling or via callback), the response will contain the transaction fields described in the [/transactions](#transaction-history) endpoint.
 
 The wallet must use the response fields in the following way to complete the withdrawal:
 
-- `status`: `incomplete` means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet in this case. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
 - `status`: `pending_user_transfer_start` means the user has given all necessary info to the anchor. The next step is for the wallet to confirm the withdrawal with the user, and then send a Stellar payment to the anchor's address.
 
 When the wallet receives the `pending_user_transfer_start` status, it must use these fields from the response in the following ways:
@@ -705,7 +710,7 @@ Name | Type | Description
 * `pending_trust` -- the user must add a trust-line for the asset for the deposit to complete
 * `pending_user` -- the user must take additional action before the deposit / withdrawal can complete
 * `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
-* `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered the amount they want to transfer in an interactive flow.
+* `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
 * `no_market` -- could not complete deposit because no satisfactory asset/XLM market was available to create the account
 * `too_small` -- deposit/withdrawal size less than `min_amount`
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -395,16 +395,13 @@ When a successful response comes back (either from polling or via callback), the
 
 The wallet must use the response fields in the following way to complete the withdrawal:
 
-- `status`: `pending_user_transfer_start` means the user has given all necessary info to the anchor. The next step is for the wallet to confirm the withdrawal with the user, and then send a Stellar payment to the anchor's address.
-
-When the wallet receives the `pending_user_transfer_start` status, it must use these fields from the response in the following ways:
-
-- `withdraw_anchor_account`: send the withdrawal payment to this Stellar account
+- `status`: `pending_user_transfer_start` means the user has given all necessary info to the anchor, and the ball is back in  the wallet's court.
+- `withdraw_anchor_account`: send the withdrawal payment to this Stellar account 
 - `withdraw_memo`: (if specified) use this memo in the payment transaction to the anchor
 - `withdraw_memo_type`: use this as the memo type
 
-It should also use the following fields to show the user a summary of their withdrawal request when requesting final confirmation from the user:
-
+ The next step is for the wallet to display a confirmation screen summarizing the withdrawal the the user, and then send a Stellar payment to `withdraw_anchor_account`. The wallet should show the following info to the user:
+ 
 - `to`: show the user what external account they will be withdrawing to
 - `external_extra_text`: show the bank name or store name that the user will be withdrawing their funds to
 - `more_info_url`: tell the user they can visit this URL for more info about their transaction as it processes


### PR DESCRIPTION
Make the interactive flow easier to implement for anchors by allowing 404 responses for incomplete transactions. This means the anchor will not need to create a transaction entry in its database as soon as `/deposit` is hit. Instead, it can wait for successful completion of the interactive flow, and the wallet will handle that correctly.

Also add a note for anchors to test their interactive forms on mobile.