### PR TITLE
Suggesting certain image types to include in toml file

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -66,7 +66,7 @@ Field | Requirements | Description
 ORG_NAME | string | Legal name of your organization
 ORG_DBA | string | (may not apply) [DBA](https://www.entrepreneur.com/encyclopedia/doing-business-as-dba) of your organization
 ORG_URL | uses `https://` | Your organization's official URL. Your `stellar.toml` must be hosted on the same domain.
-ORG_LOGO | url | Your organization's logo
+ORG_LOGO | url | A PNG image of your organization's logo on a transparent background
 ORG_DESCRIPTION | string | Short description of your organization
 ORG_PHYSICAL_ADDRESS | string | Physical address for your organization
 ORG_PHYSICAL_ADDRESS_ATTESTATION | `https://` url | URL on the same domain as your `ORG_URL` that contains an image or pdf official document attesting to your physical address. It must list your `ORG_NAME` or `ORG_DBA` as the party at the address. Only documents from an official third party are acceptable. E.g. a utility bill, mail from a financial institution, or business license.
@@ -117,7 +117,7 @@ display_decimals | int (0 to 7) | Preference for number of decimals to show when
 name | string (<= 20 char) | A short name for the token
 desc | string | Description of token and what it represents
 conditions | string | Conditions on token
-image | url | URL to image representing token
+image | url | URL to a PNG image on a transparent background representing token
 fixed_number | int | Fixed number of tokens, if the number of tokens issued will never change
 max_number | int | Max number of tokens, if there will never be more than `max_number` tokens
 is_unlimited | boolean | The number of tokens is dilutable at the issuer's discretion
@@ -207,7 +207,7 @@ VERSION="2.0.0"
 ORG_NAME="Organization Name"
 ORG_DBA="Organization DBA"
 ORG_URL="https://www.domain.com"
-ORG_LOGO="https://www.domain.com/awesomelogo.jpg"
+ORG_LOGO="https://www.domain.com/awesomelogo.png"
 ORG_DESCRIPTION="Description of issuer"
 ORG_PHYSICAL_ADDRESS="123 Sesame Street, New York, NY 12345, United States"
 ORG_PHYSICAL_ADDRESS_ATTESTATION="https://www.domain.com/address_attestation.jpg"
@@ -250,7 +250,7 @@ display_decimals=2
 name="goat share"
 desc="1 GOAT token entitles you to a share of revenue from Elkins Goat Farm."
 conditions="There will only ever be 10,000 GOAT tokens in existence. We will distribute the revenue share annually on Jan. 15th"
-image="https://pbs.twimg.com/profile_images/666921221410439168/iriHah4f.jpg"
+image="https://static.thenounproject.com/png/2292360-200.png"
 fixed_number=10000
 
 [[VALIDATORS]]


### PR DESCRIPTION
Updating SEP to be in line with https://github.com/stellar/docs/pull/492 as suggested by @theaeolianmachine 

The goal is to avoid the use of JPEGs for logos in toml files by suggesting the use of certain file formats and transparent backgrounds. Mostly to make developers and especially designers lives easier when pulling images from toml files.
