### PR TITLE
Require cross-origin on sep10

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -43,7 +43,7 @@ A web service indicates that it supports user authentication via this protocol b
 
 ## Cross-Origin Headers
 
-Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.
+Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all authentication endpoints, including error responses.
 
 ```
 Access-Control-Allow-Origin: *

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -41,6 +41,14 @@ A web service indicates that it supports user authentication via this protocol b
 * [`GET <WEB_AUTH_ENDPOINT>`](#challenge): request a challenge (step 1)
 * [`POST <WEB_AUTH_ENDPOINT>`](#token): exchange a signed challenge for session JWT (step 2)
 
+## Cross-Origin Headers
+
+Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.
+
+```
+Access-Control-Allow-Origin: *
+```
+
 ### Challenge
 
 This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).


### PR DESCRIPTION
Match the wording from Sep6 to require cross-origin headers to allow browsers to interact with the protocol