### PR TITLE
Add additional check to sep10

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -120,6 +120,7 @@ To validate the challenge transaction the following steps are performed by the s
 * verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and it's source account is not null;
 * verify that transaction envelope has a correct signature by server's signing key;
 * verify that transaction envelope has a correct signature by the operation's source account;
+* verify that transaction sequenceNumber is equal to zero;
 * use operations's source account to determine the authenticating client and perform any additional service-specific validations.
 
 Upon successful validation service responds with a session JWT, containing the following claims:


### PR DESCRIPTION
The verification of the challenge transaction is missing the check for sequence number zero.  The Utils function verifyChallengeTx mentions this in its comment, and verifies the seq number.