### PR TITLE
SEP10 Add client step to verify sequence number 0

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -21,6 +21,7 @@ This protocol is a variation of mutual challenge-response, which uses Stellar tr
 The authentication flow is as follows:
 
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
+1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
 1. The client signs the transaction using the secret key for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. If the signature checks out, the server responds with a [JWT](jwt.io) that represents the user's session


### PR DESCRIPTION
It is extremely important that the client in SEP10 verifies the transaction has a sequence number 0 so they don't accidentally sign a malicious transaction that can be sent to the blockchain.