### PR TITLE
Simplify sep6 authentication

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -49,12 +49,7 @@ As stated, Anchors may support [SEP-10](sep-0010.md) web authentication to enabl
 1. anchors must set the `authentication_required` field in their [info endpoint](#info)
 1. clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints.
 
-The JWT should be included in all requests as request header:
-```
-Authorization: Bearer <JWT>
-```
-
-Alternatively, if the client cannot add the authorization header. The JWT should be passed as a jwt query parameter:
+The JWT should be passed as a jwt query parameter:
 ```
 ?jwt=<token>
 ```


### PR DESCRIPTION
Currently there's two ways to send the JWT token to SEP6 endpoints, headers or query params. I propose that we simplify this to always use queryParams, since every client can send them this way.  My worry is that a server might develop using one or the other authentication strategies and forget to do the other one, keeping only one way will help ensure better support through the ecosystem.

@tomquisel @tomerweller 