### PR TITLE
[SEP6] Clarify jwt usage

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -54,7 +54,7 @@ The JWT should be included in all requests as request header:
 Authorization: Bearer <JWT>
 ```
 
-Alternatively, if the client cannot add the authorization header. The JWT should be passed as a jwt query parameter:
+In the case of the [interactive webapp](#customer-information-needed-interactive), since the client cannot add the authorization header, The JWT should be passed as a jwt query parameter:
 ```
 ?jwt=<token>
 ```


### PR DESCRIPTION
Clarify that jwt should always be in a header, and the only use case for query params should be in the case of the interactive webapp.