### PR TITLE
SEP-12 is deprecated for a SEP-6 implementation.

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -30,7 +30,6 @@ To support this protocol an anchor acts as a server and implements the specified
 ## Prerequisites
 
 * An anchor must define the location of their `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
-* Anchors may support [SEP-12](sep-0012.md) customer info transfer if they need to handle KYC-ing customers
 * Anchors and clients may support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups
 
 ## API Endpoints


### PR DESCRIPTION
* Anchors may support [SEP-12](sep-0012.md) customer info transfer if they need to handle KYC-ing customers