### PR TITLE
Add deprecated status

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -29,6 +29,7 @@
   implemented.
 * **Superseded: [New Final SEP]** - A SEP that which was previously final but has been superseded
   by a new, final SEP. Both SEPs should reference each other.
+* **Deprecated** - A SEP that was previously on an active track but has been deprecated and is no longer suggested for use. There may be legacy usage of a deprecated SEP.
 
 ## List of Proposals
 


### PR DESCRIPTION
SEP12 has been deprecated inside the spec but is currently shown as "Active" in the list.  We should make it clear that we clean out old seps.