### PR TITLE
Simplify/Clarify the SEP process

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -1,28 +1,17 @@
 # Stellar Ecosystem Proposals (SEPs)
 
-## SEP Tracks
-* **Informational** — A SEP on the `Informational` track is one that is open to adoption by the
-  ecosystem, but has not been formally standardized by SDF, and is not endorsed by SDF for
-  adoption. Typically a SEP can start as `Informational` to gain traction within the ecosystem
-  before moving to the `Standards` track.
-* **Standard** — A SEP on the `Standards` track is one that aims for formal standardization and
-  endorsement by SDF for adoption. Typically a SEP Standard has a higher bar towards acceptance,
-  and it requires approval by 2 SDF members of the SEP Team.
-
 ## SEP Status Terms
+* **Deprecated** - A SEP that was previously on an active track but has been deprecated and is no longer suggested for use. There may be legacy usage of a deprecated SEP.
 * **Draft** - A SEP that is currently open for consideration and actively being discussed.
 * **Awaiting Decision** — A mature and ready SEP that is ready for approval by the SEP
   Team. If enough the approval requirements are met by SEP team members, the SEP will move towards 
   `FCP`. Otherwise, it'll regress to a `Draft`.
 * **FCP** — A SEP that has entered a Final Comment Period (FCP). After one week has passed, during
-  which any new concerns should be addressed, the SEP's status will become `Active` or `Final`,
-  depending on the content of the SEP.
+  which any new concerns should be addressed, the SEP's status will become `Active`.
 * **Active** - An actively maintained SEP that is intended for immediate adoption by the entire
-  ecosystem by its author(s), and if it is a Standard, by SDF as well. Additional updates may be
-  made without changing the SEP number.
-* **Final** - A finalized SEP that is intended for immediate adoption by the entire
-  ecosystem by its author(s), and if it is a Standard, by SDF as well. A final SEP should only be
-  updated to correct errata.
+  ecosystem. Additional updates may be made without changing the SEP number.
+* **Final** - A finalized SEP that is being used in live products and will not be changed aside from
+  minor errata.
 
 ### Additional Statuses
 * **Rejected** - A Standards SEP that has been formally rejected by the SEP Team, and will not be
@@ -32,35 +21,35 @@
 
 ## List of Proposals
 
-| Number | Title | Author | Track | Status |
-| --- | --- | --- | --- | --- |
-| [SEP-0001](sep-0001.md) | stellar.toml specification | SDF | Standard | Active |
-| [SEP-0002](sep-0002.md) | Federation Protocol | SDF | Standard | Final |
-| [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Active |
-| [SEP-0004](sep-0004.md) | Tx Status Endpoint | SDF | Standard | Final |
-| [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts | SDF | Standard | Final |
-| [SEP-0006](sep-0006.md) | Anchor/Client Interoperability | SDF | Standard | Active |
-| [SEP-0007](sep-0007.md) | URI Scheme to facilitate delegated signing | Interstellar | Standard | Final |
-| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Standard | Final |
-| [SEP-0009](sep-0009.md) | Standard KYC / AML Fields | SDF | Standard | Active |
-| [SEP-0010](sep-0010.md) | Stellar Web Authentication | Sergey Nebolsin, Tom Quisel | Standard | Active |
-| [SEP-0011](sep-0011.md) | Txrep: Human-Readable Low-Level Representation of Stellar Transactions | David Mazières | Standard | Active |
-| [SEP-0012](sep-0012.md) | Anchor/Client Customer Info Transfer | Interstellar | Standard | Active |
-| [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Active |
+| Number | Title | Author | Status |
+| --- | --- | --- | --- |
+| [SEP-0001](sep-0001.md) | stellar.toml specification | SDF | Active |
+| [SEP-0002](sep-0002.md) | Federation Protocol | SDF | Final |
+| [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Active |
+| [SEP-0004](sep-0004.md) | Tx Status Endpoint | SDF | Final |
+| [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts | SDF | Final |
+| [SEP-0006](sep-0006.md) | Anchor/Client Interoperability | SDF | Active |
+| [SEP-0007](sep-0007.md) | URI Scheme to facilitate delegated signing | Interstellar | Final |
+| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Final |
+| [SEP-0009](sep-0009.md) | Standard KYC / AML Fields | SDF | Active |
+| [SEP-0010](sep-0010.md) | Stellar Web Authentication | Sergey Nebolsin, Tom Quisel | Active |
+| [SEP-0011](sep-0011.md) | Txrep: Human-Readable Low-Level Representation of Stellar Transactions | David Mazières | Active |
+| [SEP-0012](sep-0012.md) | Anchor/Client Customer Info Transfer | Interstellar | Active |
+| [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Active |
 
 ### Draft Proposals
 
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
-| [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Draft |
-| [SEP-0014](sep-0014.md) | Dynamic Asset Metadata | OrbitLens, Paul Tiplady | Standard | Draft |
-| [SEP-0015](sep-0015.md) | Attachment Convention | Interstellar | Standard | Draft |
-| [SEP-0016](sep-0016.md) | Account Transfer Permissionless Payment Protocol (@p2p) | Jeremy Rubin | Standard | Draft |
-| [SEP-0017](sep-0017.md) | Issuer account funding protocol (CAP-13 Based) | Tom Quisel | Standard | Draft |
-| [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Draft |
-| [SEP-0019](sep-0019.md) | Bootstrapping Multisig Transaction Submission | Paul Selden, Nikhil Saraf | Standard | Draft |
-| [SEP-0021](sep-0021.md) | On-chain signature & transaction sharing | Mister.Ticot | Informational | Draft |
-| [SEP-0022](sep-0022.md) | IPFS Support | Samuel B. Sendelbach | Informational | Draft |
+| [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Draft |
+| [SEP-0014](sep-0014.md) | Dynamic Asset Metadata | OrbitLens, Paul Tiplady | Draft |
+| [SEP-0015](sep-0015.md) | Attachment Convention | Interstellar | Draft |
+| [SEP-0016](sep-0016.md) | Account Transfer Permissionless Payment Protocol (@p2p) | Jeremy Rubin | Draft |
+| [SEP-0017](sep-0017.md) | Issuer account funding protocol (CAP-13 Based) | Tom Quisel | Draft |
+| [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Draft |
+| [SEP-0019](sep-0019.md) | Bootstrapping Multisig Transaction Submission | Paul Selden, Nikhil Saraf | Draft |
+| [SEP-0021](sep-0021.md) | On-chain signature & transaction sharing | Mister.Ticot | Draft |
+| [SEP-0022](sep-0022.md) | IPFS Support | Samuel B. Sendelbach | Draft |
 
 # Contribution Process
 
@@ -74,9 +63,6 @@ its process is inspired by the [IETF][ietf].
 
 Before contributing, consider the following:
 
-- Choose a track to propose your idea on. The bar for accepting an `Informational` SEP is much
-  lower than one for a `Standard`, and allows you to promote the SEP independently to gain feedback
-  and traction before creating a Standard out of it.
 - Gather feedback from discussion on the dev mailing list and other forums, and utilize it to begin
   a draft proposal.
 - Follow the proposal process listed below. If you're having difficulty moving the proposal
@@ -141,15 +127,25 @@ From there, the following process will happen:
 * Once a SEP has been approved, it goes into FCP which is broadcast to the protocol meeting members
   along with the mailing list.
 
-### FCP -> Active/Final
-* If no major concerns are brought up, the SEP is marked as `Active` or `Final` by your SEP buddy:
-  * If the SEP requires active maintenance, such as having an open schema, it should be marked at
-    `Active`.
-  * Otherwise, the SEP should be marked as `Final`.
+### FCP -> Active
+* If no major concerns are brought up, the SEP is marked as `Active` by your SEP buddy.
+* Ideally there will be a reference implementation exhibiting the behavior and value of the SEP before moving to active state.
+* Active SEPs should be brought into production by ecosystem members.
+* Minor changes may be made as more implementations are brought online highlighting any edge cases.
+
+
+### Active -> Final
+* Once there are live implementations being used in production, the SEP team can move the SEP to `Final` status.
+* No changes will be made to a finalized SEP aside from fixing minor errata.
+* Much consideration should be given before moving to Final status, it is OK for SEPs to live in Active status for a long time.
+
+### Regression
+* It is possible for a SEP to move from `Active` to `Draft` or `Deprecated` if it is never adopted, or is abandoned by the community.
+* Regression of an active SEP occurs via the same process as a proposal (`Draft` -> `Awaiting Decision` -> `FCP` -> `Deprecated`)
 
 ## SEP Team Members
 
-**SEP Team**: Tomer (SDF), Nikhil (SDF) Tom Q. (SDF), Johnny (SDF), orbitlens, David (SDF), Jed
+**SEP Team**: Tomer (SDF), Nikhil (SDF) Tom Q. (SDF), Michael (SDF), orbitlens, David (SDF), Jed
 (SDF)
 
 [ietf]: https://ietf.org/


### PR DESCRIPTION
- Remove the Information vs Standard track distinction.  It seems confusing and I'm not sure what the value prop of having the complexity is.
- Create a `Deprecated` status, and explain how a SEP would get put into such status.
- Modify the `Final` status to be one in which there are live implementations being used.  Previously, `Final` and `Active` were too similar, and often misused.  Requiring a Final sep to have multiple implementations will give us much more confidence to mark something as final since we probably got most of the edge cases handled.
- Replace Johnny with Michael as a SEP team member