### PR TITLE
Add Deprecated status to SEP Process

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -10,6 +10,7 @@
   and it requires approval by 2 SDF members of the SEP Team.
 
 ## SEP Status Terms
+* **Deprecated** - A SEP that was previously on an active track but has been deprecated and is no longer suggested for use. There may be legacy usage of a deprecated SEP.
 * **Draft** - A SEP that is currently open for consideration and actively being discussed.
 * **Awaiting Decision** — A mature and ready SEP that is ready for approval by the SEP
   Team. If enough the approval requirements are met by SEP team members, the SEP will move towards 
@@ -146,6 +147,10 @@ From there, the following process will happen:
   * If the SEP requires active maintenance, such as having an open schema, it should be marked at
     `Active`.
   * Otherwise, the SEP should be marked as `Final`.
+  
+### Regression
+* It is possible for a SEP to move from `Active` to `Draft` or `Deprecated` if it is never adopted, or is abandoned by the community.
+* Regression of an active SEP occurs via the same process as a proposal (`Draft` -> `Awaiting Decision` -> `FCP` -> `Deprecated`)
 
 ## SEP Team Members
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -10,7 +10,6 @@
   and it requires approval by 2 SDF members of the SEP Team.
 
 ## SEP Status Terms
-* **Deprecated** - A SEP that was previously on an active track but has been deprecated and is no longer suggested for use. There may be legacy usage of a deprecated SEP.
 * **Draft** - A SEP that is currently open for consideration and actively being discussed.
 * **Awaiting Decision** — A mature and ready SEP that is ready for approval by the SEP
   Team. If enough the approval requirements are met by SEP team members, the SEP will move towards 
@@ -26,6 +25,7 @@
   updated to correct errata.
 
 ### Additional Statuses
+* **Deprecated** - A SEP that was previously on an active track but has been deprecated and is no longer suggested for use. There may be legacy usage of a deprecated SEP.
 * **Rejected** - A Standards SEP that has been formally rejected by the SEP Team, and will not be
   implemented.
 * **Superseded: [New Final SEP]** - A SEP that which was previously final but has been superseded


### PR DESCRIPTION
Create a deprecated status and explain how to move a SEP into it.  Its important that we remove any cruft from our SEPs to ensure people have a clear understanding of the state of the ecosystem, and to prevent people from implementing SEPs that won't be compatible with anyone else.