### PR TITLE
[SEP1] Standardize max filesize

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -38,6 +38,8 @@ It is also recommended to set a `text/plain` content type so that browsers rende
 content-type: text/plain
 ```
 
+`stellar.toml` can have a maximum file size of 100kB.
+
 `stellar.toml` is in [TOML](https://github.com/toml-lang/toml) file format. The `stellar.toml` fields and sections are described below. You should complete as much of this as you can. Many Stellar apps, including important wallets and exchanges, make decisions on which tokens to support based on the completeness of their Account Information and Documentation sections.
 
 ### Account Information

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -38,7 +38,7 @@ It is also recommended to set a `text/plain` content type so that browsers rende
 content-type: text/plain
 ```
 
-`stellar.toml` can have a maximum file size of 100kB.
+`stellar.toml` can have a maximum file size of 100KB.
 
 `stellar.toml` is in [TOML](https://github.com/toml-lang/toml) file format. The `stellar.toml` fields and sections are described below. You should complete as much of this as you can. Many Stellar apps, including important wallets and exchanges, make decisions on which tokens to support based on the completeness of their Account Information and Documentation sections.
 


### PR DESCRIPTION
Need to standardize a max file size for stellar.toml so parsers can ensure they can handle any toml.  Context in https://github.com/stellar/stellar-protocol/issues/330