### PR TITLE
Require github handles

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -105,7 +105,7 @@ repository. You should make sure to adhere to the following:
   * For example, a SEP by Github user `happycoder` with a SHA-256 checksum of `a200f73c`
     would be titled `sep_happycoder_b274f73c.md`.
 * Make sure to place your SEP in the `ecosystem/` folder.
-* Include GitHub handles or emails for all authors listed.  Github handles are preferred.
+* Include GitHub handles or emails for all authors listed.  GitHub handles are preferred.
 
 Finally, submit a PR of your draft via your fork of this repository.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -105,6 +105,7 @@ repository. You should make sure to adhere to the following:
   * For example, a SEP by Github user `happycoder` with a SHA-256 checksum of `a200f73c`
     would be titled `sep_happycoder_b274f73c.md`.
 * Make sure to place your SEP in the `ecosystem/` folder.
+* Include Github handles or emails for all authors listed.  Github handles are preferred.
 
 Finally, submit a PR of your draft via your fork of this repository.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -105,7 +105,7 @@ repository. You should make sure to adhere to the following:
   * For example, a SEP by Github user `happycoder` with a SHA-256 checksum of `a200f73c`
     would be titled `sep_happycoder_b274f73c.md`.
 * Make sure to place your SEP in the `ecosystem/` folder.
-* Include Github handles or emails for all authors listed.  Github handles are preferred.
+* Include GitHub handles or emails for all authors listed.  Github handles are preferred.
 
 Finally, submit a PR of your draft via your fork of this repository.
 

--- a/sep-template.md
+++ b/sep-template.md
@@ -3,7 +3,7 @@
 ```
 SEP: To Be Assigned
 Title: <SEP title>
-Author: <list of authors' names and optionally, email addresses, separated by commas>
+Author: <list of authors' names, Github handles, and optionally, email addresses, separated by commas>
 Track: <Informational or Standard>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>

--- a/sep-template.md
+++ b/sep-template.md
@@ -3,7 +3,7 @@
 ```
 SEP: To Be Assigned
 Title: <SEP title>
-Author: <list of authors' names, Github handles, and optionally, email addresses, separated by commas>
+Author: <list of authors' names, GitHub handles, and optionally, email addresses, separated by commas>
 Track: <Informational or Standard>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>


### PR DESCRIPTION
It is difficult to discuss proposals when there's no contact info for the authors.  Ideally we can just tag the authors using their github handle, but if for some reason they really don't want a github account we need to at least be able to email them.