### PR TITLE
SEP6 clarify error messaging

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -152,6 +152,7 @@ Name | Type | Description
 `type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
+`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 
 Example:
 
@@ -265,6 +266,7 @@ Name | Type | Description
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
+`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 
 Example:
 
@@ -477,7 +479,7 @@ This endpoint requires [authentication](#authentication).
 
 ### 6. Error
 
-Every other HTTP status code will be considered an error. The body should contain error details.
+Every other HTTP status code will be considered an error. The body should contain a string indicating the error details.  This error is in a human readable format in the language indicated in the request and is intended to be displayed by the wallet.
 For example:
 
 ```json


### PR DESCRIPTION
For /withdraw and /deposit, we need to indicate that the error message is a string to be displayed to users, and also have a language option for localization.

Fixes #402 