### PR TITLE
Update sep-0006.md

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -732,6 +732,7 @@ Name | Type | Description
 * `pending_anchor` -- deposit/withdrawal is being processed internally by anchor.
 * `pending_stellar` -- deposit/withdrawal operation has been submitted to Stellar network, but is not yet confirmed.
 * `pending_trust` -- the user must add a trust-line for the asset for the deposit to complete.
+* `pending_kyc` -- the user must complete kyc before the deposit / withdrawal can complete.
 * `pending_user` -- the user must take additional action before the deposit / withdrawal can complete.
 * `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
 * `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.


### PR DESCRIPTION
Adds pending_kyc transaction status

Sometimes a user might initiate a transaction but still needs to complete kyc before the anchor can complete the deposit/withdrawal