### PR TITLE
Deprecate SEP3

### DIFF
--- a/ecosystem/sep-0003.md
+++ b/ecosystem/sep-0003.md
@@ -4,9 +4,9 @@
 SEP: 0003
 Title: Compliance protocol
 Author: stellar.org
-Status: Active
+Status: Deprecated
 Created: 2017-10-30
-Updated: 2018-07-15
+Updated: 2019-10-04
 Version 1.0.1
 ```
 


### PR DESCRIPTION
Seems to be deprecated in the ecosystem at large and we recommend sep6/12 instead according to https://www.stellar.org/developers/guides/compliance-protocol.html.  Moving this to deprecated status to avoid confusion