### PR TITLE
Deprecate SEP3

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -33,7 +33,6 @@
 | --- | --- | --- | --- | --- |
 | [SEP-0001](sep-0001.md) | stellar.toml specification | SDF | Standard | Active |
 | [SEP-0002](sep-0002.md) | Federation Protocol | SDF | Standard | Final |
-| [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Active |
 | [SEP-0004](sep-0004.md) | Tx Status Endpoint | SDF | Standard | Final |
 | [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts | SDF | Standard | Final |
 | [SEP-0006](sep-0006.md) | Anchor/Client Interoperability | SDF | Standard | Active |
@@ -62,6 +61,7 @@
 
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
+| [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Deprecated |
 | [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Rejected |
 
 

--- a/ecosystem/sep-0003.md
+++ b/ecosystem/sep-0003.md
@@ -4,11 +4,15 @@
 SEP: 0003
 Title: Compliance protocol
 Author: stellar.org
-Status: Active
+Status: Deprecated
 Created: 2017-10-30
-Updated: 2018-07-15
+Updated: 2019-10-04
 Version 1.0.1
 ```
+
+## Deprecation Notice
+
+For most use cases, we actually recommend the workflow specified in [SEP-0006](sep-0006.md) instead of SEP-0003 
 
 ## Simple Summary
 Complying with Anti-Money Laundering (AML) laws requires financial institutions (FIs) to know not only who their customers are sending money to but who their customers are receiving money from. In some jurisdictions banks are able to trust the AML procedures of other licensed banks. In other jurisdictions each bank must do its own sanction checking of both the sender and the receiver. The Compliance Protocol handles all these scenarios.


### PR DESCRIPTION
according to [our docs](https://www.stellar.org/developers/guides/compliance-protocol.html) we don't recommend sep3 usage anymore and i don't know anyone who's actually implemented it.  Deprecate it now to avoid confusion in future.