### PR TITLE
Make more_info_url non-optional

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -539,7 +539,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`more_info_url` | string | (optional) A URL the user can visit if they want more information about their transaction's status.
+`more_info_url` | string | A URL the user can visit if they want more information about their transaction's status.
 `amount_in` | string | (optional) Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | (optional) Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
 `amount_fee` | string | (optional) Amount of fee charged by anchor.
@@ -596,6 +596,7 @@ Example response:
       "status": "pending_external",
       "status_eta": 3600,
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "more_info_url": "https://youranchor.com/tx/242523523",
       "amount_in": "18.34",
       "amount_out": "18.24",
       "amount_fee": "0.1",
@@ -610,6 +611,7 @@ Example response:
       "amount_fee": "3",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
+      "more_info_url": "https://youranchor.com/tx/242523523",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093"
     }
@@ -662,6 +664,7 @@ Example response:
       "status": "pending_external",
       "status_eta": 3600,
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "more_info_url": "https://youranchor.com/tx/242523523",
       "amount_in": "18.34",
       "amount_out": "18.24",
       "amount_fee": "0.1",


### PR DESCRIPTION
Make it clear that more_info_url should always be returned.  I can't think of any cases where there shouldn't be a place to see info about your transaction.