### PR TITLE
Add email as an example of sep9

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -86,7 +86,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/deposit` and `/withdraw`**
-    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience.  Email address and name are good examples of fields to help pre-fill the anchors website.
+    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
     * If you do attach fields, make sure you attach them using a proper URL builder instead of just appending a string, as the interactive URL may already have query parameters or a hash-fragment value.
 * **For `/deposit`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -86,7 +86,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/deposit` and `/withdraw`**
-    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience.
+    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience.  Email address and name are good examples of fields to help pre-fill the anchors website.
     * If you do attach fields, make sure you attach them using a proper URL builder instead of just appending a string, as the interactive URL may already have query parameters or a hash-fragment value.
 * **For `/deposit`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).


### PR DESCRIPTION
The old sep6 had some stuff about passing email address from a wallet to an anchor.  This special case has been removed in favor of just supporting any SEP9 fields that the wallet may have.  It is useful to have the string `email address` there so that people can ctrl+f for `email` to find instructions on how to do this.