### PR TITLE
Make optional fields required

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -548,7 +548,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | True if the transaction was refunded.
+`refunded` | boolean | True if the transaction was refunded, false otherwise.
 
 
 ### Fields for deposit transactions

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -565,7 +565,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `withdraw_anchor_account` | string | If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or will transfer) their issued asset to.
-`withdraw_memo` | string | Memo used when the user transferred to `withdraw_anchor_account`.  Return null if the withdraw is not ready to receive payment, for example if KYC is not completed.
+`withdraw_memo` | string | Memo used when the user transferred to `withdraw_anchor_account`.  Assigned null if the withdraw is not ready to receive payment, for example if KYC is not completed.
 `withdraw_memo_type` | string | Memo type for `withdraw_memo`.
 `from` | string | Stellar address the assets were withdrawn from
 `to` | string | Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -544,7 +544,7 @@ Name | Type | Description
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
 `amount_fee` | string | Amount of fee charged by anchor.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
-`completed_at` | UTC ISO 8601 string | Completion date and time of transaction.  Return null for in-progress transactions.
+`completed_at` | UTC ISO 8601 string | Completion date and time of transaction.  Assigned null for in-progress transactions.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -264,7 +264,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Always set to `interactive_customer_info_needed`.
 `url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe.
-`id` | string | (optional) The anchor's internal ID for this deposit / withdrawal request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
+`id` | string | The anchor's internal ID for this deposit / withdrawal request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -540,15 +540,15 @@ Name | Type | Description
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
 `more_info_url` | string | A URL the user can visit if they want more information about their transaction's status.
-`amount_in` | string | (optional) Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
-`amount_out` | string | (optional) Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
-`amount_fee` | string | (optional) Amount of fee charged by anchor.
-`started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
-`completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
-`stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
+`amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
+`amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
+`amount_fee` | string | Amount of fee charged by anchor.
+`started_at` | UTC ISO 8601 string | Start date and time of transaction.
+`completed_at` | UTC ISO 8601 string | Completion date and time of transaction.  Return null for in-progress transactions.
+`stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunded` | boolean | True if the transaction was refunded.
 
 
 ### Fields for deposit transactions
@@ -557,18 +557,18 @@ Name | Type | Description
 -----|------|------------
 `deposit_memo` | string | (optional) This is the memo (if any) used to transfer the asset to the `to` Stellar address
 `deposit_memo_type` | string | (optional) Type for the `deposit_memo`.
-`from` | string | (optional) Sent from address, perhaps BTC, IBAN, or bank account.
-`to` | string | (optional) Stellar address the deposited assets were sent to.
+`from` | string | Sent from address, perhaps BTC, IBAN, or bank account.
+`to` | string | Stellar address the deposited assets were sent to.
 
 ### Fields for withdraw transactions
 
 Name | Type | Description
 -----|------|------------
-`withdraw_anchor_account` | string | (optional) If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or will transfer) their issued asset to.
-`withdraw_memo` | string | (optional) Memo used when the user transferred to `withdraw_anchor_account`.
-`withdraw_memo_type` | string | (optional) Memo type for `withdraw_memo`.
-`from` | string | (optional) Stellar address the assets were withdrawn from
-`to` | string | (optional) Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).
+`withdraw_anchor_account` | string | If this is a withdrawal, this is the anchor's Stellar account that the user transferred (or will transfer) their issued asset to.
+`withdraw_memo` | string | Memo used when the user transferred to `withdraw_anchor_account`.  Return null if the withdraw is not ready to receive payment, for example if KYC is not completed.
+`withdraw_memo_type` | string | Memo type for `withdraw_memo`.
+`from` | string | Stellar address the assets were withdrawn from
+`to` | string | Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).
 
 `status` should be one of:
 


### PR DESCRIPTION
Making too many fields optional creates a large array of places where wallets and anchors can get out of sync.  There's no reason for most of these fields to be optional so lets just require them.