### PR TITLE
Add recommendation for encoding phone numbers in federated addresses

### DIFF
--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -33,7 +33,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 #### Phone Numbers
 
-Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5, with spaces be ommitted, to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers. Spaces should be omitted.
 
 For example: `+14155550100*stellar.org`.
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -33,7 +33,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 #### Phone Numbers
 
-Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 For example: `+14155550100*stellar.org`.
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -20,9 +20,25 @@ For example: `bob*stellar.org`:
 
 * `bob` is the username,
 * `stellar.org` is the domain.
-The domain can be any valid RFC 1035 domain name. The username is limited to printable UTF-8 with whitespace and the following characters excluded: `*` ,`>` Although of course the domain administrator can place additional restrictions on usernames of its domain.
 
-Note that the `@` symbol is allowed in the username. This allows for using email addresses in the username of an address. For example: `maria@gmail.com*stellar.org`.
+### Username
+
+The username is limited to printable UTF-8 with whitespace and the following characters excluded: `*` ,`>`. Although of course the domain administrator can place additional restrictions on usernames of its domain.
+
+#### Email Addresses
+
+Email addresses may be used as the username as the `@` symbol is allowed in the username. This allows for using email addresses as the username of an address when the users username is their email address.
+
+For example: `maria@gmail.com*stellar.org`.
+
+#### Phone Numbers
+
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 and should be followed and that spaces be ommitted to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
+
+For example: `+226071234567`.
+
+### Domain
+The domain can be any valid RFC 1035 domain name. 
 
 ## Federation Request
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -35,7 +35,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 and should be followed and that spaces be ommitted to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
 
-For example: `+226071234567`.
+For example: `+14155550100`.
 
 ### Domain
 The domain can be any valid RFC 1035 domain name. 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -33,7 +33,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 #### Phone Numbers
 
-Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers. Spaces should be omitted.
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 For example: `+14155550100*stellar.org`.
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -35,6 +35,8 @@ For example: `maria@gmail.com*stellar.org`.
 
 Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations [E.123](https://www.itu.int/rec/T-REC-E.123) and [E.164](https://www.itu.int/rec/T-REC-E.164) should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
+Format: `+<country code><global subscriber number>`
+
 For example: `+14155550100*stellar.org`.
 
 ### Domain

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -35,7 +35,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 and should be followed and that spaces be ommitted to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
 
-For example: `+14155550100`.
+For example: `+14155550100*stellar.org`.
 
 ### Domain
 The domain can be any valid RFC 1035 domain name. 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -33,7 +33,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 #### Phone Numbers
 
-Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 and should be followed and that spaces be ommitted to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. Specifically, the E.123 international notation with a leading `+` as demonstrated in E.123 Section 2.5, with spaces be ommitted, to ensure phone numbers are consistently encoded and do not collide when mixing international phone numbers.
 
 For example: `+14155550100*stellar.org`.
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -33,7 +33,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 #### Phone Numbers
 
-Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations E.123 and E.164 should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations [E.123](https://www.itu.int/rec/T-REC-E.123) and [E.164](https://www.itu.int/rec/T-REC-E.164) should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 For example: `+14155550100*stellar.org`.
 

--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -35,7 +35,7 @@ For example: `maria@gmail.com*stellar.org`.
 
 Phone numbers may be used as the username. When encoding a phone number as the username the ITU-T recommendations [E.123](https://www.itu.int/rec/T-REC-E.123) and [E.164](https://www.itu.int/rec/T-REC-E.164) should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
-Format: `+<country code><global subscriber number>`
+Format: `+<country code><phone number>`
 
 For example: `+14155550100*stellar.org`.
 


### PR DESCRIPTION
### What
Add recommendation for encoding phone numbers in federated addresses and tidy up the section that defines the requirements of usernames and domains.

### Why
We provide an example of how email addresses can be used in federated addresses which is helpful as it points out to services whose users usernames are their email address that the service can simply use that existing username as the username of the federated address without requiring their users to choose a new username.

Phone numbers are increasingly becoming the user identifiers of many services and it is possible a service will use a phone number as the username.

We should encourage a common uniform approach to encoding phone numbers into usernames using the recommended approaches from industry so that it becomes straight forward to query services for phone numbers without needing to know that some use country codes, others don't, some use separates, etc.