### PR TITLE
Change NATIVE to native

### DIFF
--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -123,7 +123,7 @@ Most XDR types are rendered using C syntax. Specifically:
 
 A few aggregate values are special-cased:
 
-  - The `Asset` type is rendered as `NATIVE` (or any string up to 12 characters not containing an unescaped colon) for the native asset, and a string of the form "Code:IssuerAccountID" for issued assets.  "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).  The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash.  Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
+  - The `Asset` type is rendered as `native` (or any string up to 12 characters not containing an unescaped colon) for the native asset, and a string of the form "Code:IssuerAccountID" for issued assets.  "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).  The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash.  Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
 
   - The `asset` field of `AllowTrustOp` is rendered the same as the Code in `Asset`, only without the trailing ":IssuerAccountID" (since the issuer is the `sourceAccount` of the operation).
 
@@ -170,7 +170,7 @@ Fields in txrep are specified in an order-independent way. If a field appears tw
 
   - Enums must be shown as their symbolic value, rather than "Type#Number", unless there is no symbolic value.
 
-  - The native asset should be rendered as `XLM` for the Stellar public network, `TestXLM` for the Stellar test network, and, in the absence of a convention for any other network, `NATIVE`.
+  - The native asset should be rendered as `XLM` for the Stellar public network, `TestXLM` for the Stellar test network, and, in the absence of a convention for any other network, `native`.
 
 One possible use of non-normalized txrep is to allow users discover missing fields.  A tool that allows users to construct transactions in txrep format can translate the transactions to normalized format to highlight any missing fields along with their default values.  In contexts where users should not leave any fields missing, tools can refuse to accept non-normalized txrep.
 


### PR DESCRIPTION
### What
Change `"NATIVE"` to `"native"` as the default string representation of the native asset.

### Why
The standard defines `"NATIVE"` to be the string representation of the native asset. In practice we use the lowercase string `"native"` in Horizon and in Ticker. While the specification does mention that any string up to 12 characters to be a valid reference to the native asset it is worth naming `"native"` explicitly since in practice is seems more in use.