### PR TITLE
[SEP-24] Stop sending PII in URLs

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -10,10 +10,6 @@ Updated: 2018-09-11
 Version 1.1.0
 ```
 
-## Deprecation warning
-
-We're currently [recommending](sep-0006.md#recommendations) that anchors and wallets use the SEP-6 interactive flow for transmitting KYC information, rather than SEP-12. Therefore, SEP-12 is **deprecated** for anyone using it as part of a [SEP-6](sep-0006.md) implementation.
-
 ## Abstract
 
 This SEP defines a standard way for stellar wallets to upload KYC (or other) information to anchors who need it.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -83,6 +83,10 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * If the `/fee` endpoint is enabled, use it for computing fees when you need to show them to the user.
 * **Authentication**
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
+* **Requested Fields**
+   * If the anchor requests personal information in `/info`, and your app has it or wishes to collect it, send the information to the anchor via [SEP-12](sep-0012.md).
+   * Before sending personal information to an anchor, the user should confirm that they wish to share that information with that anchor, and be given the opportunity to decline, and this step will be skipped.
+   * This step is optional and anchors should be able to continue without any of this information, but it does create a better user experience.
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/deposit`**
@@ -101,6 +105,9 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 
 * Provide a full-featured implementation of [`/info`](#info).
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
+* **Requested fields**
+    * If you've requested additional personal information in the [`/info`](#info) endpoint, implement the [SEP-12](sep-0012.md) protocol to collect that information from the wallet.
+    * This information should be stored and linked to the stellar or user account linked to the jwt, and used to pre-fill or skip fields in the interactive flow.
 * **For both deposit and withdrawal**:
     * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
     * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as query parameters added to the interactive URL.  These can be used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
@@ -452,7 +459,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
-* `fields`: [SEP-9](sep-0009.md) fields for personal information the anchor requests from the wallet, to be provided to the `/deposit` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
+* `fields`: Personal information the anchor requests from the wallet.  Allowed fields are defined in [SEP-9](sep-0009.md) and should be submitted to the anchor via [SEP-12](sep-0012.md) before requesting the `/deposit` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
 
 #### For each withdrawal asset, response contains:
 
@@ -461,7 +468,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for withdraw. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for withdraw. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
-* `fields`: [SEP-9](sep-0009.md) fields for personal information the anchor requests from the wallet, to be provided to the `/withdraw` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
+* `fields`: Personal information the anchor requests from the wallet.  Allowed fields are defined in [SEP-9](sep-0009.md) and should be submitted to the anchor via [SEP-12](sep-0012.md) before requesting the `/withdraw` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -87,8 +87,8 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
 * **Requested Fields**
    * If the anchor requests personal information in `/info`, and your app has it or wishes to collect it, send the information to the anchor via [SEP-12](sep-0012.md).
-   * Before sending personal information to an anchor, the user should confirm that they wish to share that information with that anchor, and be given the opportunity to decline, and this step will be skipped.
-   * This step is optional and anchors should be able to continue without any of this information, but it does create a better user experience.
+   * Before sending personal information to an anchor, the user should confirm that they wish to share that information with that anchor, and be given the opportunity to decline.
+   * This step is optional and anchors should be able to continue without any of this information, but it does create a better user experience.  If the information is not sent, the anchor will request it via the interactive webapp.
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/deposit`**
@@ -412,7 +412,7 @@ The response should be a JSON object like:
       "max_amount": 1000,
       "fields": {
         "email_address": {
-          "description": "Your email address will be used for for transaction status updates."
+          "description": "Email address for transaction status updates."
         }
       }
     },
@@ -432,7 +432,7 @@ The response should be a JSON object like:
       "max_amount": 1000,
       "fields": {
         "email_address": {
-          "description": "Your email address will be used for for transaction status updates."
+          "description": "Email address for transaction status updates."
         }
       }
     },
@@ -461,7 +461,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
-* `fields`: Personal information the anchor requests from the wallet.  Allowed fields are defined in [SEP-9](sep-0009.md) and should be submitted to the anchor via [SEP-12](sep-0012.md) before requesting the `/deposit` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
+* `fields`: Personal information the anchor requests from the wallet.  Allowed fields are defined in [SEP-9](sep-0009.md) and should be submitted to the anchor via [SEP-12](sep-0012.md) before requesting the `/deposit` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing. Any information not provided via SEP-12 the anchor can request the user to enter manually during the interactive process, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
 
 #### For each withdrawal asset, response contains:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -85,9 +85,6 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
-* **For `/deposit` and `/withdraw`**
-    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
-    * If you do attach fields, make sure you attach them using a proper URL builder instead of just appending a string, as the interactive URL may already have query parameters or a hash-fragment value.
 * **For `/deposit`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
     * Handle the [special cases](#special-cases), they're relatively common.
@@ -403,7 +400,12 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
-      "max_amount": 1000
+      "max_amount": 1000,
+      "fields": {
+        "email_address": {
+          "description": "Your email address will be used for for transaction status updates."
+        }
+      }
     },
     "ETH": {
       "enabled": true,
@@ -418,7 +420,12 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 0,
       "min_amount": 0.1,
-      "max_amount": 1000
+      "max_amount": 1000,
+      "fields": {
+        "email_address": {
+          "description": "Your email address will be used for for transaction status updates."
+        }
+      }
     },
     "ETH": {
       "enabled": false
@@ -445,6 +452,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `fields`: [SEP-9](sep-0009.md) fields for personal information the anchor requests from the wallet, to be provided to the `/deposit` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
 
 #### For each withdrawal asset, response contains:
 
@@ -453,6 +461,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for withdraw. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for withdraw. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `fields`: [SEP-9](sep-0009.md) fields for personal information the anchor requests from the wallet, to be provided to the `/withdraw` endpoint.  These fields are all optional, so an anchor should be able to proceed even if the wallet provides nothing, usually by requesting the info during the KYC interactive process.  Each field can optionally have a `description` property which can be used by the wallet to explain to the user why the anchor is requesting it, and give the opportunity to prevent it from being sent.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 


### PR DESCRIPTION
The process of sending PII  as query parameters in a URL are a security risk.  We should be sending them in a secure way to the anchor.

More info on PII Leaking: https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url