### PR TITLE
[SEP24] Send PII over POST instead of GET

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -34,8 +34,8 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## API Endpoints
 
-* [`POST /deposit`](#deposit)
-* [`POST /withdraw`](#withdraw)
+* [`POST /interactive/deposit`](#deposit)
+* [`POST /interactive/withdraw`](#withdraw)f
 * [`GET /info`](#info)
 * [`GET /fee`](#fee): optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history)
@@ -85,16 +85,16 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * If the `/fee` endpoint is enabled, use it for computing fees when you need to show them to the user.
 * **Authentication**
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
-* **Make a request to `/deposit` or `/withdraw`.**
+* **Make a request to `/interactive/deposit` or `/interactive//withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
-* **For `/deposit` and `/withdraw`**
+* **For `/interactive/deposit` and `/interactive/withdraw`**
     * Optionally attach any fields from [SEP-9](sep-0009.md) as POST parameters in the `/deposit` or `/withdraw` endpoints in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
-* **For `/deposit`**
+* **For `/interactive/deposit`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
     * Handle the [special cases](#special-cases), they're relatively common.
-* **For `/withdraw`**
+* **For `/interactive/withdraw`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
-    * Do not handle the non-interactive or status responses to the `/withdraw` request.  These may be from the old [SEP6](sep-0006.md) protocol.
+    * Do not handle the non-interactive or status responses to the `/interactive/withdraw` request.  These may be from the old [SEP6](sep-0006.md) protocol.
     * When the transaction status becomes `pending_user_transfer_start` send the required payment as described in the interactive webapp callback or the `/transaction` endpoint.  This can be a `payment` or `path_payment` operation.  Sending payments via `account_merge` or `create_account` is not supported at this time.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so exchange rate fluctuations might require withdrawal values to slightly vary from the originally provided `amount`. Anchors are instructed to accept a variation of ±10% between the informed `amount` and the actual value sent to the anchor's Stellar account. The withdrawn amount will be adjusted accordingly.
 * **Transaction history**
@@ -107,10 +107,10 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
-    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/deposit` or `/withdraw` endpoints.  These can be stored away and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
-    * Include the `id` field in your response to `/deposit` and `/withdraw` so the wallet can check up on the status of the transaction if it wants.
+    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/interactive/deposit` or `/interactive/withdraw` endpoints.  These can be stored away and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
+    * Include the `id` field in your response to `/interactive/deposit` and `/interactive/withdraw` so the wallet can check up on the status of the transaction if it wants.
     * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction when the user visits the URL.
-    * Make sure to pass along the `amount` to the popup URL, especially on the `/withdraw` flow.
+    * Make sure to pass along the `amount` to the popup URL, especially on the `/interactive/withdraw` flow.
     * We recommend you use [SEP-10](#authentication) for authentication in the interactive flow and do not separately prompt for password to achieve a good user experience (although asking for MFA when confirming a transaction or requiring email confirmation is reasonable). Be sure to accept the [`jwt` parameter](#adding-parameters-to-the-url) so the user does not have to re-login. Support the `callback` parameter as well.
     * Test your interactive flows on mobile. They should be easy to use on all devices: make them responsive, handle auto-fill well, and do smart keyboard management on mobile devices.
 * **Interactive deposit**
@@ -136,7 +136,7 @@ If the given account does not exist, or if the account doesn't have a trust line
 ### Request
 
 ```
-POST TRANSFER_SERVER/deposit
+POST TRANSFER_SERVER/interactive/deposit
 Content-Type: multipart/form-data
 ```
 
@@ -193,7 +193,7 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ### Request
 
 ```
-POST TRANSFER_SERVER/withdraw
+POST TRANSFER_SERVER/interactive/withdraw
 Content-Type: multipart/form-data
 ```
 
@@ -326,7 +326,7 @@ Since the user has authenticated with [SEP-0010](sep-0010.md), the wallet should
 
 Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
-To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `/withdraw` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
+To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `/interactive/withdraw` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
 
 In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -34,8 +34,8 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## API Endpoints
 
-* [`POST /interactive/deposit`](#deposit)
-* [`POST /interactive/withdraw`](#withdraw)
+* [`POST /transactions/deposit/interactive`](#deposit)
+* [`POST /transactions/withdraw/interactive`](#withdraw)
 * [`GET /info`](#info)
 * [`GET /fee`](#fee): optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history)
@@ -85,16 +85,16 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * If the `/fee` endpoint is enabled, use it for computing fees when you need to show them to the user.
 * **Authentication**
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
-* **Make a request to `/interactive/deposit` or `/interactive/withdraw`.**
+* **Make a request to `/transactions/deposit/interactive` or `/transactions/withdraw/interactive`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
-* **For `/interactive/deposit` and `/interactive/withdraw`**
+* **For `/transactions/deposit/interactive` and `/transactions/withdraw/interactive`**
     * Optionally attach any fields from [SEP-9](sep-0009.md) as POST parameters in the `/deposit` or `/withdraw` endpoints in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
-* **For `/interactive/deposit`**
+* **For `/transactions/deposit/interactive`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
     * Handle the [special cases](#special-cases), they're relatively common.
-* **For `/interactive/withdraw`**
+* **For `/transactions/withdraw/interactive`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
-    * Do not handle the non-interactive or status responses to the `/interactive/withdraw` request.  These may be from the old [SEP6](sep-0006.md) protocol.
+    * Do not handle the non-interactive or status responses to the `/transactions/withdraw/interactive` request.  These may be from the old [SEP6](sep-0006.md) protocol.
     * When the transaction status becomes `pending_user_transfer_start` send the required payment as described in the interactive webapp callback or the `/transaction` endpoint.  This can be a `payment` or `path_payment` operation.  Sending payments via `account_merge` or `create_account` is not supported at this time.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so exchange rate fluctuations might require withdrawal values to slightly vary from the originally provided `amount`. Anchors are instructed to accept a variation of ±10% between the informed `amount` and the actual value sent to the anchor's Stellar account. The withdrawn amount will be adjusted accordingly.
 * **Transaction history**
@@ -107,10 +107,10 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
-    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/interactive/deposit` or `/interactive/withdraw` endpoints.  These can be stored and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
-    * Include the `id` field in your response to `/interactive/deposit` and `/interactive/withdraw` so the wallet can check up on the status of the transaction if it wants.
+    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/transactions/deposit/interactive` or `/transactions/withdraw/interactive` endpoints.  These can be stored and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
+    * Include the `id` field in your response to `/transactions/deposit/interactive` and `/transactions/withdraw/interactive` so the wallet can check up on the status of the transaction if it wants.
     * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction when the user visits the URL.
-    * Make sure to pass along the `amount` to the popup URL, especially on the `/interactive/withdraw` flow.
+    * Make sure to pass along the `amount` to the popup URL, especially on the `/transactions/withdraw/interactive` flow.
     * We recommend you use [SEP-10](#authentication) for authentication in the interactive flow and do not separately prompt for password to achieve a good user experience (although asking for MFA when confirming a transaction or requiring email confirmation is reasonable). Be sure to accept the [`jwt` parameter](#adding-parameters-to-the-url) so the user does not have to re-login. Support the `callback` parameter as well.
     * Test your interactive flows on mobile. They should be easy to use on all devices: make them responsive, handle auto-fill well, and do smart keyboard management on mobile devices.
 * **Interactive deposit**
@@ -136,7 +136,7 @@ If the given account does not exist, or if the account doesn't have a trust line
 ### Request
 
 ```
-POST TRANSFER_SERVER/interactive/deposit
+POST TRANSFER_SERVER/transactions/deposit/interactive
 Content-Type: multipart/form-data
 ```
 
@@ -161,7 +161,7 @@ When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` ty
 Example:
 
 ```
-POST /interactive/deposit
+POST /transactions/deposit/interactive
 Content-Type: multipart/form-data
 
 asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
@@ -202,7 +202,7 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ### Request
 
 ```
-POST TRANSFER_SERVER/interactive/withdraw
+POST TRANSFER_SERVER/transactions/withdraw/interactive
 Content-Type: multipart/form-data
 ```
 
@@ -225,7 +225,7 @@ Additionally, any [SEP-9](SEP-0009.md) parameters may be passed as well to make 
 Example:
 
 ```
-POST TRANSFER_SERVER/interactive/withdraw
+POST TRANSFER_SERVER/transactions/withdraw/interactive
 Content-Type: multipart/form-data
 
 asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
@@ -344,7 +344,7 @@ Since the user has authenticated with [SEP-0010](sep-0010.md), the wallet should
 
 Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
-To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `/interactive/withdraw` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
+To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `/transactions/withdraw/interactive` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
 
 In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -138,6 +138,8 @@ If the given account does not exist, or if the account doesn't have a trust line
 ```
 POST TRANSFER_SERVER/interactive/deposit
 Content-Type: multipart/form-data
+
+asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.
@@ -195,6 +197,8 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ```
 POST TRANSFER_SERVER/interactive/withdraw
 Content-Type: multipart/form-data
+
+asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -35,7 +35,7 @@ To support this protocol an anchor acts as a server and implements the specified
 ## API Endpoints
 
 * [`POST /interactive/deposit`](#deposit)
-* [`POST /interactive/withdraw`](#withdraw)f
+* [`POST /interactive/withdraw`](#withdraw)
 * [`GET /info`](#info)
 * [`GET /fee`](#fee): optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history)

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -138,8 +138,6 @@ If the given account does not exist, or if the account doesn't have a trust line
 ```
 POST TRANSFER_SERVER/interactive/deposit
 Content-Type: multipart/form-data
-
-asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.
@@ -159,6 +157,15 @@ Name | Type | Description
 Additionally, any [SEP-9](SEP-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 
 When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
+
+Example:
+
+```
+POST /interactive/deposit
+Content-Type: multipart/form-data
+
+asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
+```
 
 ### Response
 
@@ -197,8 +204,6 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ```
 POST TRANSFER_SERVER/interactive/withdraw
 Content-Type: multipart/form-data
-
-asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.
@@ -216,6 +221,15 @@ Name | Type | Description
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 
 Additionally, any [SEP-9](SEP-0009.md) parameters may be passed as well to make the onboarding experience simpler.
+
+Example:
+
+```
+POST TRANSFER_SERVER/interactive/withdraw
+Content-Type: multipart/form-data
+
+asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
+```
 
 When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -85,7 +85,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * If the `/fee` endpoint is enabled, use it for computing fees when you need to show them to the user.
 * **Authentication**
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
-* **Make a request to `/interactive/deposit` or `/interactive//withdraw`.**
+* **Make a request to `/interactive/deposit` or `/interactive/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/interactive/deposit` and `/interactive/withdraw`**
     * Optionally attach any fields from [SEP-9](sep-0009.md) as POST parameters in the `/deposit` or `/withdraw` endpoints in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -34,8 +34,8 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## API Endpoints
 
-* [`GET /deposit`](#deposit)
-* [`GET /withdraw`](#withdraw)
+* [`POST /deposit`](#deposit)
+* [`POST /withdraw`](#withdraw)
 * [`GET /info`](#info)
 * [`GET /fee`](#fee): optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history)
@@ -88,8 +88,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * **Make a request to `/deposit` or `/withdraw`.**
     * This will respond with the interactive url needed to proceed with KYC and deposit/withdraw details.
 * **For `/deposit` and `/withdraw`**
-    * Optionally attach any fields from [SEP-9](sep-0009.md) as query parameters in the interactive URL, in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
-    * If you do attach fields, make sure you attach them using a proper URL builder instead of just appending a string, as the interactive URL may already have query parameters or a hash-fragment value.
+    * Optionally attach any fields from [SEP-9](sep-0009.md) as POST parameters in the `/deposit` or `/withdraw` endpoints in order to let the anchor pre-fill them in the interactive flow UI.  This is optional, but can create a much nicer user experience. `email_address`, `first_name` and `last_name` are good examples of fields to help pre-fill the anchors website.
 * **For `/deposit`**
     * Handle the interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
     * Handle the [special cases](#special-cases), they're relatively common.
@@ -108,7 +107,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
-    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as query parameters added to the interactive URL.  These can be used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
+    * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/deposit` or `/withdraw` endpoints.  These can be stored away and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
     * Include the `id` field in your response to `/deposit` and `/withdraw` so the wallet can check up on the status of the transaction if it wants.
     * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction when the user visits the URL.
     * Make sure to pass along the `amount` to the popup URL, especially on the `/withdraw` flow.
@@ -137,8 +136,10 @@ If the given account does not exist, or if the account doesn't have a trust line
 ### Request
 
 ```
-GET TRANSFER_SERVER/deposit
+POST TRANSFER_SERVER/deposit
 ```
+
+The fields below should be placed in the request body using the `multipart/form-data` encoding.
 
 Request Parameters:
 
@@ -152,11 +153,9 @@ Name | Type | Description
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 
-Example:
+Additionally, any [SEP-9](SEP-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 
-```
-GET https://api.example.com/deposit?asset_code=ETH&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
-```
+When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
 
 ### Response
 
@@ -193,8 +192,11 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ### Request
 
 ```
-GET TRANSFER_SERVER/withdraw
+POST TRANSFER_SERVER/withdraw
+Content-Type: multipart/form-data
 ```
+
+The fields below should be placed in the request body using the `multipart/form-data` encoding.
 
 Request parameters:
 
@@ -208,11 +210,9 @@ Name | Type | Description
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 
-Example:
+Additionally, any [SEP-9](SEP-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 
-```
-GET https://api.example.com/withdraw?asset_code=ETH&dest=0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe
-```
+When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
 
 ### Response
 
@@ -282,7 +282,7 @@ Example response:
 
 Before the wallet sends the user to the `url` field received from the anchor, it may add query parameters to the URL.
 
-The basic parameters are summarized in the table below.  Other parameters from [SEP-9](sep-0009.md) may be passed to help autofill fields inside the webapp.
+The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -137,6 +137,7 @@ If the given account does not exist, or if the account doesn't have a trust line
 
 ```
 POST TRANSFER_SERVER/deposit
+Content-Type: multipart/form-data
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.


### PR DESCRIPTION
Current recommendation for sending Personal Information like email address is via query params on the interactive URL.  Putting Personal info inside a URL is [a security risk](https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url).  This updates the protocol to send info via POST at the initial `/deposit` or `/withdraw` endpoints.  Anchors can then store this away to pre-populate in the interactive flow, and PII is never sent over URLs.

It's also more idiomatic since `GET /deposit` creates a new deposit ID, it should be a POST request since it has side effects.

It also changes the urls from `/deposit` to `/transactions/deposit/interactive` so people can keep running sep6 integrations.

This is the first non-backwards compatible change to SEP-6.