### PR TITLE
[sep24] Add fee_minimum, clarify fees

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -81,7 +81,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file and its [`/info`](#info) endpoint to display useful information to the user about the asset they've picked.
 * Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file.
 * **Use the `/info` endpoint**
-    * Fetch the asset's deposit & withdawal fee structure: if `fee_fixed` and `fee_percent` are provided, show this to the user early in the process so they're fully informed.
+    * Fetch the asset's deposit & withdawal fee structure: if `fee_fixed`, `fee_percent`, or `fee_minimum` are provided, show this to the user early in the process so they're fully informed.
     * If the `/fee` endpoint is enabled, use it for computing fees when you need to show them to the user.
 * **Authentication**
    * Perform [authentication](#authentication) via SEP-10 before hitting those endpoints
@@ -236,8 +236,9 @@ Name | Type | Description
 `eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
 `max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
-`fee_fixed` | float | (optional) If there is a fee for withdraw. In units of the withdrawn asset.
-`fee_percent` | float | (optional) If there is a percent fee for withdraw.
+`fee_fixed` | float | (optional)  Fixed (Base) fee, in units of withdrawn asset.  This is in addition to any `fee_percent`.
+`fee_percent` | float | (optional) Percentage fee in units of percent.  This is in addition to any `fee_fixed`.
+`fee_minimum` | float | (optional) Minimum fee in units of withdrawn asset.
 `extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name.
 
 Example:
@@ -417,8 +418,8 @@ The response should be a JSON object like:
     "USD": {
       "enabled": true,
       "authentication_required": true,
-      "fee_fixed": 5,
-      "fee_percent": 0,
+      "fee_minimum": 5,
+      "fee_percent": 0.5,
       "min_amount": 0.1,
       "max_amount": 1000
     },
@@ -445,16 +446,18 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `enabled`: `true` if SEP-6 deposit for this asset is supported
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
-* `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_fixed`: Optional fixed (base) fee for deposit. In units of the deposited asset. This is in addition to any `fee_percent`.  Leave blank if there is no fee or the fee schedule is complex.
+* `fee_percent`: Optional percentage fee for deposit. In percentage points. This is in addition to any `fee_fixed`. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_minimum`: Optional minimum fee in units of the deposited asset.
 
 #### For each withdrawal asset, response contains:
 
 * `enabled`: `true` if SEP-6 withdrawal for this asset is supported
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
-* `fee_fixed`: Optional fixed (flat) fee for withdraw. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: Optional percentage fee for withdraw. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_fixed`: Optional fixed (base) fee for withdraw. In units of the withdrawn asset.  This is in addition to any `fee_percent`. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_percent`: Optional percentage fee for withdraw in percentage points. This is in addition to any `fee_fixed`. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_minimum`: Optional minimum fee in units of the withdrawn asset.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 
@@ -463,7 +466,7 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 
 ## Fee
 
-The fee endpoint allows an anchor to report the fee that would be charged for a given deposit or withdraw operation. This is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
+The fee endpoint allows an anchor to report the fee that would be charged for a given deposit or withdraw operation. This is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed`, `fee_percent` or `fee_minimum` fields in the `/info` response, then an anchor should not implement this endpoint.
 
 ```
 GET TRANSFER_SERVER/fee

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -446,8 +446,8 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `enabled`: `true` if SEP-6 deposit for this asset is supported
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
-* `fee_fixed`: Optional fixed (base) fee for deposit. In units of the deposited asset. This is in addition to any `fee_percent`.  Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: Optional percentage fee for deposit. In percentage points. This is in addition to any `fee_fixed`. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_fixed`: Optional fixed (base) fee for deposit. In units of the deposited asset. This is in addition to any `fee_percent`.  Omit if there is no fee or the fee schedule is complex.
+* `fee_percent`: Optional percentage fee for deposit. In percentage points. This is in addition to any `fee_fixed`. Omit if there is no fee or the fee schedule is complex.
 * `fee_minimum`: Optional minimum fee in units of the deposited asset.
 
 #### For each withdrawal asset, response contains:
@@ -459,7 +459,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `fee_percent`: Optional percentage fee for withdraw in percentage points. This is in addition to any `fee_fixed`.
 * `fee_minimum`: Optional minimum fee in units of the withdrawn asset.
 
-If `fee_fixed` or `fee_percent` are provided, the total fee is calculated as `(amount * fee_percent) + fee_fixed = fee_total`.  If the fee structure doesn't fit this model, leave them blank and provide the [`/fee`](#fee) endpoint instead.
+If `fee_fixed` or `fee_percent` are provided, the total fee is calculated as `(amount * fee_percent) + fee_fixed = fee_total`.  If the fee structure doesn't fit this model, omit them and provide the [`/fee`](#fee) endpoint instead.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -455,9 +455,11 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `enabled`: `true` if SEP-6 withdrawal for this asset is supported
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
-* `fee_fixed`: Optional fixed (base) fee for withdraw. In units of the withdrawn asset.  This is in addition to any `fee_percent`. Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: Optional percentage fee for withdraw in percentage points. This is in addition to any `fee_fixed`. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_fixed`: Optional fixed (base) fee for withdraw. In units of the withdrawn asset.  This is in addition to any `fee_percent`.
+* `fee_percent`: Optional percentage fee for withdraw in percentage points. This is in addition to any `fee_fixed`.
 * `fee_minimum`: Optional minimum fee in units of the withdrawn asset.
+
+If fee_fixed or fee_percent is provided, fees are calculated as `(amount * percent fee) + fixed fee = total fee`.  If the fee structure doesn't fit this model, leave them blank and provide the [`/fee`](#fee) endpoint instead.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -459,7 +459,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `fee_percent`: Optional percentage fee for withdraw in percentage points. This is in addition to any `fee_fixed`.
 * `fee_minimum`: Optional minimum fee in units of the withdrawn asset.
 
-If fee_fixed or fee_percent is provided, fees are calculated as `(amount * percent fee) + fixed fee = total fee`.  If the fee structure doesn't fit this model, leave them blank and provide the [`/fee`](#fee) endpoint instead.
+If `fee_fixed` or `fee_percent` are provided, the total fee is calculated as `(amount * fee_percent) + fee_fixed = fee_total`.  If the fee structure doesn't fit this model, leave them blank and provide the [`/fee`](#fee) endpoint instead.
 
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 


### PR DESCRIPTION
It was unclear if fee_fixed was additive with fee_percent, or if it was a minimum.  This adds `fee_minimum,` and clarifies that fixed+percent are additive.

Fixes #437 