### PR TITLE
Remove confusing sha stuff for sep submission

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -103,10 +103,10 @@ Draft a formal proposal using the [SEP Template](../sep-template.md), and submit
 repository. You should make sure to adhere to the following:
 
 * Use the following format for the filename of your draft:
-  `sep_{github_username}_{shortsha256sum}.md`
-  * `shortsha256sum` is defined as the first 8 characters of the SHA-256 checksum.
-  * For example, a SEP by Github user `happycoder` with a SHA-256 checksum of `a200f73c`
-    would be titled `sep_happycoder_b274f73c.md`.
+  `sep_{github_username}_{shorttitle}.md`
+  * `shorttitle` is a tiny description of the SEP.
+  * For example, a SEP by Github user `happycoder` with a proposal concerning new account deposits
+    would be titled `sep_happycoder_newaccountdeposit.md`.
 * Make sure to place your SEP in the `ecosystem/` folder.
 * Include GitHub handles or emails for all authors listed.  GitHub handles are preferred.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -103,10 +103,7 @@ Draft a formal proposal using the [SEP Template](../sep-template.md), and submit
 repository. You should make sure to adhere to the following:
 
 * Use the following format for the filename of your draft:
-  `sep_{github_username}_{shorttitle}.md`
-  * `shorttitle` is a tiny description of the SEP.
-  * For example, a SEP by Github user `happycoder` with a proposal concerning new account deposits
-    would be titled `sep_happycoder_newaccountdeposit.md`.
+  `sep_{shorttitle}.md`, for example `sep_newaccountdeposit.md`
 * Make sure to place your SEP in the `ecosystem/` folder.
 * Include GitHub handles or emails for all authors listed.  GitHub handles are preferred.
 


### PR DESCRIPTION
Currently we require some confusing SHA hash generation to submit a SEP proposal which seems overly confusing, so I replace it with just a short title of whats going on.

The important thing is just to have a unique name here, it will be changed to a number as soon as the draft is accepted (not finalized, just accepted as a draft).  I don't want to have barriers to entry to creating proposals