### PR TITLE
SEP-2: Add updated timestamp and version

### DIFF
--- a/ecosystem/sep-0002.md
+++ b/ecosystem/sep-0002.md
@@ -6,6 +6,8 @@ Title: Federation protocol
 Author: stellar.org
 Status: Final
 Created: 2017-10-30
+Updated: 2019-10-10
+Version 1.1.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
### What
Add `Updated` timestamp to the last date SEP-2 was updated, and a `Version` field, setting it to `1.1.0` assuming it has been updated once since its initial release.

### Why
In #428 I added instructions to the SEP for how to use a phone number as a username in a federated address. I missed adding an `Updated` timestamp when I made that change, and I've discovered reviewing other PRs that we do that normally.

I chose version `1.1.0` because there was no version field previously, but it is in `Final` status, so I assume if it hadn't had any major updates prior to now it was version `1.0.0`.