### PR TITLE
[SEP24] Remove the 403 forbidden stuff from the interactive endpoint

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -253,9 +253,9 @@ Example:
 
 ## Deposit and Withdraw shared responses
 
-### 3. Interactive customer information needed
+### 2. Interactive customer information needed
 
-Response code: `403 Forbidden`
+Response code: `200 OK`
 
 An anchor that requires the user to fill out information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or when the anchor needs the user to perform a custom step for each transaction like entering an SMS code to confirm a withdrawal or selecting a bank account. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
 


### PR DESCRIPTION
One of the vestigial remains of the evolution of SEP6 is that the call to return the interactive URL should return as a `403 forbidden`.  This made sense when sep6 could be interactive or non-interactive and there were multiple ways to get through the flow, 403 was the closest thing to "More user info needed".  Given that this is now the one and only happy path we should probably cut the cord on this 403 response, and just show it as the correct response.

It would be good to land this at the same time as https://github.com/stellar/stellar-protocol/pull/438 since its already a breaking change regarding these endpoints, we can do it all at once.