### PR TITLE
doc: make README header engaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-Stellar Protocol
-================
+<div align="center">
+<img alt="Stellar" src="https://www.stellar.org/old-content/2019/03/stellar-logo-solo-1.png" width="558" />
+<br/>
+<strong>Creating equitable access to the global financial system</strong>
+<h1>Stellar Protocol</h1>
+</div>
+<p align="center">
+<a href="./core"><img alt="Docs: CAPs" src="https://img.shields.io/badge/docs-CAPs-blue" /></a>
+<a href="./ecosystem"><img alt="Docs: SEPs" src="https://img.shields.io/badge/docs-SEPs-blue" /></a>
+</p>
 
-This repository contains **Core Advancement Proposals** (CAPs) and **Stellar Ecosystem Proposals**
+This repository is home to **Core Advancement Proposals** (CAPs) and **Stellar Ecosystem Proposals**
 (SEPs).
 
 Similar to [BIPs](https://github.com/bitcoin/bips) and [EIPs](https://github.com/ethereum/EIPs),
-CAPs and SEPs are the proposals of standards to improve Stellar protocol and related client APIs.
+CAPs and SEPs are the proposals of standards to improve the Stellar protocol and related client APIs.
 
 CAPs deal with changes to the core protocol of the Stellar network. Please see [the process for CAPs](core/README.md).
 
@@ -42,4 +50,8 @@ Example repository structure:
 └── sep-template.md
 ```
 
+## Contributing
+
 See [CONTRIBUTING](CONTRIBUTING.md) to learn how to contribute.
+
+[Stellar Development Foundation]: https://stellar.org


### PR DESCRIPTION
### What

Change the beginning of the `README` to include the Stellar logo, and Stellar's mission.

See it fully rendered at:
https://github.com/leighmcculloch/stellar--protocol/blob/sparkle/README.md

### Why

At GitHub Universe one of the talks I attended talked about how creating an inviting and engaging README makes a huge difference to communicating to developers who are coming across the project. The [dev.to README] was given as an example of a great README that goes a long way to engage poeple who visit the project. I think there's probably a lot of things we can do to make our README more alive to someone visiting it, and adding our logo and including our mission is just one small thing.

The same change has been merged on the `stellar/go` repository in stellar/go#1948.

[dev.to README]: https://github.com/thepracticaldev/dev.to/blob/master/README.md