### PR TITLE
SEP-0010: allow JWT iss field to be server public key

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Active
 Created: 2018-07-31
-Updated: 2019-07-09
-Version 1.1.0
+Updated: 2019-11-21
+Version 1.2.0
 ```
 
 ## Simple Summary
@@ -128,7 +128,7 @@ To validate the challenge transaction the following steps are performed by the s
 
 Upon successful validation service responds with a session JWT, containing the following claims:
 
-* `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — the URI of the web service (`https://example.com`)
+* `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — the public key of the servers Stellar account (`G...`) or the URI of the web service (`https://example.com`)
 * `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)


### PR DESCRIPTION
### What
Allow the JWT generated by the server in SEP-10 to contain an issuer (field: `iss`) that is the public key of the server used in the challenge process, along with the URL.

Example JWT:
```json
{ 
  "iss": "GAHSZCNU4MTXFWND3P2CJIOQRN5PXG5XPAWS3MTLH67NGDDK577UTZKG",
  "sub": "GDOAAGSRBZREJ7UEUUHLJLRH6BNIQU6X763QDF65HSTL2HZH7VVUJXNN",
  "iat": 1574382332,
  "exp": 1574385932,
  "jti": "9ec36c2f0b4e0569e89776cb05c546719dc791fc6d4ac614131d26fc0fe3b124"
}
```

### Why
Non-URL strings are allowed by [rfc7519] with the only requirement being that they do not contain a semi-colon character (`:`). This constraint by SEP-10 to limit the field to a URI seems unnecessary. In most cases the servers that will be validating the JWT are going to be also in the control by the same entity that issued the JWT so it is mostly an implementation detail what is placed in this field.

Not all servers are aware of their absolute URI. Many servers are deployed behind load balancers or frontend web servers and they may not otherwise have a need to know their absolute URI, so this unnecessary requirement will be inconvenient without any gain.

We use public keys to identify servers in other places like the TOML and it would be consistent if we allowed and encourage the issuer to identify itself with its public key everywhere. We should at least expand the SEP to allow for that consistency.

[RFC7519]: https://tools.ietf.org/html/rfc7519#section-4.1.1

### CC
@tomquisel @nebolsin – Original authors.