### PR TITLE
SEP-0010: Clarify best practices about JWTs and URIs

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Active
 Created: 2018-07-31
-Updated: 2019-07-09
-Version 1.1.0
+Updated: 2019-11-22
+Version 1.1.1
 ```
 
 ## Simple Summary
@@ -128,11 +128,16 @@ To validate the challenge transaction the following steps are performed by the s
 
 Upon successful validation service responds with a session JWT, containing the following claims:
 
-* `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — the URI of the web service (`https://example.com`)
+* `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — a [Uniform Resource Identifier (URI)] for the issuer (`https://example.com` or `https://example.com/G...`)
 * `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
 * `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
+
+The JWT may contain other claims specific to your application, see [RFC7519].
+
+[Uniform Resource Identifier (URI)]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+[RFC7519]: https://tools.ietf.org/html/rfc7519
 
 #### Request
 
@@ -193,6 +198,12 @@ Signatures in Stellar involve both the secret key of the signer and the passphra
 This convention ensures that SEP-10 clients and servers can use the same passphrase as they're using for interacting with the Stellar network. 
 
 The client can examine the `network_passphrase` (if defined) that the server includes in its response from the challenge endpoint to be sure it's using the correct passphrase and is connecting to the server that it expected.
+
+## JWT best practices
+
+When generating and validating JWTs it's important to follow best practices. The IETF in the process of producing a set of best current practices when using JWTs: [IETF JWT BCP].
+
+[IETF JWT BCP]: https://tools.ietf.org/wg/oauth/draft-ietf-oauth-jwt-bcp/
 
 ## Implementations
 


### PR DESCRIPTION
### What
Make really clear that the issuer is a URI and not a URL, and add notes about where to find best practices about JWTs.

### Why
It's really easy to see `URI` and just think `URL` even for us who are rather intimate with the SEP. An JWTs issuer can be a URL, but it also doesn't need to be, it can be a unique URI containing any information, such as the key used for signing. It is application specific and this clarification loosens the definition without prescribing how an application should populate the issuer field.

JWT best practices are important when implementing systems that use JWTs for authentication. It's out of scope for this SEP to capture those best practices, also because they are evolving, but we can link to the current best practices that the IETF are drafting.