### PR TITLE
SEP-0010: Remove the jti as a required token field

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>
 Status: Active
 Created: 2018-07-31
-Updated: 2019-07-09
-Version 1.1.0
+Updated: 2019-12-02
+Version 1.2.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -132,7 +132,6 @@ Upon successful validation service responds with a session JWT, containing the f
 * `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
-* `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
 
 #### Request
 


### PR DESCRIPTION
### What
Remove the `jti` as a required field on the JWT generated as part of SEP-10.

### Why
The `jti` is described in [RFC7519 Section 4.1.7] as being a unique identifier for a specific token that can be used to prevent a token from being replayed. In some situations it is desirable to only allow a token to be used one-time, even if it hasn't expired. While that might be a use-case of an anchor or other web service, it doesn't seem to be a core requirement of SEP-10. In fact SEP-10 uses a JWT as a way of getting a reusable token from a challenge-response that is not easily reused, so repeatable use of the JWT is anticipated.

Motivation for removing this now is that we are exploring other SEPs that build on SEP-10 and involve augmenting an existing JWT and issuing a new JWT that includes additional claims. Augmenting the JWT requires changing the `jti` since they're intended to be unique and the requirement of a `jti` in this SEP is inconvenient for extending and building on it. Our SEPs will be easier to compose if they hyper-focus on solving a single problem. This change reduces the requirements by removing a component that is not core to the problem solved by this SEP.

An implementer may be using the `jti` to log and improve traceability of where a token was generated and then later used. Implementing systems can still do this if they'd like either with the `jti` field or by specifying a custom claim to indicate transaction hash or any other identifier they have, but it is outside the scope of this SEP to make that a requirement in every implementation.

[RFC7519 Section 4.1.7]: https://tools.ietf.org/html/rfc7519#section-4.1.7