### PR TITLE
SEP-0010: Make clear about what it proves and what it doesn't prove

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -35,7 +35,7 @@ The flow achieves several things:
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
 
-Note: The result of the challenge-response and the JWT generated when implementing this SEP will confirm that an authenticating user has possession of a Stellar secret key but does not prove signing capabilities of any Stellar account. A server receiving the JWT that needs proof of control of a Stellar account should verify if the Stellar key authenticated in the JWT is a signer of the account and has a weight that is suitable for the applications operations and purpose. An application wanting to prove that the signer has complete authority of the account may want to verify that the weight of the signer is equal or greater than all thresholds on the account.
+The result of the challenge-response and the JWT generated when implementing this SEP will confirm that an authenticating user has possession of a Stellar secret key but does not prove signing capabilities of any Stellar account. A server receiving the JWT that needs proof of control of a Stellar account should verify if the Stellar key authenticated in the JWT is a signer of the account and has a weight that is suitable for the applications operations and purpose. An application wanting to prove that the signer has complete authority of the account may want to verify that the weight of the signer is equal or greater than all thresholds on the account.
 
 ## Authentication Endpoint
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -69,7 +69,7 @@ Request Parameters:
 
 Name      | Type          | Description
 ----------|---------------|------------
-`account` | `G...` string | Deprecated. Use `key`.
+`account` | `G...` string | Deprecated. Use `key`. Applications should accept and send both parameters until v2.
 `key`     | `G...` string | A Stellar public key that the wallet wishes to authenticate with the server.
 
 Example:

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -12,7 +12,7 @@ Version 1.1.1
 
 ## Simple Summary
 
-This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who holds a Stellar account. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md).
+This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who has a Stellar secret key, who therefore may have some control of a Stellar account with that key as a signer. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md).
 
 ## Abstract
 
@@ -22,7 +22,7 @@ The authentication flow is as follows:
 
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
 1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
-1. The client signs the transaction using the secret key for the user's Stellar account
+1. The client signs the transaction using the secret key for the user's key pair
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. If the signature checks out, the server responds with a [JWT](jwt.io) that represents the user's session
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
@@ -30,10 +30,13 @@ The authentication flow is as follows:
 The flow achieves several things:
 
 * Both client and server part can be implemented using well-established Stellar libraries
-* The client can verify that the server holds the secret key to a particular account
-* The server can verify that the client holds the secret key to their account
+* The client can verify that the server holds the secret key to a particular public key
+* The server can verify that the client holds the secret key to a particular public key
+* The server can verify that the client has control over any account that has the user's public key as a signer
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
+
+Note: The result of the challenge-response and the JWT generated when implementing this SEP will confirm that an authenticating user has possession of a Stellar secret key but does not prove signing capabilities of any Stellar account. A server receiving the JWT that needs proof of control of a Stellar account should verify if the Stellar key authenticated in the JWT is a signer of the account and has a weight that is suitable for the applications operations and purpose. An application wanting to prove that the signer has complete authority of the account may want to verify that the weight of the signer is equal or greater than all thresholds on the account.
 
 ## Authentication Endpoint
 
@@ -54,7 +57,7 @@ In order for browsers-based wallets to validate the CORS headers, as [specified 
 
 ### Challenge
 
-This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
+This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their key. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
 
 #### Request
 
@@ -66,12 +69,13 @@ Request Parameters:
 
 Name      | Type          | Description
 ----------|---------------|------------
-`account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
+`account` | `G...` string | Deprecated. Use `key`.
+`key`     | `G...` string | A Stellar public key that the wallet wishes to authenticate with the server.
 
 Example:
 
 ```
-GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
+GET https://auth.example.com/?key=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
 ```
 
 #### Response
@@ -79,13 +83,13 @@ GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDI
 On success the endpoint must return `200 OK` HTTP status code and a JSON object with these fields:
 
 * `transaction`: an XDR-encoded Stellar transaction with the following:
-  * source account set to server's signing account
+  * source account set to server's public key
   * invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
   * time bounds: `{min: now(), max: now() + 300 }` (we recommend expiration of 5 minutes to give user time to sign transaction)
-  * operations: `manage_data(source: client_account, key: '<anchor name> auth', value: random_nonce())`
+  * operations: `manage_data(source: client_public_key, key: '<anchor name> auth', value: random_nonce())`
     * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
     * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
-  * signature by the web service signing account
+  * signature by the server's key
 * `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing.
 
 Example:
@@ -102,7 +106,7 @@ Every other HTTP status code will be considered an error. For example:
 
 ```json
 {
-   "error": "The provided account has requested too many challenges recently. Try again later."
+   "error": "The provided key has requested too many challenges recently. Try again later."
 }
 ```
 
@@ -129,7 +133,7 @@ To validate the challenge transaction the following steps are performed by the s
 Upon successful validation service responds with a session JWT, containing the following claims:
 
 * `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — a [Uniform Resource Identifier (URI)] for the issuer (`https://example.com` or `https://example.com/G...`)
-* `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
+* `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating client (`G...`)
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
 * `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
@@ -187,6 +191,12 @@ Every other HTTP status code will be considered an error. For example:
    "error": "The provided transaction is not valid"
 }
 ```
+
+## Validating control of a Stellar account
+
+Servers that receive a JWT that proves the holder has control of a secret key must take additional steps to verify that the holder of that secret key has control of a Stellar account. Even if the secret key is the master key for an account it may not have control of an account. For operations relating to a Stellar account a server on receipt of a JWT should verify in addition to the JWT's general validity that:
+
+- the public key in the `sub` has signing authority of the Stellar account at a sufficient threshold.
 
 ## A convention for signatures
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -32,7 +32,6 @@ The flow achieves several things:
 * Both client and server part can be implemented using well-established Stellar libraries
 * The client can verify that the server holds the secret key to a particular public key
 * The server can verify that the client holds the secret key to a particular public key
-* The server can verify that the client has control over any account that has the user's public key as a signer
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
 


### PR DESCRIPTION
### What
Reduce the scope of SEP-10's promises about what it provides to proving possession of a Stellar secret key, and not possession of a Stellar account.

### Why
SEP-10 claims to provide the mechanics to help a server get proof that a client holds a Stellar account, but if a server was to implement only the functionality described in this document it would only be proving that the client is in possession of the secret key, and not any Stellar account.

Proving possession of a secret key doesn't prove any level of control of an account because an account can alter its signers. The master key for an account may have its weight reduced to zero which removes the master key as a signer, and so possession of a master key is not proof of control of an account.

It's important that if implementers of SEP-10 need to prove control of a Stellar account that they take an extra step that is not currently discussed in the document. That extra step is to verify that the key is a signer on the account and that the weight of that signature is sufficient for whatever operations and tasks the implementer is needing to perform.

This change modifies the SEP to acknowledge its limitations and not to try and solve the problem of how to authentication a Stellar account other than to point out that a server receiving the JWT would need to check with the network to confirm if the authenticated Stellar key has control over an account.

This change is important for supporting applications that do not use the master key as a signer, that rotate the signing key for a single signature account, and for accounts that have multiple signers. Implementers of these applications may read SEP-10 thinking it solves the problem of proving possession of an account when it only proves possession of a key.

### Notes

This change does not address how to use SEP-10 with multiple signers. I have another change #473 that is a work-in-progress to address that.

This change does not address how to use SEP-10 in a standard way to generate a token that could be used as proof of control of a Stellar account. I have another change #472 that is a work-in-progress to address that.

### CC

@tomquisel @nebolsin – Original authors of SEP-10.