### PR TITLE
SEP-0010: Add ability to authenticate multiple keys at once

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -12,7 +12,7 @@ Version 1.1.1
 
 ## Simple Summary
 
-This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who has a Stellar secret key, who therefore may have some control of a Stellar account with that key as a signer. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md).
+This SEP defines the standard way for clients such as wallets or exchanges to create authenticated web sessions on behalf of a user who has a Stellar secret key, who therefore may have some control of a Stellar account with that key as a signer. A wallet may want to authenticate with any web service which requires a Stellar account ownership verification, for example, to upload KYC information to an anchor in an authenticated way as described in [SEP-12](sep-0012.md). A client may prove possession of multiple keys in a single flow.
 
 ## Abstract
 
@@ -22,7 +22,7 @@ The authentication flow is as follows:
 
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
 1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
-1. The client signs the transaction using the secret key for the user's key pair
+1. The client signs the transaction using the secret key(s) for the user's key pair(s)
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. If the signature checks out, the server responds with a [JWT](jwt.io) that represents the user's session
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
@@ -31,11 +31,11 @@ The flow achieves several things:
 
 * Both client and server part can be implemented using well-established Stellar libraries
 * The client can verify that the server holds the secret key to a particular public key
-* The server can verify that the client holds the secret key to a particular public key
+* The server can verify that the client holds one or more secret keys for one or more public keys
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
 * The server can chose its own timeout for the user's session
 
-The result of the challenge-response and the JWT generated when implementing this SEP will confirm that an authenticating user has possession of a Stellar secret key but does not prove signing capabilities of any Stellar account. A server receiving the JWT that needs proof of control of a Stellar account should verify if the Stellar key authenticated in the JWT is a signer of the account and has a weight that is suitable for the applications operations and purpose. An application wanting to prove that the signer has complete authority of the account may want to verify that the weight of the signer is equal or greater than all thresholds on the account.
+The result of the challenge-response and the JWT generated when implementing this SEP will confirm that an authenticating user has possession of a Stellar secret key but does not prove signing capabilities of any Stellar account. A server receiving the JWT that needs proof of control of a Stellar account should verify if the Stellar keys authenticated in the JWT are signers of the account and have a total weight that is suitable for the applications operations and purpose. An application wanting to prove that the signers have complete authority of the account may want to verify that the total weight of the signers is equal or greater than all thresholds on the account.
 
 ## Authentication Endpoint
 
@@ -56,7 +56,7 @@ In order for browsers-based wallets to validate the CORS headers, as [specified 
 
 ### Challenge
 
-This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their key. This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
+This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their key(s). This approach is compatible with hardware wallets such as Ledger. The client can also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY` from the server's [`stellar.toml`](sep-0001.md).
 
 #### Request
 
@@ -69,12 +69,18 @@ Request Parameters:
 Name      | Type          | Description
 ----------|---------------|------------
 `account` | `G...` string | Deprecated. Use `key`. Applications should accept and send both parameters until v2.
-`key`     | `G...` string | A Stellar public key that the wallet wishes to authenticate with the server.
+`key`     | `G...` string | A Stellar public key that the wallet wishes to authenticate with the server. May be repeated for multiple keys.
 
-Example:
+Example with single key:
 
 ```
 GET https://auth.example.com/?key=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
+```
+
+Example with multiple keys:
+
+```
+GET https://auth.example.com/?key=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ&key=GBEX5ODB7HKGRYWZV2BBJSUMXKSYI7JPTJIF3OPHBMV6BZWCW67XHTU6
 ```
 
 #### Response
@@ -88,6 +94,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
   * operations: `manage_data(source: client_public_key, key: '<anchor name> auth', value: random_nonce())`
     * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
     * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
+    * Repeated for each client public key.
   * signature by the server's key
 * `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing.
 
@@ -125,14 +132,14 @@ To validate the challenge transaction the following steps are performed by the s
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
 * verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and it's source account is not null;
 * verify that transaction envelope has a correct signature by server's signing key;
-* verify that transaction envelope has a correct signature by the operation's source account;
+* verify that transaction envelope has a correct signatures by the operations' source account;
 * verify that transaction sequenceNumber is equal to zero;
-* use operations's source account to determine the authenticating client and perform any additional service-specific validations.
+* use operations' source account to determine the authenticating client and perform any additional service-specific validations.
 
 Upon successful validation service responds with a session JWT, containing the following claims:
 
 * `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — a [Uniform Resource Identifier (URI)] for the issuer (`https://example.com` or `https://example.com/G...`)
-* `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating client (`G...`)
+* `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating client comma separated for multiple (`G...,G...`)
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token, however 24 hours is recommended (`1530730493`)
 * `jti` (the unique identifier for the JWT, [RFC7519, Section 4.1.7](https://tools.ietf.org/html/rfc7519#section-4.1.7)) — hex-encoded hash of the challenge transaction (`f0e754c6ab988eb5fb2811c2cacc4d3d2aa4334763b8df7285ef341921e2530a`)
@@ -195,7 +202,7 @@ Every other HTTP status code will be considered an error. For example:
 
 Servers that receive a JWT that proves the holder has control of a secret key must take additional steps to verify that the holder of that secret key has control of a Stellar account. Even if the secret key is the master key for an account it may not have control of an account. For operations relating to a Stellar account a server on receipt of a JWT should verify in addition to the JWT's general validity that:
 
-- the public key in the `sub` has signing authority of the Stellar account at a sufficient threshold.
+- the public key(s) in the `sub` have signing authority of the Stellar account at a sufficient weight given the accounts thresholds.
 
 ## A convention for signatures
 


### PR DESCRIPTION
### What
Expand SEP-10 to support a client proving possession of multiple keys in a single challenge-response.

### Why
I'm working on SEP-10 to solve issues with it not providing proof that a user has control of an account, and @tomquisel mentioned that another issue we've had raised in the past is that the SEP also doesn't support proving multiple signers. I've put this draft together to capture how I think we could expand SEP-10 to support multiple signatures but I'm not in a rush to merge this because it's mostly tangential to what I'm focused on at the moment. I mostly want to make sure how I'm writing up #471 and #472 would allow for multiple signatures, and I think they do.

This change is dependent on #471.