### PR TITLE
[SEP-28] Ease burden on new users

### DIFF
--- a/ecosystem/sep-0028.md
+++ b/ecosystem/sep-0028.md
@@ -1,0 +1,36 @@
+## Preamble
+
+```
+SEP: 28
+Title: Ease user burden
+Author: @buhrmi
+Track: Informal
+Status: Draft
+Created: 2019-11-26
+Discussion: (see mailing list, waiting for approval)
+```
+
+## Simple Summary
+Remove the `createAccount` transaction, and trustlines to make Steller more accessible to new users.
+
+## Motivation
+The current solution to depositing an asset in a new users account is as follows
+
+Create a stellar account in their wallet
+Somehow acquire lumens to fund and open the account
+Open a trustline for the asset
+Provider sends payment
+This has a few points of failure, and the burden of asking clients to acquire lumens is too high.
+
+## Abstract
+The proposed solution is to completely remove the `createAccount` transaction and trustlines.
+Any account will be able to hold and unlimited number of assets issued by somebody else, without first creating a trustline.
+
+## Specification
+TODO
+
+## Design Rationale
+TODO
+
+## Security Concerns
+TODO / might increase size of database considerably / spam?

--- a/ecosystem/sep-0028.md
+++ b/ecosystem/sep-0028.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 28
-Title: Ease user burden
+Title: Ease burden on new users
 Author: @buhrmi
 Track: Informal
 Status: Draft

--- a/ecosystem/sep-0028.md
+++ b/ecosystem/sep-0028.md
@@ -16,10 +16,11 @@ Remove the `createAccount` transaction, and trustlines to make Steller more acce
 ## Motivation
 The current solution to depositing an asset in a new users account is as follows
 
-Create a stellar account in their wallet
-Somehow acquire lumens to fund and open the account
-Open a trustline for the asset
-Provider sends payment
+- Create a stellar account in their wallet
+- Somehow acquire lumens to fund and open the account
+- Open a trustline for the asset
+- Provider sends payment
+
 This has a few points of failure, and the burden of asking clients to acquire lumens is too high.
 
 ## Abstract

--- a/ecosystem/sep-0028.md
+++ b/ecosystem/sep-0028.md
@@ -16,10 +16,10 @@ Remove the `createAccount` transaction, and trustlines to make Steller more acce
 ## Motivation
 The current solution to depositing an asset in a new users account is as follows
 
-- Create a stellar account in their wallet
-- Somehow acquire lumens to fund and open the account
-- Open a trustline for the asset
-- Provider sends payment
+1. Create a stellar account in their wallet
+2. Somehow acquire lumens to fund and open the account
+3. Open a trustline for the asset
+4. Provider sends payment
 
 This has a few points of failure, and the burden of asking clients to acquire lumens is too high.
 


### PR DESCRIPTION
Proposing the removal of `createAccount` transaction and trustlines, because they are a huge burden on potential new users