### PR TITLE
SEP-0010: Fix grammar and typos

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -33,7 +33,7 @@ The flow achieves several things:
 * The client can verify that the server holds the secret key to a particular account
 * The server can verify that the client holds the secret key to their account
 * The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key
-* The server can chose its own timeout for the user's session
+* The server can choose its own timeout for the user's session
 
 ## Authentication Endpoint
 
@@ -120,7 +120,7 @@ To validate the challenge transaction the following steps are performed by the s
 * decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
 * verify that transaction source account is equal to the server's signing key;
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
-* verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and it's source account is not null;
+* verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation and its source account is not null;
 * verify that transaction envelope has a correct signature by server's signing key;
 * verify that transaction envelope has a correct signature by the operation's source account;
 * verify that transaction sequenceNumber is equal to zero;


### PR DESCRIPTION
### What
Change use of `chose` to `choose`, and `it's` to `its`.

### Why
Incorrect spelling and use of apostrophe.