### PR TITLE
Update SEP-24 description of the more_info_url parameter

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -552,7 +552,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`more_info_url` | string | A URL the user can visit if they want more information about their transaction's status.
+`more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits and also the status of the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
 `amount_fee` | string | Amount of fee charged by anchor.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -552,7 +552,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits and also the status of the transaction. 
+`more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
 `amount_fee` | string | Amount of fee charged by anchor.


### PR DESCRIPTION
Better describes how wallets should use the more_info_url to also show banking information (for deposits) after the interactive flow is complete.