### PR TITLE
Add sep-6 to sep-24 instructions

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -423,7 +423,6 @@ The response should be a JSON object like:
   "withdraw": {
     "USD": {
       "enabled": true,
-      "authentication_required": true,
       "fee_minimum": 5,
       "fee_percent": 0.5,
       "min_amount": 0.1,
@@ -470,7 +469,6 @@ If `fee_fixed` or `fee_percent` are provided, the total fee is calculated as `(a
 An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
 
 * `enabled`: `true` if the endpoint is available.
-* `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the endpoint.
 
 ## Fee
 
@@ -531,6 +529,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
+`account` | string | (optional) The stellar account ID involved in the transactions. This may not be the account authenticated via SEP-10 in the case that the authenticating account is a signer for the account requested.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) The kind of transaction that is desired. Should be either `deposit` or `withdrawal`.
@@ -696,6 +695,18 @@ For example:
    "error": "This anchor doesn't support the given currency code: ETH"
 }
 ```
+
+## Updating from SEP-6
+
+There is a small set of changes when upgrading from SEP-6 to SEP-24.
+
+1. SEP-24 now requires authentication on all endpoints.  The `authentication_required` flag is removed from the `/info` endpoint since authentication is assumed.
+1. `GET /deposit` and `GET /withdraw` have been replaced with [`POST /transactions/deposit/interactive`](#deposit) and [`POST /transactions/withdraw/interactive`](#withdraw).  This is for security purposes to keep submitted personally identifiable information out of URL query parameters.
+1. Remove the `type` parameter from the `/deposit` and `/withdraw` endpoints as this is information collected in the interactive flow.
+1. Removed `external_extra` transaction property since this should all live in a human readable ` more_info_url`.
+1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
+1. `/transactions` and `/transaction` are now required endpoints.
+1. `Transaction.more_info_url` is now a required property.
 
 ## Implementations
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -50,6 +50,8 @@ The JWT should be included in all requests as request header:
 Authorization: Bearer <JWT>
 ```
 
+In the case of the interactive webapp, since the client cannot add the authorization header, we recommend passing a short-lived JWT via URL query parameters and then using your own backend session scheme for the rest of the interactive flow.  Query parameters can leak, so its important to have this JWT be one-time use, or at least short-lived.
+
 ## Cross-Origin Headers
 
 Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.
@@ -706,7 +708,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.
 1. `Transaction` properties `more_info_url, amount_in, amount_out, amount_fee, and stellar_transaction_id` are now non-optional.
-1. 
+1. It is now recommended to use a one-time use or short-lived JWT in the context of the interactive webapp.
 1. `/transactions` endpoint no longer accepts an `account` query.  The account is pulled from the JWT.
 
 ## Implementations

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -700,12 +700,13 @@ For example:
 There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 1. SEP-24 now requires authentication on all endpoints.  The `authentication_required` flag is removed from the `/info` endpoint since authentication is assumed.
-1. `GET /deposit` and `GET /withdraw` have been replaced with [`POST /transactions/deposit/interactive`](#deposit) and [`POST /transactions/withdraw/interactive`](#withdraw).  This is for security purposes to keep submitted personally identifiable information out of URL query parameters.
+1. `GET /deposit` and `GET /withdraw` have been replaced with [`POST /transactions/deposit/interactive`](#deposit) and [`POST /transactions/withdraw/interactive`](#withdraw).  This is for security purposes to keep submitted personally identifiable information out of URL query parameters.  Instead of passing data through query parameters, it's now expected through `multipart/form-data` POST requests.
 1. Remove the `type` parameter from the `/deposit` and `/withdraw` endpoints as this is information collected in the interactive flow.
 1. Removed `external_extra` transaction property since this should all live in a human readable ` more_info_url`.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.
-1. `Transaction.more_info_url` is now a required property.
+1. `Transaction` properties `more_info_url, amount_in, amount_out, amount_fee, and stellar_transaction_id` are now non-optional.
+1. 
 1. `/transactions` endpoint no longer accepts an `account` query.  The account is pulled from the JWT.
 
 ## Implementations

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -529,7 +529,6 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
-`account` | string | (optional) The stellar account ID involved in the transactions. This may not be the account authenticated via SEP-10 in the case that the authenticating account is a signer for the account requested.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) The kind of transaction that is desired. Should be either `deposit` or `withdrawal`.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -12,7 +12,7 @@ Version 1.0.0
 
 ## Simple Summary
 
-This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.  It is based on, and backwards compatible with, [SEP-0006](sep-0006.md), but only supports the interactive flow, and cleans up or removes confusing artifacts.
+This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.  It is based on, and backwards compatible with, [SEP-0006](sep-0006.md), but only supports the interactive flow, and cleans up or removes confusing artifacts.  If you are updating from SEP-0006 see the [changes from SEP-6](#changes-from-SEP-6) at the bottom of this document.
 
 ## Abstract
 
@@ -696,7 +696,7 @@ For example:
 }
 ```
 
-## Updating from SEP-6
+## Changes from SEP-6
 
 There is a small set of changes when upgrading from SEP-6 to SEP-24.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -706,6 +706,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.
 1. `Transaction.more_info_url` is now a required property.
+1. `/transactions` endpoint no longer accepts an `account` query.  The account is pulled from the JWT.
 
 ## Implementations
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -12,7 +12,7 @@ Version 1.0.0
 
 ## Simple Summary
 
-This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.  It is based on, and backwards compatible with, [SEP-0006](sep-0006.md), but only supports the interactive flow, and cleans up or removes confusing artifacts.  If you are updating from SEP-0006 see the [changes from SEP-6](#changes-from-SEP-6) at the bottom of this document.
+This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.  It is based on [SEP-0006](sep-0006.md), but only supports the interactive flow, and cleans up or removes confusing artifacts.  If you are updating from SEP-0006 see the [changes from SEP-6](#changes-from-SEP-6) at the bottom of this document.
 
 ## Abstract
 


### PR DESCRIPTION
To make it a bit clearer how to update from SEP-6 to SEP-24 i list the changes at the bottom of the document.

I also brought the `account` parameter of the `/transactions` endpoint back.  In the case of a delegated signing situation where you are authenticating with a Signer account, we can't actually pull the account in question from the JWT.