### PR TITLE
Add version: 2 to sep 24

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -408,6 +408,7 @@ The response should be a JSON object like:
 
 ```json
 {
+  "version": 2,
   "deposit": {
     "USD": {
       "enabled": true,
@@ -446,7 +447,7 @@ The response should be a JSON object like:
 }
 ```
 
-The JSON object contains an entry for each asset that the anchor supports for deposit and/or withdrawal.
+The JSON object contains an entry for each asset that the anchor supports for deposit and/or withdrawal.  It also must include `version: 2` to signal to wallets that the anchor is SEP-24 aware, rather than the legacy SEP-6.
 
 #### For each deposit asset, response contains:
 
@@ -701,6 +702,7 @@ For example:
 
 There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
+1. `version: 2` has been added to the `/info` endpoint to help wallets understand whether an anchor supports SEP-24 or SEP-6
 1. SEP-24 now requires authentication on all endpoints.  The `authentication_required` flag is removed from the `/info` endpoint since authentication is assumed.
 1. `GET /deposit` and `GET /withdraw` have been replaced with [`POST /transactions/deposit/interactive`](#deposit) and [`POST /transactions/withdraw/interactive`](#withdraw).  This is for security purposes to keep submitted personally identifiable information out of URL query parameters.  Instead of passing data through query parameters, it's now expected through `multipart/form-data` POST requests.
 1. Remove the `type` parameter from the `/deposit` and `/withdraw` endpoints as this is information collected in the interactive flow.


### PR DESCRIPTION
Currently wallets are unsure whether any anchor supports SEP-6 or SEP-24, and need to hardcode that.  Now we add a `version: 2` flag to the /info endpoint to signal that the anchor supports all the new SEP-24 protocols.  If it's missing (and you haven't hardcoded that they support sep24 in your wallet) you can assume its still sep6.