### PR TITLE
[SEP24] Don't require auth for /info

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Authentication
 
-As stated, Anchors must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.  Clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints that provide user data.  Currently `/info` should be unauthenticated, but all other endpoints will require a token.
+As stated, Anchors must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.  Clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints that provide user data.  `/info` should be unauthenticated, but all other endpoints will require a token.
 
 The JWT should be included in all requests as request header:
 ```

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Authentication
 
-As stated, Anchors must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.  Clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints.
+As stated, Anchors must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.  Clients must submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow to all API endpoints that provide user data.  Currently `/info` should be unauthenticated, but all other endpoints will require a token.
 
 The JWT should be included in all requests as request header:
 ```


### PR DESCRIPTION
Clarify that the /info endpoint, which provides publicly accessible information, shouldn't require an auth token, but all other endpoints should.