### PR TITLE
SEP-10: Bump version to v2 for multi-sig support

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.co
 Status: Active
 Created: 2018-07-31
 Updated: 2020-01-29
-Version 1.3.0
+Version 2.0.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
### What
Bump the version of SEP-10 to v2.0.0.

### Why
In #489 I merged changes that added multi-sig support. While the majority of Stellar accounts will be unaffected by this because they use a single signer (the master key) or they at least have the master key have sufficient weight to meet any threshold, there are some accounts using third party signing services that act like a two-factor auth service, e.g. StellarGuard and Lobstr Vault to name a couple.

While the change that was merged is backwards compatible for accounts operating with servers and wallets that implemented the intended behavior of SEP-10, some accounts will be affected by this change when servers and wallets implement it and servers will benefit from implementing the change in a way that they support both the previous verification logic and the new logic for a limited time.

These backwards incompatible changes were discussed on the original PR and culminated in https://github.com/stellar/stellar-protocol/pull/489#issuecomment-576403467.

Because of an impact to some Stellar accounts I think bumping the major version would be communicate the impact of this change, and why a server implementing the change might choose to continue to support the previous version of verification for a limited time.