### PR TITLE
Add amount argument to interactive URL parameter list

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -304,6 +304,7 @@ The basic parameters are summarized in the table below.
 Name | Type | Description
 -----|------|------------
 `callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`.
+`amount`  | number | (optional) A whole or decimal number that will be used to pre-populate the Amount field. The amount must be valid for the asset being transferred. Even if the Amount field is not rendered in the initial response, the `amount` passed should pre-populate the field when it is eventually displayed.
 
 **`callback` details**
 


### PR DESCRIPTION
In reaction to this issue: #527 

Referenced under the **Interactive withdrawal** section:
> If an amount parameter is provided to the interactive URL, make sure to use that value to pre-populate the amount on the interactive form, since this greatly improves the user experience.

However, the `amount` parameter isn't listed as a parameter for the interactive URL. I added it to make it more clear that this is permitted.