### PR TITLE
[SEP24] remove vestigial note about sep6

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -91,7 +91,6 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * Handle the [special cases](#special-cases), they're relatively common.
 * **For `/transactions/withdraw/interactive`**
     * Handle the interactive flow, handle it as [described in detail](#2-interactive-customer-information-needed).
-    * Do not handle the non-interactive or status responses to the `/transactions/withdraw/interactive` request.  These may be from the old [SEP6](sep-0006.md) protocol.
     * When the transaction status becomes `pending_user_transfer_start` send the required payment as described in the interactive webapp callback or the `/transaction` endpoint.  This can be a `payment` or `path_payment` operation.  Sending payments via `account_merge` or `create_account` is not supported at this time.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so exchange rate fluctuations might require withdrawal values to slightly vary from the originally provided `amount`. Anchors are instructed to accept a variation of ±10% between the informed `amount` and the actual value sent to the anchor's Stellar account. The withdrawn amount will be adjusted accordingly.
 * **Transaction history**


### PR DESCRIPTION
Since sep24 now uses a completely separate endpoint from sep6 we no longer need to add this confusing note about ignoring sep6 responses.