### PR TITLE
Add changes to SEP-0018 according to the protocol team discussion

### DIFF
--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -6,6 +6,7 @@ Title: Data Entry Namespaces
 Author: MisterTicot <mister.ticot@cosmic.plus>
 Status: Draft
 Created: 2018-10-26
+Updated: 2020-02-18
 ```
 
 ## Simple Summary
@@ -35,7 +36,7 @@ libraries or utilities dealing with data entries.
 ## Specification
 
 Namespace hierarchy is encoded in the key using one or more terms separated by
-dots. Terms are made of lowercase letters, underscore and numbers and mustn't
+dots. Terms consist of lowercase letters, underscore, numbers, and mustn't
 start with a number.
 
 **Examples**
@@ -63,27 +64,30 @@ must be ignored.
 
 **Example: same data tree in JSON**
 
-```js
+```json
 {
-  config: {
-    two_factor: ...,
-    multisig: {
-      server: ...,
-      network: ...,
-      key: ...
+  "config": {
+    "two_factor": "",
+    "multisig": {
+      "server": "",
+      "network": "",
+      "key": ""
     }
   },
-  profile: {
-    name: ...,
-    language: ...
+  "profile": {
+    "name": "",
+    "language": ""
   },
-  wallet: {
-    btc: ...,
-    eth: ...
+  "wallet": {
+    "btc": "",
+    "eth": ""
   }
 }
 ```
 
+The "config" root namespace is reserved exclusively for SEP standards –
+applications shouldn't adopt values and sub-namespaces defined under this
+namespace for vendor-specific use-cases.
 
 ## Rationale
 
@@ -94,7 +98,7 @@ that is valid across a broad range of programming languages.
 
 This SEP uses JavaScript syntax because it is a well-known language. It is also
 familiar to anybody using JSON, which is a format widely used to pass data, and
-the one already used by horizon API.
+the one already used by Horizon API.
 
 Parsing the data tree must lead to the same namespace/key/value structure
 regardless of the programming language being used. This is the reason why term
@@ -133,23 +137,15 @@ data tree and they are still accessible as account data entries.
 Introduction of standard utilities to manage the data tree will provide
 an incentive to comply with the proposed semantic.
 
-## Reference utilities
+## Reference Implementation
 
-JavaScript:
+Reference JavaScript parser implementation can be found
+[here](https://github.com/MisterTicot/stellar-draft-0005/blob/master/tree.js).
+It operates with a tree-like structure representing namespaces and
+subnamespaces.
 
-* **Repository:** https://github.com/MisterTicot/stellar-draft-0005
-* **Minimal implementation:**
-  [flat.js](https://github.com/MisterTicot/stellar-draft-0005/blob/master/flat.js)
-  parse account data entries as a list of keys. It takes 45 lines of code so
-  it's nice for being compact.
-* **Recommended implementation:**
-  [tree.js](https://github.com/MisterTicot/stellar-draft-0005/blob/master/tree.js),
-  parse account data entries as a tree. It takes 70 lines of code. It is not
-  as compact and efficient, but it is dev-friendly.
+This implementation exposes the following methods:
 
-Both implementations expose the following methods:
-
-* `accountData.read(account, [convert])` parse valid namespace entries from
-  **account** and convert them to the desired format.
-* `accountData.write(account, accountData)` generate a transaction that change
-  **account** data entries to reflect **accountData**.
+* `accountData.read(account)` - parse valid namespace entries from an account.
+* `accountData.write(account, dataTree)` - generate a transaction that
+reflects account data entry changes.


### PR DESCRIPTION
Discussion follow-up:
- Removed the reference to a "flat.js" parser implementation and optional `convert` parser argument. The standard should provide a single, unified implementation that parses namespaces hierarchy and values unambiguously..
- Added the remark about the reserved "config" root namespace to prevent potential name conflicts in the future.

@MisterTicot Could you please review the changes and update the reference implementation to remove `convert` argument from `read()` method? It should internally use base64 converter that returns raw `Buffer` for values to avoid encoding conflicts across applications and different parser implementations. Horizon API always returns base64-encoded values.

cc @tomerweller 