### PR TITLE
SEP-0011: Add headings to values sections

### DIFF
--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -111,23 +111,43 @@ than a constant factor larger than the size of the txrep).
 
 Most XDR types are rendered using C syntax. Specifically:
 
-  - All integers (signed and unsigned, 32- and 64-bit) are represented as C integers (decimal by default, but prefix `0x` can be used for hex and `0` for octal).
+#### Integers
 
-  - `bool` values are `true` or `false`
+All integers (signed and unsigned, 32- and 64-bit) are represented as C integers (decimal by default, but prefix `0x` can be used for hex and `0` for octal).
 
-  - Enums are represented by the bare keyword of the value.  They can also be specified numerically as "Type#Number" (e.g., `MemoType#3` is equivalent to `MEMO_HASH`).
+#### Booleans
 
-  - `string` values are represented as double-quoted interpreted string literals, in which non-ASCII bytes are represented with hex escapes (`"\xff"`), the `"` and `\` characters can be escaped with another `\` (e.g., `"\\"`), and `\n` designates a newline.
+`bool` values are `true` or `false`
 
-  - `opaque` values are represented as an unquoted hexadecimal string (using lower-case case `a`...`f`) with an even number of digits.  An exception is that the 0-length opaque vector is represented as "0" (a single digit).  Implementations are encouraged to add the comment "bytes" so that it reads "0 bytes" to further distinguish the 0-length vector from the vector with a single byte 0x00 (rendered "00").
+#### Enums
+
+Enums are represented by the bare keyword of the value.  They can also be specified numerically as "Type#Number" (e.g., `MemoType#3` is equivalent to `MEMO_HASH`).
+
+#### Strings
+
+`string` values are represented as double-quoted interpreted string literals, in which non-ASCII bytes are represented with hex escapes (`"\xff"`), the `"` and `\` characters can be escaped with another `\` (e.g., `"\\"`), and `\n` designates a newline.
+
+#### Opaque
+
+`opaque` values are represented as an unquoted hexadecimal string (using lower-case case `a`...`f`) with an even number of digits.  An exception is that the 0-length opaque vector is represented as "0" (a single digit).  Implementations are encouraged to add the comment "bytes" so that it reads "0 bytes" to further distinguish the 0-length vector from the vector with a single byte 0x00 (rendered "00").
+
+#### Aggregate Values
 
 A few aggregate values are special-cased:
 
-  - The `Asset` type is rendered as `native` (or any string up to 12 characters not containing an unescaped colon) for the native asset, and a string of the form "Code:IssuerAccountID" for issued assets.  "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).  The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash.  Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
+##### Asset
 
-  - The `asset` field of `AllowTrustOp` is rendered the same as the Code in `Asset`, only without the trailing ":IssuerAccountID" (since the issuer is the `sourceAccount` of the operation).
+The `Asset` type is rendered as `native` (or any string up to 12 characters not containing an unescaped colon) for the native asset, and a string of the form "Code:IssuerAccountID" for issued assets.  "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).  The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash.  Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
 
-  - `PublicKey` and `SignerKey` are rendered as unquoted strings in strkey format, described below.
+##### AllowTrustOp
+
+The `asset` field of `AllowTrustOp` is rendered the same as the Code in `Asset`, only without the trailing ":IssuerAccountID" (since the issuer is the `sourceAccount` of the operation).
+
+##### PublicKey and SignerKey
+
+`PublicKey` and `SignerKey` are rendered as unquoted strings in strkey format, described below.
+
+#### Others
 
 Any fields in the XDR `TransactionEnvelope` structure that are not specified in a txrep description are to be interpreted as false for `bool`, zero (for numeric values, enums, fixed-length `opaque`), or zero-length (for strings, variable-length arrays, and variable-length `opaque`).  The `_present` pseudo-selector, if unspecified, defaults to true if any field or value of the pointer's data structure is specified, and otherwise defaults to `_false`.
 


### PR DESCRIPTION
### What
Add headings to the Values section of the document with each type and unique encoding situation getting a heading.

### Why
I find myself frequently needing to link to sections in this document, specifically the section about how to encode `Asset` as a string. Without headings it is not possible to link directly to the discussion about the `Asset` type and I can only instead link people to the section about values and hope that they read through to find what I'm referencing. It makes it easier to share concepts and behaviors defined in this SEP if they can be easily linked to.