### PR TITLE
SEP-0011: Break up the paragraph about Assets

### DIFF
--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -137,7 +137,13 @@ A few aggregate values are special-cased:
 
 ##### Asset
 
-The `Asset` type is rendered as `native` (or any string up to 12 characters not containing an unescaped colon) for the native asset, and a string of the form "Code:IssuerAccountID" for issued assets.  "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).  The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash.  Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
+The `Asset` type is rendered as a string in one of two forms:
+  - `native` (or any string up to 12 characters not containing an unescaped colon) for the native asset.
+  - `Code:IssuerAccountID` for issued assets.
+
+    "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).
+
+    The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash. Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
 
 ##### AllowTrustOp
 

--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -143,7 +143,7 @@ The `Asset` type is rendered as a string in one of two forms:
 
     "Code" must consist of printable ASCII characters (octets 0x21 through 0x7e).
 
-    The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash. Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
+    The sequence `\x` introduces a hex escape sequence, e.g., `\x00` to introduce a 0-valued byte.  Otherwise, `\` escapes the next character, so `\\` is required to introduce a backslash. Stellar disallows assets of type `ASSET_TYPE_CREDIT_ALPHANUM12` that have fewer than 5 bytes, but such assets can be represented in binary XDR, and so in txrep are rendered with trailing `\x00` (escaped NUL bytes) to as to make the length 5---e.g., the 12-byte asset code `ABC` is rendered `ABC\x00\x00`. Note that stellar-core disallows non ASCII bytes in `AssetCode` fields, so the primary use of this feature is to construct or examine invalid transaction test cases.
 
 ##### AllowTrustOp
 


### PR DESCRIPTION
### What
Break up the paragraph about assets, with the two forms that an asset can be rendered in being listed as dot points.

### Why
The paragraph is pretty big and you need to dig into it to identify what the most important parts are to find the different forms of rendering.

Breaking the paragraph up makes it easy to glance, see that there are two forms, and to skip past the additional details that for the most part are only relevant to debugging.