### PR TITLE
SEP-0018: Distill down to focus on namespace syntax and definition

### DIFF
--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -89,4 +89,4 @@ profile.language.region = US
 The following namespaces have special meanings and their use should be reserved
 for those meanings:
 
-- `config`: Fields defined for use in SEP standards.
+- `config`: Keys defined to define behaviors or limitations of an account, for use in SEP standards.

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -3,7 +3,7 @@
 ```
 SEP: 0018
 Title: Data Entry Namespaces
-Author: MisterTicot <mister.ticot@cosmic.plus>, Leigh McCulloch <@leighmcculloch>
+Author: MisterTicot <mister.ticot@cosmic.plus>
 Status: Draft
 Created: 2018-10-26
 Updated: 2020-02-20

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -3,9 +3,11 @@
 ```
 SEP: 0018
 Title: Data Entry Namespaces
-Author: MisterTicot <mister.ticot@cosmic.plus>
+Author: MisterTicot <mister.ticot@cosmic.plus>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2018-10-26
+Updated: 2020-02-20
+Version: 0.2.0
 ```
 
 ## Simple Summary
@@ -16,7 +18,7 @@ Defines a standard syntax to represent namespaces in data entries.
 
 This SEP provides a standard way to represent
 [namespaces](https://en.wikipedia.org/wiki/Namespace) into Stellar accounts
-data entries, and guidelines about how to parse them and handle edge-cases.
+data entries.
 
 ## Motivation
 
@@ -24,10 +26,7 @@ As a generic mechanism to store key/value pairs on the ledger, data entries
 accept a very wide range of use cases. If each actor uses it following its
 syntax, it will lead to a confusing experience and ultimately to name conflicts.
 
-Introducing namespaces allow to hierarchize and organize data, in such a way
-that sorting the key/value entries will result in a readable output even when
-using them for various purpose on the same account. It also helps to prevent
-names clash.
+Introducing namespaces allow to hierarchize and organize data.
 
 This SEP provides guidelines for other SEPs, external applications as well as
 libraries or utilities dealing with data entries.
@@ -41,10 +40,7 @@ start with a number.
 **Examples**
 
 ```
-config.two_factor
-config.multisig.server
-config.multisig.network
-config.multisig.key
+config.memo_required
 profile.name
 profile.language
 wallet.btc
@@ -54,47 +50,12 @@ wallet.eth
 * **Term REGEXP:** `[_a-z][_a-z0-9]*`
 * **Key REGEXP:** `[_a-z][_a-z0-9]*(\.[_a-z][_a-z0-9]*)*`
 
-When parsing the data tree in a given programming language, keys that don't
-respect this syntax must be ignored and valid entries must be hierarchized in
-an adequate data structure. If a term is used both as an identifier and a
-namespace, a warning must be thrown by the parser and the identifier value
-must be ignored.
-
-
-**Example: same data tree in JSON**
-
-```js
-{
-  config: {
-    two_factor: ...,
-    multisig: {
-      server: ...,
-      network: ...,
-      key: ...
-    }
-  },
-  profile: {
-    name: ...,
-    language: ...
-  },
-  wallet: {
-    btc: ...,
-    eth: ...
-  }
-}
-```
-
-
 ## Rationale
 
 **Syntax**
 
 The namespace syntax had to be familiar, and terms have to be written in a way
 that is valid across a broad range of programming languages.
-
-This SEP uses JavaScript syntax because it is a well-known language. It is also
-familiar to anybody using JSON, which is a format widely used to pass data, and
-the one already used by horizon API.
 
 Parsing the data tree must lead to the same namespace/key/value structure
 regardless of the programming language being used. This is the reason why term
@@ -104,52 +65,28 @@ interpretation between case-sensitive and case-insensitive languages.
 
 **Identifier/namespace conflict**
 
-This conflict happens when a term is used both as an identifier and a namespace,
-such as:
+Conflict occurs when a term is used both as an identifier and a namespace. If
+for example a data entry with key `profile.language` exists, and a data entry
+with key `profile.language.region` exists, an application parsing the data
+entries into internal types or data structure will struggle to reconcile how to
+store the value assigned to `profile.language`.
 
 ```
-config.multisig = 1234
-config.multisig.server = https://myserver.org
+profile.language = en
+profile.language.region = US
 ```
 
-This situation is can be hard or impossible to translate into a data structure,
-depending on the language.
+Applications should avoid defining namespaces that are also identifiers by
+ensuring namespaces are not given values. Example:
 
-There are three ways to solve it:
+```
+profile.language.language = en
+profile.language.region = US
+```
 
-* Ignore all related definitions
-* Ignore the identifier definition
-* Ignore the definitions under that namespace
+## Namespace Registry
 
-While no solution is ideal, the last one seems better as at least it prevents
-the shortcutting of a whole branch.
+The following namespaces have special meanings and their use should be reserved
+for those meanings:
 
-## Backwards Compatibility
-
-This SEP doesn't introduce incompatibilities: the keys that are not formatted
-following the defined syntax rules are simply not considered as part of the
-data tree and they are still accessible as account data entries.
-
-Introduction of standard utilities to manage the data tree will provide
-an incentive to comply with the proposed semantic.
-
-## Reference utilities
-
-JavaScript:
-
-* **Repository:** https://github.com/MisterTicot/stellar-draft-0005
-* **Minimal implementation:**
-  [flat.js](https://github.com/MisterTicot/stellar-draft-0005/blob/master/flat.js)
-  parse account data entries as a list of keys. It takes 45 lines of code so
-  it's nice for being compact.
-* **Recommended implementation:**
-  [tree.js](https://github.com/MisterTicot/stellar-draft-0005/blob/master/tree.js),
-  parse account data entries as a tree. It takes 70 lines of code. It is not
-  as compact and efficient, but it is dev-friendly.
-
-Both implementations expose the following methods:
-
-* `accountData.read(account, [convert])` parse valid namespace entries from
-  **account** and convert them to the desired format.
-* `accountData.write(account, accountData)` generate a transaction that change
-  **account** data entries to reflect **accountData**.
+- `config`: Fields defined for use in SEP standards.


### PR DESCRIPTION
### What
Distill SEP-18 to focus solely on namespace syntax and definition, and
leave parsing and interpretation of, parsing, and rendering of a set of
data entries to applications and/or a future SEP.

### Why
The main gains we get from @MisterTicot's SEP-18 immediately is for
other SEPs to define data entries that do not collide with other
applications by placing them in a namespace that other applications know
should be avoided. The SEP also attempts to define how to parse the data
entries into trees, but this can be implemented in many different ways
and has unique challenges that deserve being the focus of their own SEP.
It should be quite easy to build another SEP on-top of SEP-18.

@MisterTicot @orbitlens @tomerweller @tomquisel 