### PR TITLE
Minor reserve logic fix, CreateClaimableBalanceOp

### DIFF
--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -424,7 +424,7 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
 1. Fail with `CREATE_CLAIMABLE_BALANCE_LOW_RESERVE` if the `sourceAccount` does
    not have at least `claimants.size() * baseReserve` available balance of
    native asset
-2. Deduct `max(1, claimants.size()-1) * baseReserve` of native asset from
+2. Deduct `claimants.size() * baseReserve` of native asset from
    `sourceAccount`
 3. Fail with `CREATE_CLAIMABLE_BALANCE_NO_TRUST` if the `sourceAccount` does not
    have a trust line for `asset`


### PR DESCRIPTION
@jonjove I think the reserve should just be `claimants.size() * baseReserve`, but please close this out if I missed something.