### PR TITLE
SEP-0018: Add canonical paths & restrictions

### DIFF
--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -6,8 +6,8 @@ Title: Data Entry Namespaces
 Author: MisterTicot <mister.ticot@cosmic.plus>
 Status: Active
 Created: 2018-10-26
-Updated: 2020-02-20
-Version: 0.2.0
+Updated: 2020-02-26
+Version: 0.3.0
 ```
 
 ## Simple Summary
@@ -50,6 +50,20 @@ wallet.eth
 * **Term REGEXP:** `[_a-z][_a-z0-9]*`
 * **Key REGEXP:** `[_a-z][_a-z0-9]*(\.[_a-z][_a-z0-9]*)*`
 
+## Namespace Registry
+
+To guarantee interoperability and avoid naming conflicts, namespaces must be
+used as defined in SEP documents.
+
+- `app`: Space dedicated to vendor-specific keys. For example, "example.org" can
+  define its keys under `app.example_org`.
+- `config`: Space dedicated to ecosystem-wide configuration. Those are values
+  that impact software logic.
+  - `config.memo_required`: [SEP29](sep-0029.md)
+  - `config.multisig`: [SEP19](sep-0019.md)
+- `profile`: Space dedicated to account identification.
+- `wallet`: Space dedicated to external ledger addresses.
+
 ## Rationale
 
 **Syntax**
@@ -83,10 +97,3 @@ ensuring namespaces are not given values. Example:
 profile.language.language = en
 profile.language.region = US
 ```
-
-## Namespace Registry
-
-The following namespaces have special meanings and their use should be reserved
-for those meanings:
-
-- `config`: Keys defined to define behaviors or limitations of an account, for use in SEP standards.

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -40,11 +40,9 @@ start with a number.
 **Examples**
 
 ```
+app.example_org.id
 config.memo_required
-profile.name
-profile.language
-wallet.btc
-wallet.eth
+config.multisig.coordinator
 ```
 
 * **Term REGEXP:** `[_a-z][_a-z0-9]*`
@@ -83,20 +81,20 @@ interpretation between case-sensitive and case-insensitive languages.
 **Identifier/namespace conflict**
 
 Conflict occurs when a term is used both as an identifier and a namespace. If
-for example a data entry with key `profile.language` exists, and a data entry
-with key `profile.language.region` exists, an application parsing the data
-entries into internal types or data structure will struggle to reconcile how to
-store the value assigned to `profile.language`.
+for example a data entry with key `app.example_org.language` exists, and a data
+entry with key `app.example_org.language.region` exists, an application parsing
+the data entries into internal types or data structure will struggle to
+reconcile how to store the value assigned to `app.example_org.language`.
 
 ```
-profile.language = en
-profile.language.region = US
+app.example_org.language = en
+app.example_org.language.region = US
 ```
 
 Applications should avoid defining namespaces that are also identifiers by
 ensuring namespaces are not given values. Example:
 
 ```
-profile.language.language = en
+app.example_org.language.language = en
 profile.language.region = US
 ```

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -56,8 +56,8 @@ To guarantee interoperability and avoid naming conflicts, vendor-specific data
 must live under their reserved namespace:
 
 - `app`: Space dedicated to vendor-specific keys. Keys must be defined under
-  `app.{subdomain}`, with subdomain's dot(s) replaced by underscores. For
-  example, "example.org" defines its keys under `app.example_org`.
+  `app.{domain}`, with dot(s) replaced by underscores. For example,
+  "example.org" defines its keys under `app.example_org`.
 
 The other namespaces must be used according to their SEP documents:
 

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -3,11 +3,11 @@
 ```
 SEP: 0018
 Title: Data Entry Namespaces
-Author: MisterTicot <mister.ticot@cosmic.plus>
-Status: Active
+Author: MisterTicot (@misterticot), Leigh McCulloch (@leighmcculloch)
+Status: Draft
 Created: 2018-10-26
-Updated: 2020-06-09
-Version: 0.5.0
+Updated: 2020-06-30
+Version: 0.3.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -6,8 +6,8 @@ Title: Data Entry Namespaces
 Author: MisterTicot <mister.ticot@cosmic.plus>
 Status: Active
 Created: 2018-10-26
-Updated: 2020-02-26
-Version: 0.3.0
+Updated: 2020-05-06
+Version: 0.4.0
 ```
 
 ## Simple Summary
@@ -52,17 +52,24 @@ wallet.eth
 
 ## Namespace Registry
 
-To guarantee interoperability and avoid naming conflicts, namespaces must be
-used as defined in SEP documents.
+To guarantee interoperability and avoid naming conflicts, vendor-specific data
+must live under their reserved namespace:
 
-- `app`: Space dedicated to vendor-specific keys. For example, "example.org" can
-  define its keys under `app.example_org`.
+- `app`: Space dedicated to vendor-specific keys. Keys must be defined under
+  `app.{subdomain}`, with subdomain's dot(s) replaced by underscores. For
+  example, "example.org" defines its keys under `app.example_org`.
+
+The other namespaces must be used according to their SEP documents:
+
 - `config`: Space dedicated to ecosystem-wide configuration. Those are values
   that impact software logic.
   - `config.memo_required`: [SEP29](sep-0029.md)
   - `config.multisig`: [SEP19](sep-0019.md)
 - `profile`: Space dedicated to account identification.
 - `wallet`: Space dedicated to external ledger addresses.
+
+
+
 
 ## Rationale
 

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -4,7 +4,7 @@
 SEP: 0018
 Title: Data Entry Namespaces
 Author: MisterTicot (@misterticot), Leigh McCulloch (@leighmcculloch)
-Status: Draft
+Status: Active
 Created: 2018-10-26
 Updated: 2020-06-30
 Version: 0.3.0

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -96,5 +96,5 @@ ensuring namespaces are not given values. Example:
 
 ```
 app.example_org.language.language = en
-profile.language.region = US
+app.example_org.language.region = US
 ```

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -53,15 +53,15 @@ config.multisig.coordinator
 To guarantee interoperability and avoid naming conflicts, app-specific data
 must live under their reserved namespace:
 
-- `app`: Space dedicated to app-specific keys. Keys must be defined under
+- `app`: Namespace available to app-specific keys. Keys must be defined under
   `app.{domain}`, with dot(s) replaced by underscores. For example,
   "example.org" defines its keys under `app.example_org`.
 
-The other namespaces must be used according to their SEP documents. Whenever a
-SEP makes use of account data entries, it must be listed here:
+Other namespaces have special meaning according to their SEP documents.
+When a SEP makes use of account data entries, it must be listed here and
+referenced:
 
-- `config`: Space dedicated to ecosystem-wide configuration. Those are values
-  that impact software logic.
+- `config`: Namespace available for use by ecosystem-wide configuration:
   - `config.memo_required`: [SEP29](sep-0029.md)
   - `config.multisig`: [SEP19](sep-0019.md)
 

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -52,10 +52,10 @@ wallet.eth
 
 ## Namespace Registry
 
-To guarantee interoperability and avoid naming conflicts, vendor-specific data
+To guarantee interoperability and avoid naming conflicts, app-specific data
 must live under their reserved namespace:
 
-- `app`: Space dedicated to vendor-specific keys. Keys must be defined under
+- `app`: Space dedicated to app-specific keys. Keys must be defined under
   `app.{domain}`, with dot(s) replaced by underscores. For example,
   "example.org" defines its keys under `app.example_org`.
 

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -6,8 +6,8 @@ Title: Data Entry Namespaces
 Author: MisterTicot <mister.ticot@cosmic.plus>
 Status: Active
 Created: 2018-10-26
-Updated: 2020-05-06
-Version: 0.4.0
+Updated: 2020-06-09
+Version: 0.5.0
 ```
 
 ## Simple Summary
@@ -59,17 +59,13 @@ must live under their reserved namespace:
   `app.{domain}`, with dot(s) replaced by underscores. For example,
   "example.org" defines its keys under `app.example_org`.
 
-The other namespaces must be used according to their SEP documents:
+The other namespaces must be used according to their SEP documents. Whenever a
+SEP makes use of account data entries, it must be listed here:
 
 - `config`: Space dedicated to ecosystem-wide configuration. Those are values
   that impact software logic.
   - `config.memo_required`: [SEP29](sep-0029.md)
   - `config.multisig`: [SEP19](sep-0019.md)
-- `profile`: Space dedicated to account identification.
-- `wallet`: Space dedicated to external ledger addresses.
-
-
-
 
 ## Rationale
 


### PR DESCRIPTION
Defines a few canonical namespaces. The general idea is that root namespaces are tied to a function while child namespace may be tied to a scope, similarly to `/etc`, `/home` & `/lib` in Unix systems.

`profile` & `wallet` are not being used yet but are mentioned in case someone need them for future SEP. 