### PR TITLE
[SEP-1] Add SEP-24 Transfer Server Field

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -52,6 +52,7 @@ NETWORK_PASSPHRASE | string | The passphrase for the specific [Stellar network](
 FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) Federation Protocol
 AUTH_SERVER | uses `https://` | The endpoint used for [SEP-3](sep-0003.md) Compliance Protocol
 TRANSFER_SERVER | uses `https://` | The server used for [SEP-6](sep-0006.md) Anchor/Client interoperability
+TRANSFER_SERVER_SEP0024 | uses `https://` | The server used for [SEP-24](sep-0024.md) Anchor/Client interoperability 
 KYC_SERVER | uses `https://` | The server used for [SEP-12](sep-0012.md) Anchor/Client customer info transfer
 WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authentication](sep-0010.md)
 SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.md) Compliance Protocol and [SEP-10](sep-0010.md) Authentication Protocol

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -132,7 +132,7 @@ If the given account does not exist, or if the account doesn't have a trust line
 ### Request
 
 ```
-POST TRANSFER_SERVER/transactions/deposit/interactive
+POST TRANSFER_SERVER_SEP0024/transactions/deposit/interactive
 Content-Type: multipart/form-data
 ```
 
@@ -198,7 +198,7 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ### Request
 
 ```
-POST TRANSFER_SERVER/transactions/withdraw/interactive
+POST TRANSFER_SERVER_SEP0024/transactions/withdraw/interactive
 Content-Type: multipart/form-data
 ```
 
@@ -221,7 +221,7 @@ Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make 
 Example:
 
 ```
-POST TRANSFER_SERVER/transactions/withdraw/interactive
+POST TRANSFER_SERVER_SEP0024/transactions/withdraw/interactive
 Content-Type: multipart/form-data
 
 asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
@@ -387,12 +387,12 @@ For example:
 
 ## Info
 
-Allows an anchor to communicate basic info about what their `TRANSFER_SERVER` supports to wallets and clients.
+Allows an anchor to communicate basic info about what their `TRANSFER_SERVER_SEP0024` supports to wallets and clients.
 
 ### Request
 
 ```
-GET TRANSFER_SERVER/info
+GET TRANSFER_SERVER_SEP0024/info
 ```
 
 Request parameters:
@@ -471,7 +471,7 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 The fee endpoint allows an anchor to report the fee that would be charged for a given deposit or withdraw operation. This is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed`, `fee_percent` or `fee_minimum` fields in the `/info` response, then an anchor should not implement this endpoint.
 
 ```
-GET TRANSFER_SERVER/fee
+GET TRANSFER_SERVER_SEP0024/fee
 ```
 
 Request parameters:
@@ -517,7 +517,7 @@ For example:
 The transaction history endpoint helps anchors enable a better experience for users using an external wallet. With it, wallets can display the status of deposits and withdrawals while they process and a history of past transactions with the anchor. It's only for transactions that are deposits to or withdrawals from the anchor.  It returns a list of transactions from the account encoded in the authenticated JWT.
 
 ```
-GET TRANSFER_SERVER/transactions
+GET TRANSFER_SERVER_SEP0024/transactions
 ```
 
 Request parameters:
@@ -642,7 +642,7 @@ For example:
 The transaction endpoint enables clients to query/validate a specific transaction at an anchor.
 
 ```
-GET TRANSFER_SERVER/transaction
+GET TRANSFER_SERVER_SEP0024/transaction
 ```
 
 Request parameters:
@@ -661,7 +661,7 @@ Name | Type | Description
 -----|------|------------
 `transaction` | object | The transaction that was requested by the client.
 
-The `transaction` object should be of the same form as the objects returned by the `TRANSFER_SERVER/transactions` endpoint.
+The `transaction` object should be of the same form as the objects returned by the `TRANSFER_SERVER_SEP0024/transactions` endpoint.
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -29,7 +29,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Prerequisites
 
-* An anchor must define the location of their `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
+* An anchor must define the location of their `TRANSFER_SERVER_SEP0024` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.
 
 ## API Endpoints


### PR DESCRIPTION
Add "TRANSFER_SERVER_SEP0024" to the SEP-1 Account Information fields. This can be used by wallets to differentiate between anchors (or on/off ramps) that implement SEP-0006 and SEP-0024.