### PR TITLE
[SEP24] Add explicit amount field to api

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -106,14 +106,12 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
     * Some wallets may include other fields indicated in [SEP-9](sep-0009.md) as POST parameters added to the `/transactions/deposit/interactive` or `/transactions/withdraw/interactive` endpoints.  These can be stored and used to pre-populate fields in the interactive flow.  This is optional for the wallet to provide and optional for anchors to respect, but it does create a much nicer user experience.
     * Include the `id` field in your response to `/transactions/deposit/interactive` and `/transactions/withdraw/interactive` so the wallet can check up on the status of the transaction if it wants.
     * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction when the user visits the URL.
-    * Make sure to pass along the `amount` to the popup URL, especially on the `/transactions/withdraw/interactive` flow.
     * We recommend you use [SEP-10](#authentication) for authentication in the interactive flow and do not separately prompt for password to achieve a good user experience (although asking for MFA when confirming a transaction or requiring email confirmation is reasonable).  Putting a one time use token or quickly expiring JWT in the URL returned to the client is a good way to keep continuity between authenticated API calls and fresh interactive flow requests.
     * Test your interactive flows on mobile. They should be easy to use on all devices: make them responsive, handle auto-fill well, and do smart keyboard management on mobile devices.
 * **Interactive deposit**
     * Your interactive deposit popup will do everything needed to initiate the deposit without the user needing to interact with the wallet further. It should either directly initiate the deposit, or handle displaying information (such as reference number or bank account number) that the user will need to complete their deposit.
 * **Interactive withdrawal**
     * Your withdrawal flow will have to pass control back to the user's wallet, so it can initiate the withdrawal with a Stellar payment to your withdrawal address. You'll need to communicate the withdrawal address, amount and status to the wallet using the [`callback` parameter](#adding-parameters-to-the-url), and also by making it available on your `/transaction` endpoint. See [details](#guidance-for-wallets-completing-an-interactive-withdrawal) for polling by the wallet.
-    * If an `amount` parameter is provided to the interactive URL, make sure to use that value to pre-populate the amount on the interactive form, since this greatly improves the user experience.
     * In order to fulfill a withdrawal, a wallet must make a payment to the Stellar address that the anchor provides. It is the anchor's job to watch for Stellar payments to the given address and make the external transaction as soon as they're detected. Anchors must listen for `payment` and `path_payment` [operations](https://www.stellar.org/developers/horizon/reference/endpoints/payments-all.html). Most Stellar SDKs already support listening to all payment forms via streaming.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so there might be slight fluctuations of value between the informed withdrawal `amount` and the actual transferred amount. It is recommended for anchors to accept an amount fluctuation of up to ±10%, and  adjust the amount to be transferred (and fees) to reflect the actual value received.
 * **Providing transaction status**
@@ -143,6 +141,7 @@ Request Parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC, ETH, USD, INR, etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be BTC.
+`amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -209,6 +208,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
+`amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.


### PR DESCRIPTION
To make a nice UX many wallets wish to collect the amount of deposit/withdrawal ahead of time to show fees before going through the whole interactive process.  We had originally loosely suggested providing it to the interactive url, but that doesn't help calculate fees ahead of time, and wasn't well documented.  Here we add it to the params expected in the initial POST calls.