### PR TITLE
[SEP24] Document missing sep6 changes

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -700,6 +700,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 1. SEP-24 now requires authentication on all endpoints.  The `authentication_required` flag is removed from the `/info` endpoint since authentication is assumed.
 1. `GET /deposit` and `GET /withdraw` have been replaced with [`POST /transactions/deposit/interactive`](#deposit) and [`POST /transactions/withdraw/interactive`](#withdraw).  This is for security purposes to keep submitted personally identifiable information out of URL query parameters.  Instead of passing data through query parameters, it's now expected through `multipart/form-data` POST requests.
 1. Remove the `type` parameter from the `/deposit` and `/withdraw` endpoints as this is information collected in the interactive flow.
+1. Removed the `fields` and `types` definitions from the `/info` endpoint.  Instead of trying to communicate to the wallet what fields an anchor wishes for the wallet to collect and send, the wallet can send any fields it wishes to share for a better UX (such as `email_address`), and anything not sent should be collected by the anchor.  If none of these fields are sent, the anchor should still be able to continue and collect these fields during the interative flow.
 1. Removed `external_extra` transaction property since this should all live in a human readable ` more_info_url`.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.


### PR DESCRIPTION
We removed the way for anchors to request user data from wallets now that this should all be collected during the interactive flow, but this was never documented in the 'changes from sep6' section.