### PR TITLE
SEP-0030: Add proposal for recoverysigner multi-party key management

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -198,6 +198,13 @@ Name | Type | Description
 
 ### Endpoints
 
+- [`POST /accounts/<address>`](#post-accountsaddress)
+- [`PUT /accounts/<address>`](#put-accountsaddress)
+- [`POST /accounts/<address>/sign`](#post-accountsaddresssign)
+- [`GET /accounts/<address>`](#get-accountsaddress)
+- [`DELETE /accounts/<address>`](#delete-accountsaddress)
+- [`GET /accounts`](#get-accounts)
+
 #### `POST /accounts/<address>`
 
 This endpoint registers an account.

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -168,7 +168,7 @@ declaring should be allowed to gain control of the account.
 
 See [Common Fields].
 
-###### Example
+###### Example (JSON)
 
 ```json
 {
@@ -185,6 +185,12 @@ See [Common Fields].
     }
   }
 }
+```
+
+###### Example (Form)
+
+```
+identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -223,7 +229,7 @@ request does not include it, it is removed.
 
 See [Common Fields].
 
-###### Example
+###### Example (JSON)
 
 ```json
 {
@@ -240,6 +246,12 @@ See [Common Fields].
     }
   }
 }
+```
+
+###### Example (Form)
+
+```
+identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -284,12 +296,18 @@ Name | Type | Description
 -----|------|------------
 `transaction` | string | A XDR base64 encoded Stellar transaction.
 
-###### Example
+###### Example (JSON)
 
 ```json
 {
   "transaction": "AAAAAHAHhQtYBh5F2zA6...",
 }
+```
+
+###### Example (Form)
+
+```
+transaction=AAAAAHAHhQtYBh5F2zA6...
 ```
 
 ##### Response

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -33,8 +33,12 @@ server, and later ask the server to sign transactions for the account.
 The registration flow is as follows:
 - The client uses [SEP-10] to get a [JWT] proving high threshold control of an account.
 - The client, authenticated as the account, registers with the server, providing:
-  - One or more alternative identities that the client is stating are allowed to control the account:
-    - Another Stellar address.
+  - Alternative identities for the owner of the account:
+    - A Stellar address.
+    - A phone number.
+    - An email address.
+  - Alternative identities for another user of the account (optional):
+    - A Stellar address.
     - A phone number.
     - An email address.
 - The server verifies the [JWT] is valid according to [SEP-10].

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -12,7 +12,7 @@ Version: 0.1.0
 
 ## Summary
 
-This protocol defines an API that servers can implement and a user, client, or wallet can use to regain access to a Stellar account that was registered with two or more implementing servers without any individual server controlling the account.
+This protocol defines an API that enables a user or wallet to control a Stellar account without its key, by pre-registering the account and a phone number/email with two or more servers implementing the protocol, and adding those servers as signers of the account without an individual server being given control of the account.
 
 ## Motivation
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -134,18 +134,67 @@ Name | Type | Description
 
 ### Common Fields
 
-A set of common fields are used to describe an account in most endpoints:
+A set of common fields are used to describe an account in requests and responses most endpoints.
+
+#### Common Request Fields
+
+Name | Type | Description
+-----|------|------------
+`identities.owner.account` | string | The Stellar account ID of an another account that if authenticated will be given full permissions of this account.
+`identities.owner.phone_number` | string | The phone number that if authenticated will be given full permissions of this account. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`identities.owner.email` | string | The email that if authenticated will be given full permissions of this account.
+`identities.other.account` | string | Same as `identities.owner.account`, for the `other` identity.
+`identities.other.phone_number` | string | Same as `identities.owner.phone_number`, for the `other` identity.
+`identities.other.email` | string | Same as `identities.owner.email`, for the `other` identity.
+
+##### Example (JSON)
+
+```json
+{
+  "identities": {
+    "owner": {
+      "account": "GDUA...",
+      "phone_number": "+10000000001",
+      "email": "person1@example.com"
+    },
+    "other": {
+      "account": "GBEA...",
+      "phone_number": "+10000000002",
+      "email": "person2@example.com"
+    }
+  }
+}
+```
+
+###### Example (Form)
+
+```
+identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
+```
+
+#### Common Response Fields
 
 Name | Type | Description
 -----|------|------------
 `address` | string | The Stellar account ID or address of the account.
 `identities.has_owner` | boolean | True if the account has alternative identities set for the owner identity.
 `identities.has_other` | boolean | True if the account has alternative identities set for the other identity.
-`identities.*.account` | string | The Stellar account ID of an another account that if authenticated will be given full permissions of this account.
-`identities.*.phone_number` | string | The phone number that if authenticated will be given full permissions of this account. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
-`identities.*.email` | string | The email that if authenticated will be given full permissions of this account.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `identity` | string | The identity of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an owner identity.</li><li>`other`: Authenticated with an other identity.</li></ul>
+
+##### Example (JSON)
+
+```json
+{
+  "address": "GFDD...",
+  "identities": {
+    "has_owner": true,
+    "has_other": true
+  },
+  "identity": "account",
+  "signer": "GADF..."
+}
+```
 
 ### Endpoints
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -12,7 +12,7 @@ Version: 0.1.0
 
 ## Summary
 
-This protocol defines an API that enables a user or wallet to control a Stellar account without its key, by pre-registering the account and a phone number/email with two or more servers implementing the protocol, and adding those servers as signers of the account without an individual server being given control of the account.
+This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number or email with two or more servers implementing the protocol and add those servers as signers of the account. No individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
 
 ## Motivation
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -35,12 +35,12 @@ The registration flow is as follows:
 - The client, authenticated as the account, registers with the server, providing:
   - Alternative identities for the owner of the account:
     - A Stellar address.
-    - A phone number.
-    - An email address.
+    - And/or, a phone number.
+    - And/or, an email address.
   - Alternative identities for another user of the account (optional):
     - A Stellar address.
-    - A phone number.
-    - An email address.
+    - And/or, a phone number.
+    - And/or, an email address.
 - The server verifies the [JWT] is valid according to [SEP-10].
 - The server verifies that the account the [JWT] proves control of is the account being registered.
 - The server verifies that the account is not already registered.

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -1,0 +1,448 @@
+## Preamble
+
+```
+SEP: 0030
+Title: Recoverysigner: multi-party key management of Stellar accounts
+Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin
+Track: Standard
+Status: Draft
+Created: 2019-12-20
+Version: 0.1.0
+```
+
+## Summary
+
+This protocol defines an API that servers can implement and a user, client, or wallet can use to regain access to a Stellar account that was registered with two or more implementing servers without any individual server controlling the account.
+
+## Motivation
+
+The ability for users to gain access to a Stellar account using credentials
+other than the account keys is a critical feature of wallets that support the following use cases for a user:
+1. Recover access to Stellar accounts for which they may have lost keys.
+2. Gain access to Stellar accounts that another user intends to share with them.
+
+Solutions exist for wallets to store keys for users and to allow users to retrieve those keys, such as the [keystore] service, but those solutions usually prevent the server from controlling the account by requiring the user to remember an encryption password that, if forgotten, means permanent loss of the account. Those solutions also don't typically support sharing accounts.
+
+The user experience is improved if gaining access to a Stellar account does not require remembering a password.
+
+## Abstract
+
+This protocol defines an API allowing a client to register an account with a
+server, and later ask the server to sign transactions for the account.
+
+The registration flow is as follows:
+- The client uses [SEP-10] to get a [JWT] proving high threshold control of an account.
+- The client, authenticated as the account, registers with the server, providing:
+  - One or more alternative identities that the client is stating are allowed to control the account:
+    - Another Stellar address.
+    - A phone number.
+    - An email address.
+- The server verifies the [JWT] is valid according to [SEP-10].
+- The server verifies that the account the [JWT] proves control of is the account being registered.
+- The server verifies that the account is not already registered.
+- The server stores the account address and alternative identities.
+- The server generates a unique random signing key for the account.
+- The server encrypts the signing secret key and stores it.
+- The server responds to the client with the signing public key.
+- The client adds the signing public key as a signer of the account with an appropriate weight.
+
+The signing flow is as follows:
+- The client uses the servers phone or email authentication provider to get a [JWT] proving possession of the phone number or email address.
+- Alternatively, the client uses [SEP-10] to get a [JWT] proving high threshold control of another account that is listed as an alternative identity of the account to be accessed.
+- The client, authenticated as the phone, email, or another account, requests the server to sign a transaction.
+- The server verifies that the [JWT] is valid according to the authentication providers specification.
+- The server verifies that the phone, email, or account in the [JWT] is an alternative identity of the account.
+- The server verifies that the source account of the transaction is the account.
+- The server verifies that the source account of all operations on the transaction are not set or set to the account.
+- The server signs the transaction with the signing secret key.
+- The server responds to the client with the signature.
+
+A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. As an example, if a client is intending to use two servers that should individually have no control of the account but together are able to approve transactions, then the client can configure [account thresholds] to high 20, med 20, low 20, and assign weights 10 to both server signing keys.
+
+A client can also use the endpoints in the specification to:
+- Discover registered accounts that it has access to.
+- Update the identities associated with an account.
+- Delete accounts.
+
+## Specification
+
+### Authentication
+
+All endpoints require authentication in the form of a [JWT] token that is passed
+in the `Authorization` header. The [JWT] can be issued by two types of issuers.
+Some endpoints require a specific provider while others should function with
+both. The two issuers are:
+
+- `SEP-10`: A [SEP-10] Web Auth server for proving high threshold control of an
+account. The [SEP-10] server should be configured to only issue [JWT]s if signers
+prove they meet the high threshold on the account.
+- `External`: Defined by the implementer. Proves control of a phone number,
+email address, or other identity.
+
+### Content Type
+
+All endpoints accept in requests the following `Content-Type`s:
+- `application/x-www-form-urlencoded`
+- `application/json`
+
+All endpoints respond with content type:
+- `application/json`
+
+### Errors
+
+If an error occurs when calling any endpoint, an appropriate HTTP status code
+will be returned along with an error response.
+
+#### Status Code
+
+Common HTTP status codes may be returned for a server. In particular the following are expected:
+
+Status Code | Name | Reason
+-----|------|------------
+`400` | Bad Request | The request is invalid in anyway.
+`401` | Unauthorized | No `Authorization` header has been provided or the contents of the header are not accepted as valid.
+`404` | Not Found | The path is not recognized by the server, or the address does not have an account, or the authenticated user does not have permission to access the account.
+`409` | Conflict | The account is already registered, when attempting to register an account that is already registered.
+
+#### Response
+
+##### Fields
+
+Name | Type | Description
+-----|------|------------
+`error` | string | A description of the error.
+
+##### Example
+
+```json
+{
+   "error": "..."
+}
+```
+
+### Common Fields
+
+A set of common fields are used to describe an account in most endpoints:
+
+Name | Type | Description
+-----|------|------------
+`address` | string | The Stellar account ID or address of the account.
+`identities.has_owner` | boolean | True if the account has alternative identities set for the owner identity.
+`identities.has_other` | boolean | True if the account has alternative identities set for the other identity.
+`identities.*.account` | string | The Stellar account ID of an another account that if authenticated will be given full permissions of this account.
+`identities.*.phone_number` | string | The phone number that if authenticated will be given full permissions of this account. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`identities.*.email` | string | The email that if authenticated will be given full permissions of this account.
+`signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
+`identity` | string | The identity of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an owner identity.</li><li>`other`: Authenticated with an other identity.</li></ul>
+
+### Endpoints
+
+#### `POST /accounts/<address>`
+
+This endpoint registers an account.
+
+The owner identities are the alternative identities of the user who owns the
+account.
+
+The other identities are the identities of any other person who the owner is
+declaring should be allowed to gain control of the account.
+
+##### Authentication
+[`SEP-10`]
+
+##### Request
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "identities": {
+    "owner": {
+      "account": "GDUA...",
+      "phone_number": "+10000000001",
+      "email": "person1@example.com"
+    },
+    "other": {
+      "account": "GBEA...",
+      "phone_number": "+10000000002",
+      "email": "person2@example.com"
+    }
+  }
+}
+```
+
+##### Response
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "address": "GFDD...",
+  "identities": {
+    "has_owner": true,
+    "has_other": true
+  },
+  "identity": "account",
+  "signer": "GADF..."
+}
+```
+
+#### `PUT /accounts/<address>`
+
+This endpoint updates the identities for the account. The identities should be
+entirely replaced with the identities provided in the request, and not merged.
+Either owner or other or both should be set. If one is currently set and the
+request does not include it, it is removed.
+
+##### Authentication
+[`SEP-10`] or [`External`].
+
+##### Request
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "identities": {
+    "owner": {
+      "account": "GDUA...",
+      "phone_number": "+10000000001",
+      "email": "person1@example.com"
+    },
+    "other": {
+      "account": "GBEA...",
+      "phone_number": "+10000000002",
+      "email": "person2@example.com"
+    }
+  }
+}
+```
+
+##### Response
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "address": "GFDD...",
+  "identities": {
+    "has_owner": true,
+    "has_other": true
+  },
+  "identity": "account",
+  "signer": "GADF..."
+}
+```
+
+#### `POST /accounts/<address>/sign`
+
+This endpoint signs a transaction that has operations for the account.
+
+The transaction must only contain operations for the account. The transaction
+can contain any operations, but it is anticipated for the use cases discussed
+earlier in this protocol that the transaction will contain an operation to add
+a new signer to the account and possibly to remove an old signer. The signature
+will be generated using the signing key that the server generated during
+registration for the account.
+
+##### Authentication
+[`SEP-10`] or [`External`].
+
+##### Request
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`transaction` | string | A XDR base64 encoded Stellar transaction.
+
+###### Example
+
+```json
+{
+  "transaction": "AAAAAHAHhQtYBh5F2zA6...",
+}
+```
+
+##### Response
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
+`signer` | string | The signer public key that the server used to sign the transaction.
+`network_passphrase` | string | The network passphrase used when generating a signature.
+
+###### Example
+
+```json
+{
+  "signature": "YpVelqPAKsYTP...",
+  "signer": "GADF...",
+  "network_passphrase": "Test SDF Network ; September 2015"
+}
+```
+
+#### `GET /accounts/<address>`
+
+This endpoint returns the registered account’s details.
+
+In this response and in other responses the identities are not included in the
+response to ensure that for shared accounts one person’s identities are not
+leaked to another.
+
+##### Authentication
+
+[`SEP-10`] or [`External`].
+
+##### Response
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "address": "GFDD...",
+  "identities": {
+    "has_owner": true,
+    "has_other": true
+  },
+  "identity": "account|owner|other",
+  "signer": "GADF..."
+}
+```
+
+#### `DELETE /accounts/<address>`
+
+This endpoint will delete the record for an account. This should be
+irrecoverable.
+
+##### Authentication
+
+[`SEP-10`] or [`External`].
+
+##### Response
+
+###### Fields
+
+See [Common Fields].
+
+###### Example
+
+```json
+{
+  "address": "GFDD...",
+  "identities": {
+    "has_owner": true,
+    "has_other": true
+  },
+  "identity": "account|owner|other",
+  "signer": "GADF..."
+}
+```
+
+#### `GET /accounts`
+
+This endpoint will return a list of accounts that the [JWT] allows access to.
+This includes the account authenticated with a [SEP-10] [JWT], or any account that
+has the account authenticated as an alternative identity, or any account that
+has the phone number or email address as an alternative identity with a [JWT]
+from another authentication provider.
+
+##### Authentication
+
+[`SEP-10`] or [`External`].
+
+##### Response
+
+###### Query Parameters
+
+Name | Type | Description
+-----|------|------------
+`after` | string | Used for cursor-based pagination to get results after the given cursor. Accounts ordered chronologically based on when they were registered. Use the value of the address of the last account in the current page to get the next page.
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`accounts` | string | A list of accounts accessible by the authenticated client.
+`accounts[].*` | object | See [Common Fields].
+
+###### Example
+
+```json
+{
+  "accounts": [
+    {
+      "address": "GFDD...",
+      "identities": {
+        "has_owner": true,
+        "has_other": true
+      },
+      "identity": "account|owner|other",
+      "signer": "GADF..."
+    }
+  ]
+}
+```
+
+## Security Concerns
+
+Building, hosting and using this system has numerous security concerns because
+a server is being delegated to be a signer of an account and will handle one or
+more signing keys for many accounts. Implementers should also consider [JWT],
+encryption, secure coding, and general security best practices.
+
+Implementers and users of the protocol must consider the risks of relying on
+alternative identities such as phone number or email to be definite proof of
+the identity of a client or user.
+
+This list of concerns is not exhaustive.
+
+## Limitations
+
+This protocol discusses a phone and email authentication provider vaguely but
+does not provide any specifics to that specification. This is an area still
+under research and once a better definition for what the specification is it
+will either be added to this protocol, added as a separate protocol proposal,
+or referenced if it is already captured as a standard elsewhere.
+
+## Implementations
+
+### Go
+
+Recoverysigner is implemented by the Stellar recoverysigner service, [recoverysigner].
+
+
+[`SEP-10`]: #authentication
+[`External`]: #authentication
+[Common Fields]: #common-fields
+
+[SEP-10]: sep-0010.md
+[JWT]: https://tools.ietf.org/html/rfc7519
+[E.123]: https://www.itu.int/rec/T-REC-E.123
+[E.164]: https://www.itu.int/rec/T-REC-E.164
+
+[recoverysigner]: https://github.com/stellar/go/tree/master/exp/services/recoverysigner
+[keystore]: https://github.com/stellar/go/tree/master/services/keystore
+[account thresholds]: https://www.stellar.org/developers/guides/concepts/multi-sig.html#thresholds

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -34,11 +34,11 @@ The registration flow is as follows:
 - The client uses [SEP-10] to get a [JWT] proving high threshold control of an account.
 - The client, authenticated as the account, registers with the server, providing:
   - Alternative identities for the owner of the account:
-    - A Stellar address.
+    - Another Stellar address.
     - And/or, a phone number.
     - And/or, an email address.
   - Alternative identities for another user of the account (optional):
-    - A Stellar address.
+    - Another Stellar address.
     - And/or, a phone number.
     - And/or, an email address.
 - The server verifies the [JWT] is valid according to [SEP-10].

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -415,7 +415,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`accounts` | string | A list of accounts accessible by the authenticated client.
+`accounts` | array | A list of accounts accessible by the authenticated client.
 `accounts[].*` | object | See [Common Fields].
 
 ###### Example

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -3,7 +3,7 @@
 ```
 SEP: 0030
 Title: Recoverysigner: multi-party key management of Stellar accounts
-Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin
+Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Created: 2019-12-20

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -134,7 +134,7 @@ Name | Type | Description
 
 ### Common Fields
 
-A set of common fields are used to describe an account in requests and responses most endpoints.
+A set of common fields are used to describe an account in requests and responses on most endpoints.
 
 #### Common Request Fields
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -46,6 +46,8 @@ The registration flow is as follows:
 - The server responds to the client with the signing public key.
 - The client adds the signing public key as a signer of the account with an appropriate weight.
 
+A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. As an example, if a client is intending to use two servers that should individually have no control of the account but together are able to approve transactions, then the client can configure [account thresholds] to high 20, med 20, low 20, and assign weights 10 to both server signing keys.
+
 The signing flow is as follows:
 - The client uses the servers phone or email authentication provider to get a [JWT] proving possession of the phone number or email address.
 - Alternatively, the client uses [SEP-10] to get a [JWT] proving high threshold control of another account that is listed as an alternative identity of the account to be accessed.
@@ -57,7 +59,13 @@ The signing flow is as follows:
 - The server signs the transaction with the signing secret key.
 - The server responds to the client with the signature.
 
-A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. As an example, if a client is intending to use two servers that should individually have no control of the account but together are able to approve transactions, then the client can configure [account thresholds] to high 20, med 20, low 20, and assign weights 10 to both server signing keys.
+The client repeats the signing flow with each server it needs to meet the
+accounts threshold to be able to successfully submit a transaction.
+
+The client can use this process to sign a transaction with the [Set Options
+operation] to add a new signer to the account to regain control of an account
+of which they have lost the key, or to gain control of an account shared with
+them.
 
 A client can also use the endpoints in the specification to:
 - Discover registered accounts that it has access to.
@@ -443,6 +451,7 @@ Recoverysigner is implemented by the Stellar recoverysigner service, [recoverysi
 [E.123]: https://www.itu.int/rec/T-REC-E.123
 [E.164]: https://www.itu.int/rec/T-REC-E.164
 
+[Set Options operation]: https://www.stellar.org/developers/guides/concepts/list-of-operations.html#set-options
 [recoverysigner]: https://github.com/stellar/go/tree/master/exp/services/recoverysigner
 [keystore]: https://github.com/stellar/go/tree/master/services/keystore
 [account thresholds]: https://www.stellar.org/developers/guides/concepts/multi-sig.html#thresholds

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -166,7 +166,7 @@ Name | Type | Description
 }
 ```
 
-###### Example (Form)
+##### Example (Form)
 
 ```
 identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002


### PR DESCRIPTION
### What
Add a proposal for recoverysigner, multi-party key management of Stellar accounts where no server managing keys has control of the account, and supporting users:
1. Recovering access to Stellar accounts for which they may have lost keys.
2. Gaining access to Stellar accounts that another user intends to share with them.

### Why
I have been experimenting with this proposal in implementation first over in the [exp/services/recoverysigner] package which implements most of what is documented here. I think I've experimented enough with it to warrant documenting.

### Expectations
I expect this proposal to remain in draft state for sometime while the finer details of the SEP are ironed out. I'd like to merge the SEP without perfecting it so that I can iterate on it, and keep it and the experimental implementation in line so that the experimental implementation has a well defined specification as it evolves, and so that as the specification changes it is captured clearly outside of code.

### Reviewing in Style
To review the markdown rendered version, click here to view the file on the branch:
https://github.com/leighmcculloch/stellar--stellar-protocol/blob/sep-recovery-signer/ecosystem/sep-0030.md

[exp/services/recoverysigner]: https://github.com/stellar/go/blob/master/exp/services/recoverysigner