### PR TITLE
README: Update CAP/SEP buttons to link to their READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1>Stellar Protocol</h1>
 </div>
 <p align="center">
-<a href="./core"><img alt="Docs: CAPs" src="https://img.shields.io/badge/docs-CAPs-blue" /></a>
-<a href="./ecosystem"><img alt="Docs: SEPs" src="https://img.shields.io/badge/docs-SEPs-blue" /></a>
+<a href="./core/README.md"><img alt="Docs: CAPs" src="https://img.shields.io/badge/docs-CAPs-blue" /></a>
+<a href="./ecosystem/README.md"><img alt="Docs: SEPs" src="https://img.shields.io/badge/docs-SEPs-blue" /></a>
 </p>
 
 This repository is home to **Core Advancement Proposals** (CAPs) and **Stellar Ecosystem Proposals**


### PR DESCRIPTION
### What
Update CAP/SEP buttons to link to their READMEs.

### Why
For the longest time I didn't realize the README's exist, because I'd go to each directory and have more than a screen's worth of files displayed above the page fold. I think surfacing the READMEs as the primary place to go will help newcomers because those READMEs organize the CAPs/SEPs into accepted vs drafts which is really helpful when first arriving at the repo.