### PR TITLE
SEP-0030: Be less prescriptive about order of pagination

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -465,7 +465,7 @@ from another authentication provider.
 
 Name | Type | Description
 -----|------|------------
-`after` | string | Used for cursor-based pagination to get results after the given cursor. Accounts ordered chronologically based on when they were registered. Use the value of the address of the last account in the current page to get the next page.
+`after` | string | Used for cursor-based pagination to get results after the given cursor. Use the value of the address of the last account in the current page to get the next page.
 
 ###### Fields
 


### PR DESCRIPTION
### What
Remove the statement about the order of the results that are returned by
the `GET /accounts` endpoint.

### Why
Ordering by when the accounts were registered is not of significance
since no fields about the registration time are included in the response
and there is nothing that we can imagine right now that a client would
do with that information. We should limit the SEPs requirements to those
that matter.