### PR TITLE
SEP-0030: Change the list of identities to be an arbitrary list

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -35,7 +35,7 @@ The registration flow is as follows:
 - The client uses [SEP-10] to get a [JWT] proving high threshold control of an account.
 - The client, authenticated as the account, registers with the server, providing:
   - One or more identities of individuals that can request the server sign transactions for the account, and for each identity:
-    - The identities role in the client's use case for later identifying an authenticated client's role in relation to the account.
+    - The identities role in the client's [use case].
     - The authentication methods that can be used to authenticate as this identity:
       - One or more other Stellar addresses.
       - And/or, one or more phone numbers.
@@ -609,6 +609,7 @@ Recoverysigner is implemented by the Stellar recoverysigner service, [recoverysi
 [`External`]: #authentication
 [Common Fields]: #common-fields
 [Motivation]: #motivation
+[use case]: #use-cases
 
 [SEP-10]: sep-0010.md
 [JWT]: https://tools.ietf.org/html/rfc7519

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -7,6 +7,7 @@ Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Created: 2019-12-20
+Updated: 2020-03-11
 Version: 0.2.0
 ```
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -156,7 +156,7 @@ Name | Type | Description
   "identities": [
     {
       "auth_methods": [
-        { "type": "account", "value": "GDUA..." },
+        { "type": "stellar_address", "value": "GDUA..." },
         { "type": "phone_number", "value": "+10000000001" },
         { "type": "email", "value": "person1@example.com" }
       ]
@@ -181,7 +181,7 @@ identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person
     {
       "role": "sender",
       "auth_methods": [
-        { "type": "account", "value": "GDUA..." },
+        { "type": "stellar_address", "value": "GDUA..." },
         { "type": "phone_number", "value": "+10000000001" },
         { "type": "email", "value": "person1@example.com" }
       ]
@@ -189,7 +189,7 @@ identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person
     {
       "role": "receiver",
       "auth_methods": [
-        { "type": "account", "value": "GBEA..." },
+        { "type": "stellar_address", "value": "GBEA..." },
         { "type": "phone_number", "value": "+10000000002" },
         { "type": "email", "value": "person2@example.com" }
       ]
@@ -275,7 +275,7 @@ See [Common Fields].
     {
       "role": "sender",
       "auth_methods": [
-        { "type": "account", "value": "GDUA..." },
+        { "type": "stellar_address", "value": "GDUA..." },
         { "type": "phone_number", "value": "+10000000001" },
         { "type": "email", "value": "person1@example.com" }
       ]
@@ -283,7 +283,7 @@ See [Common Fields].
     {
       "role": "receiver",
       "auth_methods": [
-        { "type": "account", "value": "GBEA..." },
+        { "type": "stellar_address", "value": "GBEA..." },
         { "type": "phone_number", "value": "+10000000002" },
         { "type": "email", "value": "person2@example.com" }
       ]
@@ -341,7 +341,7 @@ See [Common Fields].
     {
       "role": "sender",
       "auth_methods": [
-        { "type": "account", "value": "GDUA..." },
+        { "type": "stellar_address", "value": "GDUA..." },
         { "type": "phone_number", "value": "+10000000001" },
         { "type": "email", "value": "person1@example.com" }
       ]
@@ -349,7 +349,7 @@ See [Common Fields].
     {
       "role": "receiver",
       "auth_methods": [
-        { "type": "account", "value": "GBEA..." },
+        { "type": "stellar_address", "value": "GBEA..." },
         { "type": "phone_number", "value": "+10000000002" },
         { "type": "email", "value": "person2@example.com" }
       ]

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -140,29 +140,23 @@ A set of common fields are used to describe an account in requests and responses
 
 Name | Type | Description
 -----|------|------------
-`identities.owner.account` | string | The Stellar account ID of an another account that if authenticated will be given full permissions of this account.
-`identities.owner.phone_number` | string | The phone number that if authenticated will be given full permissions of this account. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
-`identities.owner.email` | string | The email that if authenticated will be given full permissions of this account.
-`identities.other.account` | string | Same as `identities.owner.account`, for the `other` identity.
-`identities.other.phone_number` | string | Same as `identities.owner.phone_number`, for the `other` identity.
-`identities.other.email` | string | Same as `identities.owner.email`, for the `other` identity.
+`identities` | array | A list of identities that if any one is authenticated will be given full permissions of this account.
+`identities[].role` | string | The role of the identity: the individual registering the account (`registrant`) or another party (`other`).
+`identities[].type` | string | The type of identity: `account`, `phone_number`, or `email`.
+`identities[].value` | string | The identity that if authenticated will be given full permissions of the account, either an account, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 ##### Example (JSON)
 
 ```json
 {
-  "identities": {
-    "owner": {
-      "account": "GDUA...",
-      "phone_number": "+10000000001",
-      "email": "person1@example.com"
-    },
-    "other": {
-      "account": "GBEA...",
-      "phone_number": "+10000000002",
-      "email": "person2@example.com"
-    }
-  }
+  "identities": [
+    { "role": "registrant", "type": "account", "value": "GDUA..." },
+    { "role": "registrant", "type": "phone_number", "value": "+10000000001" },
+    { "role": "registrant", "type": "email", "value": "person1@example.com" },
+    { "role": "other", "type": "account", "value": "GBEA..." },
+    { "role": "other", "type": "phone_number", "value": "+10000000002" },
+    { "role": "other", "type": "email", "value": "person2@example.com" },
+  ]
 }
 ```
 
@@ -177,10 +171,10 @@ identities.other.account=GDUA...&identities.other.email=person1%40example.com&id
 Name | Type | Description
 -----|------|------------
 `address` | string | The Stellar account ID or address of the account.
-`identities.has_owner` | boolean | True if the account has alternative identities set for the owner identity.
-`identities.has_other` | boolean | True if the account has alternative identities set for the other identity.
+`identities.has_role_registrant` | boolean | True if the account has alternative identities set for the registrant role.
+`identities.has_role_other` | boolean | True if the account has alternative identities set for the other role.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
-`identity` | string | The identity of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an owner identity.</li><li>`other`: Authenticated with an other identity.</li></ul>
+`role` | string | The role of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an registrant role.</li><li>`other`: Authenticated with an other identity.</li></ul>
 
 ##### Example (JSON)
 
@@ -188,10 +182,10 @@ Name | Type | Description
 {
   "address": "GFDD...",
   "identities": {
-    "has_owner": true,
-    "has_other": true
+    "has_role_registrant": true,
+    "has_role_other": true
   },
-  "identity": "account",
+  "role": "account",
   "signer": "GADF..."
 }
 ```

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -186,12 +186,12 @@ A set of common fields are used to describe an account in requests and responses
 Name | Type | Description
 -----|------|------------
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
-`identities[].role` | string | Optional. The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
+`identities[].role` | string | The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
 `identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
 `identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, or `email`.
 `identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either another stellar address, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
-##### Example (Without Role)
+##### Example (With One Identity)
 
 ###### JSON
 
@@ -199,6 +199,7 @@ Name | Type | Description
 {
   "identities": [
     {
+      "role": "owner",
       "auth_methods": [
         { "type": "stellar_address", "value": "GDUA..." },
         { "type": "phone_number", "value": "+10000000001" },
@@ -212,10 +213,10 @@ Name | Type | Description
 ###### Form
 
 ```
-identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001
+identities.0.role=owner&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001
 ```
 
-##### Example (With Role)
+##### Example (With Multiple Roles)
 
 ###### JSON
 
@@ -254,23 +255,23 @@ Name | Type | Description
 -----|------|------------
 `address` | string | The Stellar account ID or address of the account.
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
-`identities[].role` | string | Optional, same as request. See examples above.
+`identities[].role` | string | Same as request. See above.
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 
-##### Example (Without Role)
+##### Example (With One Role)
 
 ```json
 {
   "address": "GFDD...",
   "identities": [
-    { "authenticated": true }
+    { "role": "owner", "authenticated": true }
   ],
   "signer": "GADF..."
 }
 ```
 
-##### Example (With Role)
+##### Example (With Multiple Roles)
 
 ```json
 {
@@ -348,14 +349,26 @@ identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.
 
 See [Common Fields].
 
-###### Example
+##### Example (With One Identity)
+
+```json
+{
+  "address": "GFDD...",
+  "identities": [
+    { "role": "owner" }
+  ],
+  "signer": "GADF..."
+}
+```
+
+##### Example (With Multiple Identities)
 
 ```json
 {
   "address": "GFDD...",
   "identities": [
     { "role": "sender" },
-    { "role": "receiver" },
+    { "role": "receiver" }
   ],
   "signer": "GADF..."
 }

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -34,14 +34,12 @@ server, and later ask the server to sign transactions for the account.
 The registration flow is as follows:
 - The client uses [SEP-10] to get a [JWT] proving high threshold control of an account.
 - The client, authenticated as the account, registers with the server, providing:
-  - Alternative identities for the owner of the account:
-    - Another Stellar address.
-    - And/or, a phone number.
-    - And/or, an email address.
-  - Alternative identities for another user of the account (optional):
-    - Another Stellar address.
-    - And/or, a phone number.
-    - And/or, an email address.
+  - One or more identities of individuals that can request the server sign transactions for the account, and for each identity:
+    - The identities role in the client's use case for later identifying an authenticated client's role in relation to the account.
+    - The authentication methods that can be used to authenticate as this identity:
+      - One or more other Stellar addresses.
+      - And/or, one or more phone numbers.
+      - And/or, one or more email addresses.
 - The server verifies the [JWT] is valid according to [SEP-10].
 - The server verifies that the account the [JWT] proves control of is the account being registered.
 - The server verifies that the account is not already registered.

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -140,30 +140,67 @@ A set of common fields are used to describe an account in requests and responses
 
 Name | Type | Description
 -----|------|------------
-`identities` | array | A list of identities that if any one is authenticated will be given full permissions of this account.
-`identities[].role` | string | The role of the identity: the individual registering the account (`registrant`) or another party (`other`).
-`identities[].type` | string | The type of identity: `account`, `phone_number`, or `email`.
-`identities[].value` | string | The identity that if authenticated will be given full permissions of the account, either an account, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
+`identities[].role` | string | Optional. The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
+`identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
+`identities[].auth_methods[].type` | string | The type of identity: `account`, `phone_number`, or `email`.
+`identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either an account, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
-##### Example (JSON)
+##### Example (Without Role)
+
+###### JSON
 
 ```json
 {
   "identities": [
-    { "role": "registrant", "type": "account", "value": "GDUA..." },
-    { "role": "registrant", "type": "phone_number", "value": "+10000000001" },
-    { "role": "registrant", "type": "email", "value": "person1@example.com" },
-    { "role": "other", "type": "account", "value": "GBEA..." },
-    { "role": "other", "type": "phone_number", "value": "+10000000002" },
-    { "role": "other", "type": "email", "value": "person2@example.com" },
+    {
+      "auth_methods": [
+        { "type": "account", "value": "GDUA..." },
+        { "type": "phone_number", "value": "+10000000001" },
+        { "type": "email", "value": "person1@example.com" }
+      ]
+    }
   ]
 }
 ```
 
-##### Example (Form)
+###### Form
 
 ```
-identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
+identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001
+```
+
+##### Example (With Role)
+
+###### JSON
+
+```json
+{
+  "identities": [
+    {
+      "role": "sender",
+      "auth_methods": [
+        { "type": "account", "value": "GDUA..." },
+        { "type": "phone_number", "value": "+10000000001" },
+        { "type": "email", "value": "person1@example.com" }
+      ]
+    },
+    {
+      "role": "receiver",
+      "auth_methods": [
+        { "type": "account", "value": "GBEA..." },
+        { "type": "phone_number", "value": "+10000000002" },
+        { "type": "email", "value": "person2@example.com" }
+      ]
+    },
+  ]
+}
+```
+
+###### Form
+
+```
+identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 #### Common Response Fields
@@ -171,19 +208,25 @@ identities.other.account=GDUA...&identities.other.email=person1%40example.com&id
 Name | Type | Description
 -----|------|------------
 `address` | string | The Stellar account ID or address of the account.
-`has_identity_registrant` | boolean | True if the account has alternative identities set for the registrant role.
-`has_identity_other` | boolean | True if the account has alternative identities set for the other role.
+`identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
+`identities[].role` | string | Optional, same as request. See examples above.
+`identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
-`role` | string | The role of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an registrant role.</li><li>`other`: Authenticated with an other identity.</li></ul>
 
 ##### Example (JSON)
 
 ```json
 {
   "address": "GFDD...",
-  "has_identity_registrant": true,
-  "has_identity_other": true,
-  "role": "account",
+  "identities": [
+    {
+      "role": "sender",
+      "authenticated": true
+    },
+    {
+      "role": "receiver"
+    }
+  ],
   "signer": "GADF..."
 }
 ```

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -145,7 +145,7 @@ Name | Type | Description
 `identities[].role` | string | Optional. The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
 `identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
 `identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, or `email`.
-`identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either an account, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either another stellar address, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 ##### Example (Without Role)
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -7,7 +7,7 @@ Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Created: 2019-12-20
-Version: 0.1.0
+Version: 0.2.0
 ```
 
 ## Summary

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -19,8 +19,8 @@ This protocol defines an API that enables an individual (e.g., a user or wallet)
 
 The ability for users to gain access to a Stellar account using credentials
 other than the account keys is a critical feature of wallets that support the following use cases for a user:
-1. Recover access to Stellar accounts for which they may have lost keys.
-2. Gain access to Stellar accounts that another user intends to share with them.
+1. Recover – Recover access to Stellar accounts for which they may have lost keys.
+2. Share – Gain access to Stellar accounts that another user intends to share with them.
 
 Solutions exist for wallets to store keys for users and to allow users to retrieve those keys, such as the [keystore] service, but those solutions usually prevent the server from controlling the account by requiring the user to remember an encryption password that, if forgotten, means permanent loss of the account. Those solutions also don't typically support sharing accounts.
 
@@ -74,6 +74,28 @@ A client can also use the endpoints in the specification to:
 - Discover registered accounts that it has access to.
 - Update the identities associated with an account.
 - Delete accounts.
+
+## Use Cases
+
+This protocol is intended to satisfy a wide range of use cases, but initially
+the two use cases mentioned under [Motivation] are apparent.
+
+### Use Case: Recover
+An individual that expects to maybe lose access to their keys can use SEP-30 to
+recover access to their Stellar accounts. In this use case a single identity is
+likely sufficient and specifying a role would be unnecessary. The individual
+registers the account with two or more servers and gives each server signer
+weights so that no individual server can control the account, but together they
+can approve transactions.
+
+### Use Case: Share
+An individual that wishes to share an account with another user and allow that
+other user to gain access to the account by recovering it from two or more
+servers. In this use case multiple identities should be specified each with a
+unique role so that when each individual is authenticated using an identities
+authentication methods they can recognize their role in relation to the
+account. In this case using roles such as `sender` and `receiver` are
+appropriate.
 
 ## Specification
 
@@ -586,6 +608,7 @@ Recoverysigner is implemented by the Stellar recoverysigner service, [recoverysi
 [`SEP-10`]: #authentication
 [`External`]: #authentication
 [Common Fields]: #common-fields
+[Motivation]: #motivation
 
 [SEP-10]: sep-0010.md
 [JWT]: https://tools.ietf.org/html/rfc7519

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -214,19 +214,26 @@ Name | Type | Description
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 
-##### Example (JSON)
+##### Example (Without Role)
 
 ```json
 {
   "address": "GFDD...",
   "identities": [
-    {
-      "role": "sender",
-      "authenticated": true
-    },
-    {
-      "role": "receiver"
-    }
+    { "authenticated": true }
+  ],
+  "signer": "GADF..."
+}
+```
+
+##### Example (With Role)
+
+```json
+{
+  "address": "GFDD...",
+  "identities": [
+    { "role": "sender", "authenticated": true },
+    { "role": "receiver" }
   ],
   "signer": "GADF..."
 }
@@ -264,25 +271,31 @@ See [Common Fields].
 
 ```json
 {
-  "identities": {
-    "owner": {
-      "account": "GDUA...",
-      "phone_number": "+10000000001",
-      "email": "person1@example.com"
+  "identities": [
+    {
+      "role": "sender",
+      "auth_methods": [
+        { "type": "account", "value": "GDUA..." },
+        { "type": "phone_number", "value": "+10000000001" },
+        { "type": "email", "value": "person1@example.com" }
+      ]
     },
-    "other": {
-      "account": "GBEA...",
-      "phone_number": "+10000000002",
-      "email": "person2@example.com"
-    }
-  }
+    {
+      "role": "receiver",
+      "auth_methods": [
+        { "type": "account", "value": "GBEA..." },
+        { "type": "phone_number", "value": "+10000000002" },
+        { "type": "email", "value": "person2@example.com" }
+      ]
+    },
+  ]
 }
 ```
 
 ###### Example (Form)
 
 ```
-identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
+identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -296,11 +309,10 @@ See [Common Fields].
 ```json
 {
   "address": "GFDD...",
-  "identities": {
-    "has_owner": true,
-    "has_other": true
-  },
-  "identity": "account",
+  "identities": [
+    { "role": "sender" },
+    { "role": "receiver" },
+  ],
   "signer": "GADF..."
 }
 ```
@@ -325,25 +337,31 @@ See [Common Fields].
 
 ```json
 {
-  "identities": {
-    "owner": {
-      "account": "GDUA...",
-      "phone_number": "+10000000001",
-      "email": "person1@example.com"
+  "identities": [
+    {
+      "role": "sender",
+      "auth_methods": [
+        { "type": "account", "value": "GDUA..." },
+        { "type": "phone_number", "value": "+10000000001" },
+        { "type": "email", "value": "person1@example.com" }
+      ]
     },
-    "other": {
-      "account": "GBEA...",
-      "phone_number": "+10000000002",
-      "email": "person2@example.com"
-    }
-  }
+    {
+      "role": "receiver",
+      "auth_methods": [
+        { "type": "account", "value": "GBEA..." },
+        { "type": "phone_number", "value": "+10000000002" },
+        { "type": "email", "value": "person2@example.com" }
+      ]
+    },
+  ]
 }
 ```
 
 ###### Example (Form)
 
 ```
-identities.other.account=GDUA...&identities.other.email=person1%40example.com&identities.other.phone_number=%2B10000000001&identities.owner.account=GBEA...&identities.owner.email=person2%40example.com&identities.owner.phone_number=%2B10000000002
+identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -357,11 +375,10 @@ See [Common Fields].
 ```json
 {
   "address": "GFDD...",
-  "identities": {
-    "has_owner": true,
-    "has_other": true
-  },
-  "identity": "account",
+  "identities": [
+    { "role": "sender" },
+    { "role": "receiver" },
+  ],
   "signer": "GADF..."
 }
 ```
@@ -445,11 +462,10 @@ See [Common Fields].
 ```json
 {
   "address": "GFDD...",
-  "identities": {
-    "has_owner": true,
-    "has_other": true
-  },
-  "identity": "account|owner|other",
+  "identities": [
+    { "role": "sender", "authenticated": true },
+    { "role": "receiver" },
+  ],
   "signer": "GADF..."
 }
 ```
@@ -474,11 +490,10 @@ See [Common Fields].
 ```json
 {
   "address": "GFDD...",
-  "identities": {
-    "has_owner": true,
-    "has_other": true
-  },
-  "identity": "account|owner|other",
+  "identities": [
+    { "role": "sender", "authenticated": true },
+    { "role": "receiver" },
+  ],
   "signer": "GADF..."
 }
 ```
@@ -516,13 +531,27 @@ Name | Type | Description
 {
   "accounts": [
     {
+      "address": "GEAC...",
+      "identities": [
+        { "authenticated": true }
+      ],
+      "signer": "GDJF..."
+    },
+    {
       "address": "GFDD...",
-      "identities": {
-        "has_owner": true,
-        "has_other": true
-      },
-      "identity": "account|owner|other",
+      "identities": [
+        { "role": "sender", "authenticated": true },
+        { "role": "receiver" },
+      ],
       "signer": "GADF..."
+    },
+    {
+      "address": "GACD...",
+      "identities": [
+        { "role": "sender" },
+        { "role": "receiver", "authenticated": true },
+      ],
+      "signer": "GABF..."
     }
   ]
 }

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -171,8 +171,8 @@ identities.other.account=GDUA...&identities.other.email=person1%40example.com&id
 Name | Type | Description
 -----|------|------------
 `address` | string | The Stellar account ID or address of the account.
-`identities.has_role_registrant` | boolean | True if the account has alternative identities set for the registrant role.
-`identities.has_role_other` | boolean | True if the account has alternative identities set for the other role.
+`has_identity_registrant` | boolean | True if the account has alternative identities set for the registrant role.
+`has_identity_other` | boolean | True if the account has alternative identities set for the other role.
 `signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `role` | string | The role of the authenticated client in relation to the account:<ul><li>`account`: Authenticated as the account with [SEP-10].</li><li>`owner`: Authenticated with an registrant role.</li><li>`other`: Authenticated with an other identity.</li></ul>
 
@@ -181,10 +181,8 @@ Name | Type | Description
 ```json
 {
   "address": "GFDD...",
-  "identities": {
-    "has_role_registrant": true,
-    "has_role_other": true
-  },
+  "has_identity_registrant": true,
+  "has_identity_other": true,
   "role": "account",
   "signer": "GADF..."
 }

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -144,7 +144,7 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | Optional. The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
 `identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
-`identities[].auth_methods[].type` | string | The type of identity: `account`, `phone_number`, or `email`.
+`identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, or `email`.
 `identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either an account, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 ##### Example (Without Role)

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -82,20 +82,44 @@ the two use cases mentioned under [Motivation] are apparent.
 
 ### Use Case: Recover
 An individual that expects to maybe lose access to their keys can use SEP-30 to
-recover access to their Stellar accounts. In this use case a single identity is
-likely sufficient and specifying a role would be unnecessary. The individual
-registers the account with two or more servers and gives each server signer
-weights so that no individual server can control the account, but together they
-can approve transactions.
+recover access to their Stellar accounts.
+
+A single identity is sufficient and specifying a role would be unnecessary. The
+individual registers the account with two or more servers and gives each server
+signer weights so that no individual server can control the account, but
+together they can approve transactions.
+
+The individual can recover the account by authenticating with all servers and
+requesting all servers sign a transaction giving a new key signing weight
+sufficient to meet the high threshold of the account.
 
 ### Use Case: Share
 An individual that wishes to share an account with another user and allow that
 other user to gain access to the account by recovering it from two or more
-servers. In this use case multiple identities should be specified each with a
-unique role so that when each individual is authenticated using an identities
-authentication methods they can recognize their role in relation to the
-account. In this case using roles such as `sender` and `receiver` are
-appropriate.
+servers.
+
+Multiple identities should be specified each with a unique role so that when
+each individual is authenticated using an identities authentication methods
+they can recognize their role in relation to the account. In this case using
+roles such as `sender` and `receiver` are appropriate.
+
+Either individual can recover the account by authenticating with all servers and
+asking all servers to sign a transaction giving a new key signing weight
+sufficient to meet the high threshold of the account.
+
+The receiver can accept the account and either take ownership of it or merge it
+into another account by authenticating with all servers and requesting all
+servers sign a transaction giving a new key signing weight sufficient to meet
+the high threshold of the account. The receiver can then merge the account into
+their primary account. If the receiver chooses to keep the account they can
+delete the account from the servers or replace the identities so that the
+sender is no longer an identity authorized to recover the account.
+
+The sender may wish to recover the account if the receiver does not and can use
+the same process.
+
+The sender and receiver can recognize their relationship to an account by
+inspecting the authenticated identities role.
 
 ## Specification
 


### PR DESCRIPTION
### What
Change the fixed set of identities to be a list and make the roles arbitrary strings rather than a fixed set.

### Why
To allow for easier expansion in the future of both additional roles, multiple identities per role, and multiple values for each identity type (email, phone, etc).
