### PR TITLE
SEP-0010: Add info about why network_passphrase is included

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -91,7 +91,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
     * The value of key is not important, but can be the name of the anchor followed by `auth`. It can be at most 64 bytes.
     * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
   * signature by the web service signing account
-* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing.
+* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing and is useful for identifying when a client or server have been configured incorrectly.
 
 Example:
 ```json


### PR DESCRIPTION
### What
Add information about why the network_passphrase field is provided in
the response.

### Why
On a quick read of the docs readers have assumed the presence of the
network_passphrase field is for the server to tell the client which
passphrase to use. While there may be valid uses of the field in that
way the intention for why the field was added was to be a debugging
mechanism so that it is immediately clear if a client or server as
misconfigured. The reason this is helpful in that situation is because
the network passphrase affects the signature of the transaction but is
not stored in the transaction, so if a client or server are configured
incorrectly the error message from the server when verifying the
transaction will simply be that the signature is invalid.

This change is not a breaking change because it just shares some
insight into why the feature exists and does not change the feature or
how the feature functions in anyway.