### PR TITLE
README: Fix Stellar logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img alt="Stellar" src="https://www.stellar.org/old-content/2019/03/stellar-logo-solo-1.png" width="558" />
+<img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" />
 <br/>
 <strong>Creating equitable access to the global financial system</strong>
 <h1>Stellar Protocol</h1>


### PR DESCRIPTION
### What
Update the URL for the Stellar logo image displayed at the top of the
README.

### Why
A new version of the stellar.org website was deployed and the image we
were using is no longer available there. In stellar/.github#9 we added
the logo to a GitHub repository so that we could reference it from one
location that won't be affected by website changes.
