### PR TITLE
SEP-0030: Make what transactions can be signed clearer

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -451,8 +451,8 @@ transaction must match the account in the request.
 The transaction can contain any operations, but it is anticipated for the use
 cases discussed earlier in this protocol that the transaction will contain an
 operation to add a new signer to the account and possibly to remove an old
-signer. The signature will be generated using the signing key that the server
-generated during registration for the account.
+signer or to merge an account. The signature will be generated using the
+signing key that the server generated during registration for the account.
 
 ##### Authentication
 [`SEP-10`] or [`External`].

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -444,12 +444,15 @@ See [Common Fields].
 
 This endpoint signs a transaction that has operations for the account.
 
-The transaction must only contain operations for the account. The transaction
-can contain any operations, but it is anticipated for the use cases discussed
-earlier in this protocol that the transaction will contain an operation to add
-a new signer to the account and possibly to remove an old signer. The signature
-will be generated using the signing key that the server generated during
-registration for the account.
+The transaction must only contain operations for the account. The source
+account of the transaction and the source account of all operations in the
+transaction must match the account in the request.
+
+The transaction can contain any operations, but it is anticipated for the use
+cases discussed earlier in this protocol that the transaction will contain an
+operation to add a new signer to the account and possibly to remove an old
+signer. The signature will be generated using the signing key that the server
+generated during registration for the account.
 
 ##### Authentication
 [`SEP-10`] or [`External`].


### PR DESCRIPTION
### What
State what transactions will be signed by a SEP-30 server.

### Why
It isn't clear exactly what transactions a SEP-30 server will sign. The document states that transactions for an account will be signed, but we should be more explicit about what that means.

This is a follow up to https://github.com/stellar/stellar-protocol/pull/566#discussion_r392453939.