### PR TITLE
[SEP24] Update lang param description

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -148,7 +148,7 @@ Name | Type | Description
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
 
 Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -214,7 +214,7 @@ Name | Type | Description
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
 
 Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 


### PR DESCRIPTION
Expand the scope of the `lang` param when starting a transaction.  This can also be used to localize the interactive flow UI, as well as anything else that might be shown to the user in the context of this transaction
