### PR TITLE
SEP-26 - Make document easier to read

### DIFF
--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -560,7 +560,6 @@ If the given account does not exist, or if the account doesn't have a trust line
 ```
 POST TRANSFER_SERVER/deposit
 Content-Type: multipart/form-data
-
 ```
 
 Request Parameters:
@@ -610,8 +609,10 @@ Name | Type | Description
 `fee` | float | (optional) Calculated fee (if any). In units of the deposited asset.
 `extra_info` | array | (optional) JSON array with additional information about the deposit process. Each element in the array is formatted as follows {key: KEY, value: VALUE}. Wallets are encouraged to present extra_info in a tabular manner and enable easy copy to clipboard for each line value.
 
-
-Bitcoin response example:
+<details>
+<summary>
+  <b>Bitcoin response example</b>
+</summary>
 
 ```json
 {
@@ -620,7 +621,12 @@ Bitcoin response example:
 }
 ```
 
-Ripple response example:
+</details>
+
+<details>
+<summary>
+  <b>Ripple response example</b>
+</summary>
 
 ```json
 {
@@ -640,13 +646,16 @@ Ripple response example:
       "key" : "Tag",
       "value": "88"
     }
-
   ]
-
 }
 ```
 
-Mexican peso (MXN) response example:
+</details>
+
+<details>
+<summary>
+  <b>Mexican peso (MXN) response example</b>
+</summary>
 
 ```json
 {
@@ -654,7 +663,6 @@ Mexican peso (MXN) response example:
   "eta": 1800,
   "fee": 100,
   "extra_info": [
-
     {
       "key" : "Bank",
       "value": "STP"
@@ -670,6 +678,8 @@ Mexican peso (MXN) response example:
   ]
 }
 ```
+
+</details>
 
 ##### Special Cases
 ###### Stellar account does not exist
@@ -755,7 +765,10 @@ Name | Type | Description
 `extra_info` | array | (optional) JSON array with additional information about the withdrawal process. Each element in the array is formatted as follows {key: KEY, value: VALUE}. Wallets are encouraged to present extra_info in a tabular manner and enable easy copy to clipboard for each line value.
 
 
-Example:
+<details>
+<summary>
+  <b>Example response</b>
+</summary>
 
 ```json
 {
@@ -776,6 +789,8 @@ Example:
 }
 ```
 
+</details>
+
 ## Deposit and Withdraw shared responses
 
 ### 1. Interactive customer information needed
@@ -787,7 +802,6 @@ An anchor that requires the user to fill out `one time` information on a webpage
 Note that this is for **one time** information only. Please use [SEP-24](sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing.
 
 
-
 The response body must be a JSON object with the following fields:
 
 Name | Type | Description
@@ -795,7 +809,10 @@ Name | Type | Description
 `type` | string | Always set to `interactive_customer_info_needed`.
 `url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe. We encourage anchors to make this url unique for each wallet, and to include a required random short-lived session id for privacy and security reasons.
 
-Example response:
+<details>
+<summary>
+  <b>Example response</b>
+</summary>
 
 ```json
 {
@@ -804,10 +821,11 @@ Example response:
 }
 ```
 
+</details>
+
 **`jwt` details**
 
 Even when the user has authenticated with [SEP-0010](sep-0010.md), the wallet should NEVER pass the jwt into the interactive URL.
-
 
 
 ### 2. Customer Information Needed
@@ -827,7 +845,10 @@ If the anchor decides that more customer information is needed after receiving s
 
 Note: this status response should never be used in the case that the user's KYC request succeeds. In that case, the anchor should respond with a deposit / withdrawal address as described by those endpoints.
 
-Example:
+<details>
+<summary>
+  <b>Example response</b>
+</summary>
 
 ```json
 {
@@ -836,6 +857,8 @@ Example:
   "more_info_url": "https://api.example.com/kycstatus?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI&session_id=random_short_lived_uuid"
 }
 ```
+
+</details>
 
 
 ### 3. Authentication required
@@ -931,7 +954,10 @@ Name | Type | Description
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.
 * `error` -- catch-all for any error not enumerated above.
 
-Example response:
+<details>
+<summary>
+  <b>Example response</b>
+</summary>
 
 ```json
 {
@@ -962,6 +988,8 @@ Example response:
   ]
 }
 ```
+
+</details>
 
 Every HTTP status code other than `200 OK` will be considered an error. An empty transaction list is *not* an error. The body should contain error details.
 For example:
@@ -998,7 +1026,10 @@ Name | Type | Description
 
 The `transaction` object should be of the same form as the objects returned by the `TRANSFER_SERVER/transactions` endpoint.
 
-Example response:
+<details>
+<summary>
+  <b>Example response</b>
+</summary>
 
 ```json
 {
@@ -1015,6 +1046,8 @@ Example response:
     }
 }
 ```
+
+</details>
 
 If the transaction cannot be found, the endpoint should return a `404 NOT FOUND` result.
 

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -578,9 +578,7 @@ For example:
 
 [SEP-27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP-26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP-27.
 
-### Examples
-
-<details>
+<details id="btc-example">
 <summary>
   <b>BTC Example</b>
 </summary>
@@ -958,12 +956,12 @@ Field | Type | Description
 `value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
  `title` | string | Human readable title for the choice. E.g. Bank of America.
 
- See the [BTC SEP27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
+ See the [BTC SEP-27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
 
 
 ### sep26.withdrawals
 
-See ["sep26.deposits"](#sep26-/-deposits)
+See ["sep26.deposits"](#sep26deposits)
 
 
 ### sep26.transaction_history
@@ -975,7 +973,7 @@ The following fields are allowed:
 Field | Type | Description
 ------|------|------------|
 `enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
- `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
+ `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to `["sep10"]`, if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
 
 ### sep26.authentication_protocols.{authenticactionProtocol}
 
@@ -988,5 +986,5 @@ For SEP10, you need to specify two fields:
 
 Field | Type | Description
 ------|------|------------|
-`authentication_server`| url | Server to use for SEP10 authentication.
- `authentication_signing_key` | G... | Public key used for signing SEP10 transactions.
+`authentication_server`| url | Server to use for [SEP-10](sep-0010.md) authentication.
+ `authentication_signing_key` | G... | Public key used for signing SEP-10 transactions.

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -32,420 +32,6 @@ This proposal defines a standard protocol enabling the following features direct
 
 To support this protocol, an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.
 
-## SEP27 Asset Information Response
-
-[SEP27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP27.
-
-### BTC Example
-
-```json
-
-
-{
-  "transfer_protocols": {
-    "sep26": {
-
-      "transfer_server": "https://api.examplebtcanchor.com",
-
-      "fund_wallet": {
-        "enabled": true,
-        "amount_native": 5,
-        "fee": "2 * XLM/BTC market price",
-        "funding_protocols": ["sep25"]
-      },
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": []
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "fields": [
-          {
-            "id": "priority",
-            "name": "Priority",
-            "type": "choice",
-            "choices": [{
-              "value": "low",
-              "title": "Low"
-            },{
-              "value": "med",
-              "title": "Medium"
-            },{
-              "value": "high",
-              "title": "High"
-            }]
-          }
-        ]
-      },
-
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-
-    }
-  }
-}
-
-
-```
-
-### FIATUSD Example
-
-```json
-
-{
-  "transfer_protocols": {
-    "sep26": {
-      "transfer_server": "https://acme.inc/api26/usd",
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "cashapp",
-            "name": "Cash App",
-            "fee": "1 USD",
-            "logo": "https://squa.re/cashapp.png",
-
-            "fields": [
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          },
-          {
-            "id": "wire",
-            "name":  "Wire Transfer",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://acme.inc/bank_wire_logo.png",
-
-            "fields": [
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          }
-        ]
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "facebook_pay",
-            "name": "Facebook Pay",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://fb.com/pay.png",
-            
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Facebook Pay ID"
-              }
-            ]
-          },
-          {
-            "id": "google_cache",
-            "name": "Google Cache",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://goog.com/cache.png",
-            
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Google Cache ID"
-              }
-            ]
-          },
-          {
-            "id": "cashapp",
-            "name": "Cash App",
-            "fee": "0.2% + 1 USD",
-            "logo": "https://squa.re/cashapp.png",
-            
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Google Cache ID"
-              },
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          },
-          {
-            "id": "wire",
-            "name": "Wire Transfer",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://acme.inc/bank_wire_logo.png",
-
-            "fields": [
-              {
-                "id": "swift_code",
-                "title": "Swift Code"
-              },
-              {
-                "id": "routing_number",
-                "title": "Routing Number"
-              },
-              {
-                "id": "dest",
-                "title": "Account Number"
-              },
-              {
-                "id": "receiver_name",
-                "title": "Full names of your recepient"
-              },
-              {
-                "id": "reason",
-                "title": "Reason for the transfer"
-              },
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          }
-          
-        ]
-      },
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-    }
-  }
-}
-
-```
-
-### FIATCNY Example
-
-```json
-
-{
-  "transfer_protocols": {
-    "sep26": {
-      "transfer_server": "https://acme.inc/api26/cny",
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "wechat",
-            "name": "WeChat",
-            "fee": "0 CNY",
-            "logo": "https://wech.at/wechat.png",
-          },
-          {
-            "id": "alipay",
-            "name": "AliPay",
-            "fee": "0 CNY",
-            "logo": "https://alip.ay/alipay.png",
-          }
-        ]
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "wechat",
-            "name": "WeChat",
-            "fee": "0.1% + 1 CNY",
-            "logo": "https://wech.at/wechat.png",
-            
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your WeChat ID"
-              }
-            ]
-          },
-          {
-            "id": "alipay",
-            "name": "AliPay",
-            "fee": "0.1% + 1 CNY. Max 10 CNY.",
-            "logo": "https://alip.ay/alipay.png",
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your AliPay ID"
-              }
-            ]
-          }
-        ]
-      },
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-    }
-  }
-}
-
-```
-
-
-## Prerequisites: sep26
-
-* The concept of  `transfer protocols` was introduced in [SEP27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [sep24](sep-0024.md).
-
-The following fields are allowed under the "sep26" object.
-
-
-Field | Type | Description
-------|------|------------|
-`transfer_server`| url | The asset's transfer server for handling deposits, withdrawals and transaction history.
-
-
-## sep26 / fund_wallet
-
-Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the "fund_wallet" field under the "sep26" field. 
-
-The following fields are allowed under "fund_wallet":
-
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Set to true for assets that support funding of unfunded wallet accounts. Default is false if not set.
-`amount_native`| number | The number of lumens the anchored asset will use to fund the wallet
-`fees`| string | human readable fee structure for funding accounts.  e.g. "2 * XLM/BTC market price".
-`funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
-
-
-## sep26 / deposits 
-
-Deposit metadata for each anchored asset is specified inside the "deposits" field
-
-The following fields are allowed:
-
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Determines if deposits are supported or not. Wallets should consider deposits disabled if this field is not specified.
- `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when performing deposits. An anchored asset that doesn't need any authentication protocol for deposits doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for deposits.
-
-
-## sep26 / deposits / options
-
-An array of objects containing all supported deposit options for the asset.
-
-The following fields are allowed under each deposit option.
-
-
-
-Field | Type | Description
-------|------|------------|
-`id`| string (required) | e.g. crypto, mobilemoney, wire
- `name` | string | Short name for the deposit option.
- `min_amount`| number | Minimum deposit amount supported by this deposit option.
- `max_amount` | number | Maximum deposit amount supported by this deposit option.
- `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees" 
-
-
-## sep26 / deposits / options / fields
-
-An array of form fields supported for each deposit option.
-
-The following fields are allowed.
-
-
-Field | Type | Description
-------|------|------------|
-`id`| string (required) | Id of the form field. e.g. dest, email, routing_number. 
- `title` | string | Title of the form field e.g. "Your Email", "Routing Number".
- `description`| string | Description of the form field.
- `optional` | boolean | Marks the form field as optional or not.
- `type`| string  | One of 'text', 'number', 'email', or 'choice'. The default form field type is text. See below on how to specify choices for the 'choice' type.
-
-## sep26 / deposits / options / fields / choices
-
-
-An array of choices for deposit form fields that have type set to  `choice`.
-
-
-
-Field | Type | Description
-------|------|------------|
-`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001". 
- `title` | string | Human readable title for the choice. E.g. Bank of America.
-
- See the [BTC SEP27 example response](#btc-example)  above of an asset that uses the choice type on a withdrawal field.
-
-
-
-## sep26 / withdrawals 
-
-See ["sep26 / deposits"](#sep26-/-deposits)
-
-
-## sep26 / transaction_history
-
-Transaction history metadata for each anchored asset is specified inside the "transaction_history" field.
-
-The following fields are allowed:
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
- `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
-
-## sep26 / authentication_protocols / {authenticactionProtocol}
-
-Authentication configuration parameters for each supported authentication protocol is defined under the "authentication_protocols" field.
-
-The fields allowed depend on each authentication protocol.
-
-For SEP10, you need to specify two fields:
-
-
-Field | Type | Description
-------|------|------------|
-`authentication_server`| url | Server to use for SEP10 authentication.
- `authentication_signing_key` | G... | Public key used for signing SEP10 transactions.
-
-
 ## API Endpoints
 
 * [`POST /deposit`](#deposit): required
@@ -457,7 +43,7 @@ Field | Type | Description
 
 Asset anchors that need authentication should do the relevant changes to their SEP27 response JSON as stipulated above.
 
-Wallets, clients and anchors should follow the authentication protocol specifications of each supported authentication protocol. For example  [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups. 
+Wallets, clients and anchors should follow the authentication protocol specifications of each supported authentication protocol. For example  [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.
 
 ## Cross-Origin Headers
 
@@ -482,7 +68,7 @@ SEP-26 lays out many options for how deposit and withdrawal can work non-interac
 * Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file  and [SEP27](sep-0027.md) response to display useful information to the user about the asset they've picked. Asset information obtained via SEP27 takes precendence over the same information found in stellar.toml. This is especially true for fields that need localization.
 * Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file and SEP27 response.
-* **Use the `SEP27` response to:** 
+* **Use the `SEP27` response to:**
     * Determine which anchor endpoints will require authentication
     * Fetch the asset's deposit & withdawal fee structure: show this to the user early in the process so they're fully informed.
 * **Authentication**
@@ -529,7 +115,7 @@ Request Parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset the user wants to deposit with the anchor. E.g.  BTC, ETH, USD, INR, etc. This should be the same asset code specified in the stellar.toml file.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent to.
 `memo_type` | string | (optional) Type of memo that the anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -603,7 +189,7 @@ Ripple response example:
     }
 
   ]
-    
+
 }
 ```
 
@@ -615,7 +201,7 @@ Mexican peso (MXN) response example:
   "eta": 1800,
   "fee": 100,
   "extra_info": [
-    
+
     {
       "key" : "Bank",
       "value": "STP"
@@ -670,7 +256,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. For example, if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `amount` | number | The amount the user wishes to withdraw. Some anchors may use the amount to withdraw to determine fees.
 `type` | string |  Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
@@ -745,7 +331,7 @@ Response code: `403 Forbidden`
 
 An anchor that requires the user to fill out `one time` information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or needs a user to agree to Terms of Service. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
 
-Note that this is for `one time` information only. Please use [SEP24] (sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing. 
+Note that this is for `one time` information only. Please use [SEP24] (sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing.
 
 
 
@@ -767,7 +353,7 @@ Example response:
 
 **`jwt` details**
 
-Even when the user has authenticated with [SEP-0010](sep-0010.md), the wallet should NEVER pass the jwt into the interactive URL. 
+Even when the user has authenticated with [SEP-0010](sep-0010.md), the wallet should NEVER pass the jwt into the interactive URL.
 
 
 
@@ -836,7 +422,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `account` | string | The stellar account ID involved in the transactions.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.
@@ -987,3 +573,404 @@ For example:
    "error": "This anchor doesn't support the given currency code: ETH"
 }
 ```
+
+## SEP27 Asset Information Response
+
+[SEP27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP27.
+
+### BTC Example
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+
+      "transfer_server": "https://api.examplebtcanchor.com",
+
+      "fund_wallet": {
+        "enabled": true,
+        "amount_native": 5,
+        "fee": "2 * XLM/BTC market price",
+        "funding_protocols": ["sep25"]
+      },
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": []
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "fields": [
+          {
+            "id": "priority",
+            "name": "Priority",
+            "type": "choice",
+            "choices": [{
+              "value": "low",
+              "title": "Low"
+            },{
+              "value": "med",
+              "title": "Medium"
+            },{
+              "value": "high",
+              "title": "High"
+            }]
+          }
+        ]
+      },
+
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+
+    }
+  }
+}
+```
+
+### FIATUSD Example
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+      "transfer_server": "https://acme.inc/api26/usd",
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "cashapp",
+            "name": "Cash App",
+            "fee": "1 USD",
+            "logo": "https://squa.re/cashapp.png",
+
+            "fields": [
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          },
+          {
+            "id": "wire",
+            "name":  "Wire Transfer",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://acme.inc/bank_wire_logo.png",
+
+            "fields": [
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          }
+        ]
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "facebook_pay",
+            "name": "Facebook Pay",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://fb.com/pay.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Facebook Pay ID"
+              }
+            ]
+          },
+          {
+            "id": "google_cache",
+            "name": "Google Cache",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://goog.com/cache.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Google Cache ID"
+              }
+            ]
+          },
+          {
+            "id": "cashapp",
+            "name": "Cash App",
+            "fee": "0.2% + 1 USD",
+            "logo": "https://squa.re/cashapp.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Google Cache ID"
+              },
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          },
+          {
+            "id": "wire",
+            "name": "Wire Transfer",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://acme.inc/bank_wire_logo.png",
+
+            "fields": [
+              {
+                "id": "swift_code",
+                "title": "Swift Code"
+              },
+              {
+                "id": "routing_number",
+                "title": "Routing Number"
+              },
+              {
+                "id": "dest",
+                "title": "Account Number"
+              },
+              {
+                "id": "receiver_name",
+                "title": "Full names of your recepient"
+              },
+              {
+                "id": "reason",
+                "title": "Reason for the transfer"
+              },
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          }
+
+        ]
+      },
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+    }
+  }
+}
+```
+
+### FIATCNY Example
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+      "transfer_server": "https://acme.inc/api26/cny",
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "wechat",
+            "name": "WeChat",
+            "fee": "0 CNY",
+            "logo": "https://wech.at/wechat.png",
+          },
+          {
+            "id": "alipay",
+            "name": "AliPay",
+            "fee": "0 CNY",
+            "logo": "https://alip.ay/alipay.png",
+          }
+        ]
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "wechat",
+            "name": "WeChat",
+            "fee": "0.1% + 1 CNY",
+            "logo": "https://wech.at/wechat.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your WeChat ID"
+              }
+            ]
+          },
+          {
+            "id": "alipay",
+            "name": "AliPay",
+            "fee": "0.1% + 1 CNY. Max 10 CNY.",
+            "logo": "https://alip.ay/alipay.png",
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your AliPay ID"
+              }
+            ]
+          }
+        ]
+      },
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+    }
+  }
+}
+```
+
+
+## `sep26` transfer protocol
+
+The concept of  `transfer protocols` was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
+
+The following fields are allowed under the "sep26" object.
+
+
+Field | Type | Description
+------|------|------------|
+`transfer_server`| url | The asset's transfer server for handling deposits, withdrawals and transaction history.
+
+
+### sep26.fund_wallet
+
+Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the `fund_wallet` field under the `sep26` field.
+
+The following fields are allowed under `fund_wallet`:
+
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Set to true for assets that support funding of unfunded wallet accounts. Default is false if not set.
+`amount_native`| number | The number of lumens the anchored asset will use to fund the wallet
+`fees`| string | human readable fee structure for funding accounts.  e.g. "2 * XLM/BTC market price".
+`funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
+
+
+### sep26.deposits
+
+Deposit metadata for each anchored asset is specified inside the `deposits` field
+
+The following fields are allowed:
+
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Determines if deposits are supported or not. Wallets should consider deposits disabled if this field is not specified.
+ `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when performing deposits. An anchored asset that doesn't need any authentication protocol for deposits doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for deposits.
+
+
+### sep26.deposits.options
+
+An array of objects containing all supported deposit options for the asset.
+
+The following fields are allowed under each deposit option.
+
+
+Field | Type | Description
+------|------|------------|
+`id`| string (required) | e.g. crypto, mobilemoney, wire
+ `name` | string | Short name for the deposit option.
+ `min_amount`| number | Minimum deposit amount supported by this deposit option.
+ `max_amount` | number | Maximum deposit amount supported by this deposit option.
+ `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees"
+
+
+### sep26.deposits.options.fields
+
+An array of form fields supported for each deposit option.
+
+The following fields are allowed.
+
+
+Field | Type | Description
+------|------|------------|
+`id`| string (required) | Id of the form field. e.g. dest, email, routing_number.
+ `title` | string | Title of the form field e.g. "Your Email", "Routing Number".
+ `description`| string | Description of the form field.
+ `optional` | boolean | Marks the form field as optional or not.
+ `type`| string  | One of 'text', 'number', 'email', or 'choice'. The default form field type is text. See below on how to specify choices for the 'choice' type.
+
+### sep26.deposits.options.fields.choices
+
+An array of choices for deposit form fields that have type set to  `choice`.
+
+
+Field | Type | Description
+------|------|------------|
+`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
+ `title` | string | Human readable title for the choice. E.g. Bank of America.
+
+ See the [BTC SEP27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
+
+
+### sep26.withdrawals
+
+See ["sep26.deposits"](#sep26-/-deposits)
+
+
+### sep26.transaction_history
+
+Transaction history metadata for each anchored asset is specified inside the `transaction_history` field.
+
+The following fields are allowed:
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
+ `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
+
+### sep26.authentication_protocols.{authenticactionProtocol}
+
+Authentication configuration parameters for each supported authentication protocol is defined under the `authentication_protocols` field.
+
+The fields allowed depend on each authentication protocol.
+
+For SEP10, you need to specify two fields:
+
+
+Field | Type | Description
+------|------|------------|
+`authentication_server`| url | Server to use for SEP10 authentication.
+ `authentication_signing_key` | G... | Public key used for signing SEP10 transactions.

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -879,15 +879,23 @@ For example:
 
 The concept of  "transfer protocols" was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
 
-The following fields are allowed under the `sep26` object.
+<details id="sep26">
+<summary>
+  <b>sep26</b>
+</summary>
 
+The following fields are allowed under the `sep26` object.
 
 Field | Type | Description
 ------|------|------------|
 `transfer_server`| url | The asset's transfer server for handling deposits, withdrawals and transaction history.
 
+</details>
 
-### sep26.fund_wallet
+<details id="sep26.fund_wallet">
+<summary>
+  <b>sep26.fund_wallet</b>
+</summary>
 
 Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the `fund_wallet` field under the `sep26` field.
 
@@ -901,8 +909,12 @@ Field | Type | Description
 `fees`| string | human readable fee structure for funding accounts.  e.g. "2 * XLM/BTC market price".
 `funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
 
+</details>
 
-### sep26.deposits
+<details id="sep26.deposits">
+<summary>
+  <b>sep26.deposits</b>
+</summary>
 
 Deposit metadata for each anchored asset is specified inside the `deposits` field
 
@@ -914,8 +926,12 @@ Field | Type | Description
 `enabled`| boolean | Determines if deposits are supported or not. Wallets should consider deposits disabled if this field is not specified.
  `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when performing deposits. An anchored asset that doesn't need any authentication protocol for deposits doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for deposits.
 
+</details>
 
-### sep26.deposits.options
+<details id="sep26.deposits.options">
+<summary>
+  <b>sep26.deposits.options</b>
+</summary>
 
 An array of objects containing all supported deposit options for the asset.
 
@@ -930,8 +946,12 @@ Field | Type | Description
  `max_amount` | number | Maximum deposit amount supported by this deposit option.
  `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees"
 
+</details>
 
-### sep26.deposits.options.fields
+<details id="sep26.deposits.options.fields">
+<summary>
+  <b>sep26.deposits.options.fields</b>
+</summary>
 
 An array of form fields supported for each deposit option.
 
@@ -946,25 +966,37 @@ Field | Type | Description
  `optional` | boolean | Marks the form field as optional or not.
  `type`| string  | One of 'text', 'number', 'email', or 'choice'. The default form field type is text. See below on how to specify choices for the 'choice' type.
 
-### sep26.deposits.options.fields.choices
+</details>
+
+<details id="sep26.deposits.options.fields.choices">
+<summary>
+  <b>sep26.deposits.options.fields.choices</b>
+</summary>
 
 An array of choices for deposit form fields that have type set to  `choice`.
-
 
 Field | Type | Description
 ------|------|------------|
 `value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
  `title` | string | Human readable title for the choice. E.g. Bank of America.
 
- See the [BTC SEP-27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
+See the [BTC SEP-27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
 
+</details>
 
-### sep26.withdrawals
+<details id="sep26.withdrawals">
+<summary>
+  <b>sep26.withdrawals</b>
+</summary>
 
 See ["sep26.deposits"](#sep26deposits)
 
+</details>
 
-### sep26.transaction_history
+<details id="sep26.transaction_history">
+<summary>
+  <b>sep26.transaction_history</b>
+</summary>
 
 Transaction history metadata for each anchored asset is specified inside the `transaction_history` field.
 
@@ -975,7 +1007,12 @@ Field | Type | Description
 `enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
  `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to `["sep10"]`, if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
 
-### sep26.authentication_protocols.{authenticactionProtocol}
+</details>
+
+<details id="sep26.authentication_protocols.authenticactionProtocol">
+<summary>
+  <b>sep26.authentication_protocols.{authenticactionProtocol}</b>
+</summary>
 
 Authentication configuration parameters for each supported authentication protocol is defined under the `authentication_protocols` field.
 
@@ -983,8 +1020,9 @@ The fields allowed depend on each authentication protocol.
 
 For SEP10, you need to specify two fields:
 
-
 Field | Type | Description
 ------|------|------------|
 `authentication_server`| url | Server to use for [SEP-10](sep-0010.md) authentication.
  `authentication_signing_key` | G... | Public key used for signing SEP-10 transactions.
+
+</details>

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -476,7 +476,7 @@ Authentication configuration parameters for each supported authentication protoc
 
 The fields allowed depend on each authentication protocol.
 
-For SEP10, you need to specify two fields:
+For SEP-10, you need to specify two fields:
 
 Field | Type | Description
 ------|------|------------|
@@ -494,7 +494,7 @@ Field | Type | Description
 
 ## Authentication
 
-Asset anchors that need authentication should do the relevant changes to their SEP27 response JSON as stipulated above.
+Asset anchors that need authentication should do the relevant changes to their SEP-27 response JSON as stipulated above.
 
 Wallets, clients and anchors should follow the authentication protocol specifications of each supported authentication protocol. For example  [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.
 
@@ -519,9 +519,9 @@ SEP-26 lays out many options for how deposit and withdrawal can work non-interac
 ### Basic Wallet Implementation
 
 * Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
-* For each anchor, use information from its [`stellar.toml`](sep-0001.md) file  and [SEP27](sep-0027.md) response to display useful information to the user about the asset they've picked. Asset information obtained via SEP27 takes precendence over the same information found in stellar.toml. This is especially true for fields that need localization.
-* Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file and SEP27 response.
-* **Use the `SEP27` response to:**
+* For each anchor, use information from its [`stellar.toml`](sep-0001.md) file  and [SEP-27](sep-0027.md) response to display useful information to the user about the asset they've picked. Asset information obtained via SEP-27 takes precendence over the same information found in stellar.toml. This is especially true for fields that need localization.
+* Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file and SEP-27 response.
+* **Use the `SEP-27` response to:**
     * Determine which anchor endpoints will require authentication
     * Fetch the asset's deposit & withdawal fee structure: show this to the user early in the process so they're fully informed.
 * **Authentication**
@@ -573,7 +573,7 @@ Name | Type | Description
 `memo_type` | string | (optional) Type of memo that the anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
-`type` | string | (required) Deposit option. If the anchor supports one or multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`. The type should be set to one of the deposit options defined above in the SEP27 json response.
+`type` | string | (required) Deposit option. If the anchor supports one or multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`. The type should be set to one of the deposit options defined above in the SEP-27 json response.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
@@ -784,7 +784,7 @@ Response code: `403 Forbidden`
 
 An anchor that requires the user to fill out `one time` information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or needs a user to agree to Terms of Service. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
 
-Note that this is for `one time` information only. Please use [SEP24] (sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing.
+Note that this is for **one time** information only. Please use [SEP-24](sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing.
 
 
 

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -32,6 +32,459 @@ This proposal defines a standard protocol enabling the following features direct
 
 To support this protocol, an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.
 
+## SEP-27 Asset Information Response
+
+[SEP-27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP-26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP-27.
+
+<details id="btc-example">
+<summary>
+  <b>BTC Example</b>
+</summary>
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+
+      "transfer_server": "https://api.examplebtcanchor.com",
+
+      "fund_wallet": {
+        "enabled": true,
+        "amount_native": 5,
+        "fee": "2 * XLM/BTC market price",
+        "funding_protocols": ["sep25"]
+      },
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": []
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "fields": [
+          {
+            "id": "priority",
+            "name": "Priority",
+            "type": "choice",
+            "choices": [{
+              "value": "low",
+              "title": "Low"
+            },{
+              "value": "med",
+              "title": "Medium"
+            },{
+              "value": "high",
+              "title": "High"
+            }]
+          }
+        ]
+      },
+
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>
+  <b>FIATUSD Example</b>
+</summary>
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+      "transfer_server": "https://acme.inc/api26/usd",
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "cashapp",
+            "name": "Cash App",
+            "fee": "1 USD",
+            "logo": "https://squa.re/cashapp.png",
+
+            "fields": [
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          },
+          {
+            "id": "wire",
+            "name":  "Wire Transfer",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://acme.inc/bank_wire_logo.png",
+
+            "fields": [
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          }
+        ]
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "facebook_pay",
+            "name": "Facebook Pay",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://fb.com/pay.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Facebook Pay ID"
+              }
+            ]
+          },
+          {
+            "id": "google_cache",
+            "name": "Google Cache",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://goog.com/cache.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Google Cache ID"
+              }
+            ]
+          },
+          {
+            "id": "cashapp",
+            "name": "Cash App",
+            "fee": "0.2% + 1 USD",
+            "logo": "https://squa.re/cashapp.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your Google Cache ID"
+              },
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          },
+          {
+            "id": "wire",
+            "name": "Wire Transfer",
+            "fee": "0.1% + 1 USD",
+            "logo": "https://acme.inc/bank_wire_logo.png",
+
+            "fields": [
+              {
+                "id": "swift_code",
+                "title": "Swift Code"
+              },
+              {
+                "id": "routing_number",
+                "title": "Routing Number"
+              },
+              {
+                "id": "dest",
+                "title": "Account Number"
+              },
+              {
+                "id": "receiver_name",
+                "title": "Full names of your recepient"
+              },
+              {
+                "id": "reason",
+                "title": "Reason for the transfer"
+              },
+              {
+                "id": "email",
+                "optional": true,
+                "title": "Your Email",
+                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
+              }
+            ]
+          }
+
+        ]
+      },
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>
+  <b>FIATCNY Example</b>
+</summary>
+
+```json
+{
+  "transfer_protocols": {
+    "sep26": {
+      "transfer_server": "https://acme.inc/api26/cny",
+
+      "deposits": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "wechat",
+            "name": "WeChat",
+            "fee": "0 CNY",
+            "logo": "https://wech.at/wechat.png",
+          },
+          {
+            "id": "alipay",
+            "name": "AliPay",
+            "fee": "0 CNY",
+            "logo": "https://alip.ay/alipay.png",
+          }
+        ]
+      },
+
+      "withdrawals": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"],
+        "options": [
+          {
+            "id": "wechat",
+            "name": "WeChat",
+            "fee": "0.1% + 1 CNY",
+            "logo": "https://wech.at/wechat.png",
+
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your WeChat ID"
+              }
+            ]
+          },
+          {
+            "id": "alipay",
+            "name": "AliPay",
+            "fee": "0.1% + 1 CNY. Max 10 CNY.",
+            "logo": "https://alip.ay/alipay.png",
+            "fields": [
+              {
+                "id": "dest",
+                "title": "Your AliPay ID"
+              }
+            ]
+          }
+        ]
+      },
+      "transaction_history": {
+        "enabled": true,
+        "authentication_protocols": ["sep10"]
+      },
+
+      "authentication_protocols": {
+        "sep10": {
+          "authentication_server" : "sep10.auth.server.com",
+          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
+        }
+      }
+    }
+  }
+}
+```
+</details>
+
+
+## Transfer Protocol sep26
+
+The concept of  "transfer protocols" was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
+
+<details id="sep26">
+<summary>
+  <b>sep26</b>
+</summary>
+
+The following fields are allowed under the `sep26` object.
+
+Field | Type | Description
+------|------|------------|
+`transfer_server`| url | The asset's transfer server for handling deposits, withdrawals and transaction history.
+
+</details>
+
+<details id="sep26.fund_wallet">
+<summary>
+  <b>sep26.fund_wallet</b>
+</summary>
+
+Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the `fund_wallet` field under the `sep26` field.
+
+The following fields are allowed under `fund_wallet`:
+
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Set to true for assets that support funding of unfunded wallet accounts. Default is false if not set.
+`amount_native`| number | The number of lumens the anchored asset will use to fund the wallet
+`fees`| string | human readable fee structure for funding accounts.  e.g. "2 * XLM/BTC market price".
+`funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
+
+</details>
+
+<details id="sep26.deposits">
+<summary>
+  <b>sep26.deposits</b>
+</summary>
+
+Deposit metadata for each anchored asset is specified inside the `deposits` field
+
+The following fields are allowed:
+
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Determines if deposits are supported or not. Wallets should consider deposits disabled if this field is not specified.
+ `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when performing deposits. An anchored asset that doesn't need any authentication protocol for deposits doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for deposits.
+
+</details>
+
+<details id="sep26.deposits.options">
+<summary>
+  <b>sep26.deposits.options</b>
+</summary>
+
+An array of objects containing all supported deposit options for the asset.
+
+The following fields are allowed under each deposit option.
+
+
+Field | Type | Description
+------|------|------------|
+`id`| string (required) | e.g. crypto, mobilemoney, wire
+ `name` | string | Short name for the deposit option.
+ `min_amount`| number | Minimum deposit amount supported by this deposit option.
+ `max_amount` | number | Maximum deposit amount supported by this deposit option.
+ `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees"
+
+</details>
+
+<details id="sep26.deposits.options.fields">
+<summary>
+  <b>sep26.deposits.options.fields</b>
+</summary>
+
+An array of form fields supported for each deposit option.
+
+The following fields are allowed.
+
+
+Field | Type | Description
+------|------|------------|
+`id`| string (required) | Id of the form field. e.g. dest, email, routing_number.
+ `title` | string | Title of the form field e.g. "Your Email", "Routing Number".
+ `description`| string | Description of the form field.
+ `optional` | boolean | Marks the form field as optional or not.
+ `type`| string  | One of 'text', 'number', 'email', or 'choice'. The default form field type is text. See below on how to specify choices for the 'choice' type.
+
+</details>
+
+<details id="sep26.deposits.options.fields.choices">
+<summary>
+  <b>sep26.deposits.options.fields.choices</b>
+</summary>
+
+An array of choices for deposit form fields that have type set to  `choice`.
+
+Field | Type | Description
+------|------|------------|
+`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
+ `title` | string | Human readable title for the choice. E.g. Bank of America.
+
+See the [BTC SEP-27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
+
+</details>
+
+<details id="sep26.withdrawals">
+<summary>
+  <b>sep26.withdrawals</b>
+</summary>
+
+See ["sep26.deposits"](#sep26deposits)
+
+</details>
+
+<details id="sep26.transaction_history">
+<summary>
+  <b>sep26.transaction_history</b>
+</summary>
+
+Transaction history metadata for each anchored asset is specified inside the `transaction_history` field.
+
+The following fields are allowed:
+
+Field | Type | Description
+------|------|------------|
+`enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
+ `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to `["sep10"]`, if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
+
+</details>
+
+<details id="sep26.authentication_protocols.authenticactionProtocol">
+<summary>
+  <b>sep26.authentication_protocols.{authenticactionProtocol}</b>
+</summary>
+
+Authentication configuration parameters for each supported authentication protocol is defined under the `authentication_protocols` field.
+
+The fields allowed depend on each authentication protocol.
+
+For SEP10, you need to specify two fields:
+
+Field | Type | Description
+------|------|------------|
+`authentication_server`| url | Server to use for [SEP-10](sep-0010.md) authentication.
+ `authentication_signing_key` | G... | Public key used for signing SEP-10 transactions.
+
+</details>
+
 ## API Endpoints
 
 * [`POST /deposit`](#deposit): required
@@ -573,456 +1026,3 @@ For example:
    "error": "This anchor doesn't support the given currency code: ETH"
 }
 ```
-
-## SEP-27 Asset Information Response
-
-[SEP-27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP-26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP-27.
-
-<details id="btc-example">
-<summary>
-  <b>BTC Example</b>
-</summary>
-
-```json
-{
-  "transfer_protocols": {
-    "sep26": {
-
-      "transfer_server": "https://api.examplebtcanchor.com",
-
-      "fund_wallet": {
-        "enabled": true,
-        "amount_native": 5,
-        "fee": "2 * XLM/BTC market price",
-        "funding_protocols": ["sep25"]
-      },
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": []
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "fields": [
-          {
-            "id": "priority",
-            "name": "Priority",
-            "type": "choice",
-            "choices": [{
-              "value": "low",
-              "title": "Low"
-            },{
-              "value": "med",
-              "title": "Medium"
-            },{
-              "value": "high",
-              "title": "High"
-            }]
-          }
-        ]
-      },
-
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>
-  <b>FIATUSD Example</b>
-</summary>
-
-```json
-{
-  "transfer_protocols": {
-    "sep26": {
-      "transfer_server": "https://acme.inc/api26/usd",
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "cashapp",
-            "name": "Cash App",
-            "fee": "1 USD",
-            "logo": "https://squa.re/cashapp.png",
-
-            "fields": [
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          },
-          {
-            "id": "wire",
-            "name":  "Wire Transfer",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://acme.inc/bank_wire_logo.png",
-
-            "fields": [
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          }
-        ]
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "facebook_pay",
-            "name": "Facebook Pay",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://fb.com/pay.png",
-
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Facebook Pay ID"
-              }
-            ]
-          },
-          {
-            "id": "google_cache",
-            "name": "Google Cache",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://goog.com/cache.png",
-
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Google Cache ID"
-              }
-            ]
-          },
-          {
-            "id": "cashapp",
-            "name": "Cash App",
-            "fee": "0.2% + 1 USD",
-            "logo": "https://squa.re/cashapp.png",
-
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your Google Cache ID"
-              },
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          },
-          {
-            "id": "wire",
-            "name": "Wire Transfer",
-            "fee": "0.1% + 1 USD",
-            "logo": "https://acme.inc/bank_wire_logo.png",
-
-            "fields": [
-              {
-                "id": "swift_code",
-                "title": "Swift Code"
-              },
-              {
-                "id": "routing_number",
-                "title": "Routing Number"
-              },
-              {
-                "id": "dest",
-                "title": "Account Number"
-              },
-              {
-                "id": "receiver_name",
-                "title": "Full names of your recepient"
-              },
-              {
-                "id": "reason",
-                "title": "Reason for the transfer"
-              },
-              {
-                "id": "email",
-                "optional": true,
-                "title": "Your Email",
-                "description": "Your email will enable us to automatically notify you about the status of your withdrawal."
-              }
-            ]
-          }
-
-        ]
-      },
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>
-  <b>FIATCNY Example</b>
-</summary>
-
-```json
-{
-  "transfer_protocols": {
-    "sep26": {
-      "transfer_server": "https://acme.inc/api26/cny",
-
-      "deposits": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "wechat",
-            "name": "WeChat",
-            "fee": "0 CNY",
-            "logo": "https://wech.at/wechat.png",
-          },
-          {
-            "id": "alipay",
-            "name": "AliPay",
-            "fee": "0 CNY",
-            "logo": "https://alip.ay/alipay.png",
-          }
-        ]
-      },
-
-      "withdrawals": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"],
-        "options": [
-          {
-            "id": "wechat",
-            "name": "WeChat",
-            "fee": "0.1% + 1 CNY",
-            "logo": "https://wech.at/wechat.png",
-
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your WeChat ID"
-              }
-            ]
-          },
-          {
-            "id": "alipay",
-            "name": "AliPay",
-            "fee": "0.1% + 1 CNY. Max 10 CNY.",
-            "logo": "https://alip.ay/alipay.png",
-            "fields": [
-              {
-                "id": "dest",
-                "title": "Your AliPay ID"
-              }
-            ]
-          }
-        ]
-      },
-      "transaction_history": {
-        "enabled": true,
-        "authentication_protocols": ["sep10"]
-      },
-
-      "authentication_protocols": {
-        "sep10": {
-          "authentication_server" : "sep10.auth.server.com",
-          "authentication_signing_key" : "GCKLZLMYTLRBKM6BDZJYAKHDBSNCGBSN7EDF32FMIAYFAITLCB45ZJW4"
-        }
-      }
-    }
-  }
-}
-```
-</details>
-
-
-## Transfer Protocol sep26
-
-The concept of  "transfer protocols" was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
-
-<details id="sep26">
-<summary>
-  <b>sep26</b>
-</summary>
-
-The following fields are allowed under the `sep26` object.
-
-Field | Type | Description
-------|------|------------|
-`transfer_server`| url | The asset's transfer server for handling deposits, withdrawals and transaction history.
-
-</details>
-
-<details id="sep26.fund_wallet">
-<summary>
-  <b>sep26.fund_wallet</b>
-</summary>
-
-Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the `fund_wallet` field under the `sep26` field.
-
-The following fields are allowed under `fund_wallet`:
-
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Set to true for assets that support funding of unfunded wallet accounts. Default is false if not set.
-`amount_native`| number | The number of lumens the anchored asset will use to fund the wallet
-`fees`| string | human readable fee structure for funding accounts.  e.g. "2 * XLM/BTC market price".
-`funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
-
-</details>
-
-<details id="sep26.deposits">
-<summary>
-  <b>sep26.deposits</b>
-</summary>
-
-Deposit metadata for each anchored asset is specified inside the `deposits` field
-
-The following fields are allowed:
-
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Determines if deposits are supported or not. Wallets should consider deposits disabled if this field is not specified.
- `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when performing deposits. An anchored asset that doesn't need any authentication protocol for deposits doesn't need to specify this field. You could for example set the value for authentication_protocols to ["sep10"], if an anchored asset supports [SEP-10](sep-0010.md) authentication for deposits.
-
-</details>
-
-<details id="sep26.deposits.options">
-<summary>
-  <b>sep26.deposits.options</b>
-</summary>
-
-An array of objects containing all supported deposit options for the asset.
-
-The following fields are allowed under each deposit option.
-
-
-Field | Type | Description
-------|------|------------|
-`id`| string (required) | e.g. crypto, mobilemoney, wire
- `name` | string | Short name for the deposit option.
- `min_amount`| number | Minimum deposit amount supported by this deposit option.
- `max_amount` | number | Maximum deposit amount supported by this deposit option.
- `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees"
-
-</details>
-
-<details id="sep26.deposits.options.fields">
-<summary>
-  <b>sep26.deposits.options.fields</b>
-</summary>
-
-An array of form fields supported for each deposit option.
-
-The following fields are allowed.
-
-
-Field | Type | Description
-------|------|------------|
-`id`| string (required) | Id of the form field. e.g. dest, email, routing_number.
- `title` | string | Title of the form field e.g. "Your Email", "Routing Number".
- `description`| string | Description of the form field.
- `optional` | boolean | Marks the form field as optional or not.
- `type`| string  | One of 'text', 'number', 'email', or 'choice'. The default form field type is text. See below on how to specify choices for the 'choice' type.
-
-</details>
-
-<details id="sep26.deposits.options.fields.choices">
-<summary>
-  <b>sep26.deposits.options.fields.choices</b>
-</summary>
-
-An array of choices for deposit form fields that have type set to  `choice`.
-
-Field | Type | Description
-------|------|------------|
-`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
- `title` | string | Human readable title for the choice. E.g. Bank of America.
-
-See the [BTC SEP-27 example response](#btc-example) above of an asset that uses the choice type on a withdrawal field.
-
-</details>
-
-<details id="sep26.withdrawals">
-<summary>
-  <b>sep26.withdrawals</b>
-</summary>
-
-See ["sep26.deposits"](#sep26deposits)
-
-</details>
-
-<details id="sep26.transaction_history">
-<summary>
-  <b>sep26.transaction_history</b>
-</summary>
-
-Transaction history metadata for each anchored asset is specified inside the `transaction_history` field.
-
-The following fields are allowed:
-
-Field | Type | Description
-------|------|------------|
-`enabled`| boolean | Determines if transaction history is enabled or not. Wallets should consider transaction history disabled if this field is not specified.
- `authentication_protocols` | array | An array of all  authentication methods supported by the anchored asset when querying transaction history. An anchored asset that doesn't need any authentication protocol for transaction history doesn't need to specify this field. You could for example set the value for authentication_protocols to `["sep10"]`, if an anchored asset supports [SEP-10](sep-0010.md) authentication for transaction history.
-
-</details>
-
-<details id="sep26.authentication_protocols.authenticactionProtocol">
-<summary>
-  <b>sep26.authentication_protocols.{authenticactionProtocol}</b>
-</summary>
-
-Authentication configuration parameters for each supported authentication protocol is defined under the `authentication_protocols` field.
-
-The fields allowed depend on each authentication protocol.
-
-For SEP10, you need to specify two fields:
-
-Field | Type | Description
-------|------|------------|
-`authentication_server`| url | Server to use for [SEP-10](sep-0010.md) authentication.
- `authentication_signing_key` | G... | Public key used for signing SEP-10 transactions.
-
-</details>

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -574,11 +574,16 @@ For example:
 }
 ```
 
-## SEP27 Asset Information Response
+## SEP-27 Asset Information Response
 
-[SEP27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP27.
+[SEP-27](sep-0027.md) specifies an endpoint that provides extra information about an asset. We define our SEP-26 transfer protocols parameters inside the `transfer_protocols` field as specified in SEP-27.
 
-### BTC Example
+### Examples
+
+<details>
+<summary>
+  <b>BTC Example</b>
+</summary>
 
 ```json
 {
@@ -638,7 +643,12 @@ For example:
 }
 ```
 
-### FIATUSD Example
+</details>
+
+<details>
+<summary>
+  <b>FIATUSD Example</b>
+</summary>
 
 ```json
 {
@@ -786,7 +796,12 @@ For example:
 }
 ```
 
-### FIATCNY Example
+</details>
+
+<details>
+<summary>
+  <b>FIATCNY Example</b>
+</summary>
 
 ```json
 {
@@ -859,13 +874,14 @@ For example:
   }
 }
 ```
+</details>
 
 
-## `sep26` transfer protocol
+## Transfer Protocol sep26
 
-The concept of  `transfer protocols` was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
+The concept of  "transfer protocols" was introduced in [SEP-27](sep-0027.md). By convention, the transfer protocol described in this document will be called `sep26`. Other transfer protocols include [`sep24`](sep-0024.md).
 
-The following fields are allowed under the "sep26" object.
+The following fields are allowed under the `sep26` object.
 
 
 Field | Type | Description


### PR DESCRIPTION
Make large example responses collapsible using `<details>`/`<summary>` elements. The doc as of now looks super intimidating, even to SEP-6 / SEP-24 veterans. This should make it much easier to keep an overview.

[**Before**](https://github.com/stellar/stellar-protocol/blob/fcc397b6cc3dbbeb3ef44323581395322e907816/ecosystem/sep-0026.md) • [**After**](https://github.com/andywer/stellar-protocol/blob/sep-26/make-easier-to-read/ecosystem/sep-0026.md)

Related to #484.