### PR TITLE
Update SEP-26 endpoint route paths

### DIFF
--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -155,7 +155,7 @@ To support this protocol, an anchor acts as a server and implements the specifie
             "name": "Facebook Pay",
             "fee": "0.1% + 1 USD",
             "logo": "https://fb.com/pay.png",
-            
+
             "fields": [
               {
                 "id": "dest",
@@ -168,7 +168,7 @@ To support this protocol, an anchor acts as a server and implements the specifie
             "name": "Google Cache",
             "fee": "0.1% + 1 USD",
             "logo": "https://goog.com/cache.png",
-            
+
             "fields": [
               {
                 "id": "dest",
@@ -181,7 +181,7 @@ To support this protocol, an anchor acts as a server and implements the specifie
             "name": "Cash App",
             "fee": "0.2% + 1 USD",
             "logo": "https://squa.re/cashapp.png",
-            
+
             "fields": [
               {
                 "id": "dest",
@@ -230,7 +230,7 @@ To support this protocol, an anchor acts as a server and implements the specifie
               }
             ]
           }
-          
+
         ]
       },
       "transaction_history": {
@@ -287,7 +287,7 @@ To support this protocol, an anchor acts as a server and implements the specifie
             "name": "WeChat",
             "fee": "0.1% + 1 CNY",
             "logo": "https://wech.at/wechat.png",
-            
+
             "fields": [
               {
                 "id": "dest",
@@ -341,7 +341,7 @@ Field | Type | Description
 
 ## sep26 / fund_wallet
 
-Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the "fund_wallet" field under the "sep26" field. 
+Certain anchored assets may support the ability to fund unfunded accounts. In that case, the anchor should define the "fund_wallet" field under the "sep26" field.
 
 The following fields are allowed under "fund_wallet":
 
@@ -354,7 +354,7 @@ Field | Type | Description
 `funding_protocols`| array | An array of funding protocols the anchored asset supports. e.g. ["sep25"](sep-0025.md). For custom funding protocols that only work on specific wallets, simply use the name of your supported wallets e.g. ["sep25", "walleta", "walletb"]
 
 
-## sep26 / deposits 
+## sep26 / deposits
 
 Deposit metadata for each anchored asset is specified inside the "deposits" field
 
@@ -381,7 +381,7 @@ Field | Type | Description
  `name` | string | Short name for the deposit option.
  `min_amount`| number | Minimum deposit amount supported by this deposit option.
  `max_amount` | number | Maximum deposit amount supported by this deposit option.
- `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees" 
+ `fee`| string/url | Human readable fee structure supported by this deposit option. e.g. "1 USD", "0.1%", "0.1% plus 0.001 BTC", "0.1%, Max: 100 USD", "https://acme.inc/ourfees"
 
 
 ## sep26 / deposits / options / fields
@@ -393,7 +393,7 @@ The following fields are allowed.
 
 Field | Type | Description
 ------|------|------------|
-`id`| string (required) | Id of the form field. e.g. dest, email, routing_number. 
+`id`| string (required) | Id of the form field. e.g. dest, email, routing_number.
  `title` | string | Title of the form field e.g. "Your Email", "Routing Number".
  `description`| string | Description of the form field.
  `optional` | boolean | Marks the form field as optional or not.
@@ -408,14 +408,14 @@ An array of choices for deposit form fields that have type set to  `choice`.
 
 Field | Type | Description
 ------|------|------------|
-`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001". 
+`value`| string (required) | e.g. This is the value that will be sent back to the deposit  api endpoint. e.g. "bank001".
  `title` | string | Human readable title for the choice. E.g. Bank of America.
 
  See the [BTC SEP27 example response](#btc-example)  above of an asset that uses the choice type on a withdrawal field.
 
 
 
-## sep26 / withdrawals 
+## sep26 / withdrawals
 
 See ["sep26 / deposits"](#sep26-/-deposits)
 
@@ -448,8 +448,8 @@ Field | Type | Description
 
 ## API Endpoints
 
-* [`POST /deposit`](#deposit): required
-* [`POST /withdraw`](#withdraw): required
+* [`POST /transactions/deposit/non-interactive`](#deposit): required
+* [`POST /transactions/withdraw/non-interactive`](#withdraw): required
 * [`GET /transactions`](#transaction-history): optional, but recommended
 * [`GET /transaction`](#single-historical-transaction): optional
 
@@ -457,7 +457,7 @@ Field | Type | Description
 
 Asset anchors that need authentication should do the relevant changes to their SEP27 response JSON as stipulated above.
 
-Wallets, clients and anchors should follow the authentication protocol specifications of each supported authentication protocol. For example  [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups. 
+Wallets, clients and anchors should follow the authentication protocol specifications of each supported authentication protocol. For example  [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.
 
 ## Cross-Origin Headers
 
@@ -482,18 +482,18 @@ SEP-26 lays out many options for how deposit and withdrawal can work non-interac
 * Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file  and [SEP27](sep-0027.md) response to display useful information to the user about the asset they've picked. Asset information obtained via SEP27 takes precendence over the same information found in stellar.toml. This is especially true for fields that need localization.
 * Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file and SEP27 response.
-* **Use the `SEP27` response to:** 
+* **Use the `SEP27` response to:**
     * Determine which anchor endpoints will require authentication
     * Fetch the asset's deposit & withdawal fee structure: show this to the user early in the process so they're fully informed.
 * **Authentication**
    * If needed, perform [authentication](#authentication) via SEP-10 or any other supported authentication mechanism before hitting those endpoints
-* **Make a request to `/deposit` or `/withdraw`.**
-* **For `/deposit`**
-    * If the issuer's `/deposit` endpoint immediately returns success:
+* **Make a request to `/transactions/deposit/non-interactive` or `/transactions/withdraw/non-interactive`.**
+* **For `/transactions/deposit/non-interactive`**
+    * If the issuer's `/transactions/deposit/non-interactive` endpoint immediately returns success:
         * display the deposit info that came back from the endpoint to the user, including fee. You're done! The user will execute the deposit exernally using the instructions if they want to.
     * Handle the [special cases](#special-cases), they're relatively common.
-* **For `/withdraw`**
-    * If the issuer's `/withdraw` endpoint immediately returns success:
+* **For `/transactions/withdraw/non-interactive`**
+    * If the issuer's `/transactions/withdraw/non-interactive` endpoint immediately returns success:
         * Provide an interface to the user that allows them to view the withdrawal details including the computed fee. The user can confirm and then the wallet will initiate the withdrawal by sending the Stellar payment to the address provided by the issuer.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so exchange rate fluctuations might require withdrawal values to slightly vary from the originally provided `amount`. Anchors are instructed to accept a variation of ±10% between the informed `amount` and the actual value sent to the anchor's Stellar account. The withdrawn amount will be adjusted accordingly.
 * **Transaction history**
@@ -519,7 +519,7 @@ If the given account does not exist, or if the account doesn't have a trust line
 ### Request
 
 ```
-POST TRANSFER_SERVER/deposit
+POST TRANSFER_SERVER/transactions/deposit/non-interactive
 Content-Type: multipart/form-data
 
 ```
@@ -529,7 +529,7 @@ Request Parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset the user wants to deposit with the anchor. E.g.  BTC, ETH, USD, INR, etc. This should be the same asset code specified in the stellar.toml file.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent to.
 `memo_type` | string | (optional) Type of memo that the anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -542,7 +542,7 @@ Name | Type | Description
 Example:
 
 ```
-POST https://api.example.com/deposit
+POST https://api.example.com/transactions/deposit/non-interactive
 Content-Type: multipart/form-data
 
 asset_code=ETH&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
@@ -603,7 +603,7 @@ Ripple response example:
     }
 
   ]
-    
+
 }
 ```
 
@@ -615,7 +615,7 @@ Mexican peso (MXN) response example:
   "eta": 1800,
   "fee": 100,
   "extra_info": [
-    
+
     {
       "key" : "Bank",
       "value": "STP"
@@ -661,7 +661,7 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 ### Request
 
 ```
-POST TRANSFER_SERVER/withdraw
+POST TRANSFER_SERVER/transactions/withdraw/non-interactive
 Content-Type: multipart/form-data
 ```
 
@@ -670,7 +670,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. For example, if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `amount` | number | The amount the user wishes to withdraw. Some anchors may use the amount to withdraw to determine fees.
 `type` | string |  Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
@@ -684,7 +684,7 @@ Name | Type | Description
 Example:
 
 ```
-POST https://api.example.com/withdraw
+POST https://api.example.com/transactions/withdraw/non-interactive
 Content-Type: multipart/form-data
 
 asset_code=ETH&dest=0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe
@@ -745,7 +745,7 @@ Response code: `403 Forbidden`
 
 An anchor that requires the user to fill out `one time` information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or needs a user to agree to Terms of Service. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
 
-Note that this is for `one time` information only. Please use [SEP24] (sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing. 
+Note that this is for `one time` information only. Please use [SEP24] (sep-0024.md) instead if you need other custom steps interactive to be performed for every deposit and withdrawal. e.g. SMS confirmation before withdrawing.
 
 
 
@@ -767,7 +767,7 @@ Example response:
 
 **`jwt` details**
 
-Even when the user has authenticated with [SEP-0010](sep-0010.md), the wallet should NEVER pass the jwt into the interactive URL. 
+Even when the user has authenticated with [SEP-0010](sep-0010.md), the wallet should NEVER pass the jwt into the interactive URL.
 
 
 
@@ -836,7 +836,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
-`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor. 
+`asset_issuer` | string | The issuer of the asset the user wants to deposit with the anchor.
 `account` | string | The stellar account ID involved in the transactions.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.


### PR DESCRIPTION
Make them consistent with SEP-24 route paths. My VS code also auto-fixed a bunch of trailing spaces.

- `/deposit` => `/transactions/deposit/non-interactive`
- `/withdraw` => `/transactions/withdraw/non-interactive`

I mentioned the intended change in #484, but got no reply so far. So here is the PR as it's straight-forward. If you disagree with this change, let's discuss it here or over at #484 🙂