### PR TITLE
SEP-0010: Note behavior for non-existent accounts in Abstract

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <sergey@mobius.network>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-01-29
-Version 1.3.0
+Updated: 2020-04-03
+Version 1.3.1
 ```
 
 ## Simple Summary
@@ -24,10 +24,14 @@ The authentication flow is as follows:
 1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
 1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
-1. The server gets the signers of the user's account
-1. The server verifies the signatures
-1. The server verifies the weight provided by the signers meets the required threshold(s), if any
-1. If the signature checks out, the server responds with a [JWT](https://jwt.io) that represents the user's session
+1. The server checks that the user's account exists
+1. If the user's account exists:
+  1. The server gets the signers of the user's account
+  1. The server verifies the signatures
+  1. The server verifies the weight provided by the signers meets the required threshold(s), if any
+  1. If the signature checks out, the server responds with a [JWT](https://jwt.io) that represents the user's session
+1. If the user's account does not exist (optional):
+  1. The server verifies the signature is correct for the master key of the account
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
 
 The flow achieves several things:
@@ -39,6 +43,7 @@ The flow achieves several things:
 * The server can choose its own timeout for the user's session
 * The server can choose required threshold(s) that the user needs on the account, if any
 * The server can choose to include other application specific claims
+* The server can choose to authenticate accounts that do not yet exist
 
 ## Authentication Endpoint
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -27,11 +27,13 @@ The authentication flow is as follows:
 1. The server checks that the user's account exists
 1. If the user's account exists:
   1. The server gets the signers of the user's account
-  1. The server verifies the signatures
+  1. The server verifies the client signatures count is one or more;
+  1. The server verifies the client signatures on the transaction are signers user's account;
   1. The server verifies the weight provided by the signers meets the required threshold(s), if any
-  1. If the signature checks out, the server responds with a [JWT](https://jwt.io) that represents the user's session
+  1. If the signatures checks out, the server responds with a [JWT](https://jwt.io) that represents the user's session
 1. If the user's account does not exist (optional):
-  1. The server verifies the signature is correct for the master key of the account
+  1. The server verifies the client signature count is one
+  1. The server verifies the client signature is correct for the master key of the account
 1. Any future calls to the server can be authenticated by including the JWT as a parameter
 
 The flow achieves several things:

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -28,7 +28,7 @@ The authentication flow is as follows:
 1. If the user's account exists:
   1. The server gets the signers of the user's account
   1. The server verifies the client signatures count is one or more;
-  1. The server verifies the client signatures on the transaction are signers user's account;
+  1. The server verifies the client signatures on the transaction are signers of the user's account;
   1. The server verifies the weight provided by the signers meets the required threshold(s), if any
   1. If the signatures check out, the server responds with a [JWT](https://jwt.io) that represents the user's session
 1. If the user's account does not exist (optional):

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -30,7 +30,7 @@ The authentication flow is as follows:
   1. The server verifies the client signatures count is one or more;
   1. The server verifies the client signatures on the transaction are signers user's account;
   1. The server verifies the weight provided by the signers meets the required threshold(s), if any
-  1. If the signatures checks out, the server responds with a [JWT](https://jwt.io) that represents the user's session
+  1. If the signatures check out, the server responds with a [JWT](https://jwt.io) that represents the user's session
 1. If the user's account does not exist (optional):
   1. The server verifies the client signature count is one
   1. The server verifies the client signature is correct for the master key of the account


### PR DESCRIPTION
### What
Add notes to the Abstract section about the optional behavior with Stellar accounts that do not yet exist.

### Why
This behavior is already detailed in the section that describes the behavior of the server when handling the Token endpoint. This is not new behavior, but not mentioning the behavior in the abstract has led to some confusion because a reader who only reads the abstract will think that an account must exist to be compatible with SEP-10.

The version bump as a patch number is due to no functional changes to the proposal.