### PR TITLE
Make the VERSION field more prominent

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -48,6 +48,7 @@ These are global fields in the `stellar.toml` file.
 
 Field | Requirements | Description
 ------|--------------|------------
+VERSION | string | The version of SEP-1 your `stellar.toml` adheres to.  This helps parsers know which fields to expect.
 NETWORK_PASSPHRASE | string | The passphrase for the specific [Stellar network](https://www.stellar.org/developers/guides/concepts/networks.html) this infrastructure operates on
 FEDERATION_SERVER | uses `https://` | The endpoint for clients to resolve stellar addresses for users on your domain via [SEP-2](sep-0002.md) Federation Protocol
 AUTH_SERVER | uses `https://` | The endpoint used for [SEP-3](sep-0003.md) Compliance Protocol
@@ -58,7 +59,6 @@ WEB_AUTH_ENDPOINT | uses `https://` | The endpoint used for [SEP-10 Web Authenti
 SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.md) Compliance Protocol and [SEP-10](sep-0010.md) Authentication Protocol
 HORIZON_URL | url | Location of public-facing Horizon instance (if you offer one)
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
-VERSION | string | The version of SEP-1 your `stellar.toml` adheres to.  This helps parsers know which fields to expect.
 URI_REQUEST_SIGNING_KEY | Stellar public key | The signing key is used for [SEP-7](sep-0007.md) delegated signing
 
 ### Issuer Documentation
@@ -192,6 +192,7 @@ Content-length: 482
 
 ```toml
 # Sample stellar.toml
+VERSION="2.0.0"
 
 NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 FEDERATION_SERVER="https://api.domain.com/federation"
@@ -204,7 +205,6 @@ ACCOUNTS=[
 "GAENZLGHJGJRCMX5VCHOLHQXU3EMCU5XWDNU4BGGJFNLI2EL354IVBK7",
 "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
 ]
-VERSION="2.0.0"
 
 [DOCUMENTATION]
 ORG_NAME="Organization Name"


### PR DESCRIPTION
This is a minor cosmetic change to put the version field in a more prominent location in the spec and in the example