### PR TITLE
[sep24] Add asset_issuer

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -109,7 +109,7 @@ The public key in the verification photo should be the issuing public key for th
 
 ### Currency Documentation
 
-These fields go in the `stellar.toml` `[[CURRENCIES]]` list, one set of fields for each currency issued. Complete all applicable fields, and exclude any that don't apply.
+These fields go in the `stellar.toml` `[[CURRENCIES]]` list, one set of fields for each currency supported. Complete all applicable fields, and exclude any that don't apply.
 
 Field | Requirements | Description
 ------|--------------|------------
@@ -135,6 +135,7 @@ collateral_address_signatures | list of signature strings | These prove you cont
 regulated| boolean | indicates whether or not this is a [sep0008](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md) regulated asset. If missing, `false` is assumed.
 approval_server | url | url of a [sep0008](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md) compliant approval service that signs validated transactions.
 approval_criteria | string | a human readable string that explains the issuer's requirements for approving transactions.
+non_issuer | boolean | indicates that the asset is not issued by this organization, but can still be supported via a transfer server or other use cases.
 
 
 Message to put in `collateral_address_messages` for each entry in `collateral_addresses`:

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -135,7 +135,6 @@ collateral_address_signatures | list of signature strings | These prove you cont
 regulated| boolean | indicates whether or not this is a [sep0008](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md) regulated asset. If missing, `false` is assumed.
 approval_server | url | url of a [sep0008](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md) compliant approval service that signs validated transactions.
 approval_criteria | string | a human readable string that explains the issuer's requirements for approving transactions.
-non_issuer | boolean | indicates that the asset is not issued by this organization, but can still be supported via a transfer server or other use cases.
 
 
 Message to put in `collateral_address_messages` for each entry in `collateral_addresses`:

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -140,7 +140,7 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.
+`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the code `XLM`.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
@@ -208,7 +208,7 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.  If the user wants to withdraw lumens use the code `XLM`.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to deposit with the anchor.  If the user wants to withdraw lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -140,7 +140,8 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC, ETH, USD, INR, etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be BTC.
+`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
@@ -207,7 +208,8 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to deposit with the anchor.  If the user wants to withdraw lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.


### PR DESCRIPTION
Fixes #443 
Adds an asset_issuer field to the initial POST requests when creating a transaction.  This serves 2 purposes:
1. Allows anchors to deposit/withdraw assets they didn't issue
1. Allows deposit/withdraw of lumens

It also changes the definition of asset_code to refer to the stellar asset for deposit as well as withdrawal, instead of being different for deposit and withdrawal.  This was a subtle difference that caused a lot of confusion.