### PR TITLE
[SEP24] Remove interactive call no-info-needed response

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -237,40 +237,9 @@ There are several possible kinds of response, depending on whether the anchor ne
 
 The first response, the success response, is explained below. The other possible responses are shared with the deposit endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section directly below.
 
-#### 1. Success: no additional information needed
-
-Response code: `200 OK`
-
-This is the correct response if the anchor is able to execute the withdrawal and needs no additional information about the user. It should also be used if the anchor requires information about the user, but the information has previously been submitted and accepted.
-
-The response body should be a JSON object with the following fields:
-
-Name | Type | Description
------|------|------------
-`account_id` | `G...` string | The account the user should send its token back to.
-`memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
-`memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
-`eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
-`min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
-`max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
-`fee_fixed` | float | (optional)  Fixed (Base) fee, in units of withdrawn asset.  This is in addition to any `fee_percent`.
-`fee_percent` | float | (optional) Percentage fee in units of percent.  This is in addition to any `fee_fixed`.
-`fee_minimum` | float | (optional) Minimum fee in units of withdrawn asset.
-`extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name.
-
-Example:
-
-```json
-{
-  "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
-  "memo_type": "id",
-  "memo": "123"
-}
-```
-
 ## Deposit and Withdraw shared responses
 
-### 2. Interactive customer information needed
+### Interactive customer information needed
 
 Response code: `200 OK`
 


### PR DESCRIPTION
SEP24 always has an interactive portion so we shouldn't provide a case that was from SEP6 where no information was needed and it was safe to not do any interactive portion.  
Fixes #539 