### PR TITLE
Update SEP-29 to handle muxed accounts

### DIFF
--- a/ecosystem/sep-0029.md
+++ b/ecosystem/sep-0029.md
@@ -46,7 +46,7 @@ with a `MANAGE_DATA` operation that adds a data entry with the name
 
 When a payment sender submits a transaction containing a `PAYMENT`,
 `PATH_PAYMENT_STRICT_SEND`, `PATH_PAYMENT_STRICT_RECEIVE`, or `MERGE_ACCOUNT`
-operation they:
+operation to a destination account which is **not** a [multiplexed account](../core/cap-0027.md) they:
 
 - Load details about the destination account.
 - Check if the destination account has the `config.memo_required` data entry set.

--- a/ecosystem/sep-0029.md
+++ b/ecosystem/sep-0029.md
@@ -6,8 +6,8 @@ Title: Account Memo Requirements
 Author: OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières
 Status: Active
 Created: 2019-12-27
-Updated: 2020-02-13
-Version: 0.4.0
+Updated: 2020-05-04
+Version: 0.5.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
If there as a payment operation where the destination address is a muxed account with a memo id, then we should not perform the SEP29 check on the destination account. A muxed account with a memo id essentially encodes a memo within the account's address. There is no point in requiring clients to provide a memo when sending payments to a multiplexed account.