### PR TITLE
SEP-0030: Add support for rotating signing keys

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -260,7 +260,7 @@ Name | Type | Description
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signer` | string | **Deprecated.** The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
-`signers[].signer` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
+`signers[].key` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
 `signers[].added_at` | string | The RFC3339/ISO8601 timestamp of when the signer was added and became available on this server for signing.
 
 ##### Example (With One Role)

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -577,7 +577,6 @@ transaction=AAAAAHAHhQtYBh5F2zA6...
 Name | Type | Description
 -----|------|------------
 `signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
-`signer` | string | The signer public key that the server used to sign the transaction.
 `network_passphrase` | string | The network passphrase used when generating a signature.
 
 ###### Example
@@ -585,7 +584,6 @@ Name | Type | Description
 ```json
 {
   "signature": "YpVelqPAKsYTP...",
-  "signer": "GADF...",
   "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -747,7 +747,7 @@ any reason, e.g. as a routine best practice, or in response to a compromised
 key. An implementor should maintain old signing keys so that accounts that have
 not added a new signing key are still able to use them.
 
-A client can query the backend for what signers the server has available for an
+A client can query the server for what signers the server has available for an
 account and should replace the signer on the account with the most recently
 generated signing key at its earliest convenience.
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -7,8 +7,8 @@ Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Created: 2019-12-20
-Updated: 2020-03-11
-Version: 0.2.0
+Updated: 2020-05-18
+Version: 0.3.0
 ```
 
 ## Summary
@@ -73,6 +73,7 @@ them.
 A client can also use the endpoints in the specification to:
 - Discover registered accounts that it has access to.
 - Update the identities associated with an account.
+- Find out if a new signing key is available due to signing key rotation.
 - Delete accounts.
 
 ## Use Cases
@@ -257,7 +258,10 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | Same as request. See above.
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
-`signer` | string | The signer public key that the server will sign transactions with for this account when requested by an authenticated user.
+`signer` | string | The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
+`signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
+`signers[].signer` | array | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
+`signers[].generated_at` | array | The ISO8601 timestamp of when the signer was generated and became available for signing.
 
 ##### Example (With One Role)
 
@@ -267,7 +271,10 @@ Name | Type | Description
   "identities": [
     { "role": "owner", "authenticated": true }
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
@@ -280,7 +287,10 @@ Name | Type | Description
     { "role": "sender", "authenticated": true },
     { "role": "receiver" }
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
@@ -289,6 +299,7 @@ Name | Type | Description
 - [`POST /accounts/<address>`](#post-accountsaddress)
 - [`PUT /accounts/<address>`](#put-accountsaddress)
 - [`POST /accounts/<address>/sign`](#post-accountsaddresssign)
+- [`POST /accounts/<address>/sign/<signing-address>`](#post-accountsaddresssignsigningaddress)
 - [`GET /accounts/<address>`](#get-accountsaddress)
 - [`DELETE /accounts/<address>`](#delete-accountsaddress)
 - [`GET /accounts`](#get-accounts)
@@ -357,7 +368,10 @@ See [Common Fields].
   "identities": [
     { "role": "owner" }
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
@@ -370,7 +384,10 @@ See [Common Fields].
     { "role": "sender" },
     { "role": "receiver" }
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
@@ -436,13 +453,19 @@ See [Common Fields].
     { "role": "sender" },
     { "role": "receiver" },
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
 #### `POST /accounts/<address>/sign`
 
-This endpoint signs a transaction that has operations for the account.
+**Deprecated.** Use [`POST /accounts/<address>/sign/<signing-address>`](#post-accountsaddresssignsigningaddress).
+
+This endpoint signs a transaction that has operations for the account using the
+most recent signing key that the server has generated for the account.
 
 The transaction must only contain operations for the account. The source
 account of the transaction and the source account of all operations in the
@@ -526,7 +549,78 @@ See [Common Fields].
     { "role": "sender", "authenticated": true },
     { "role": "receiver" },
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
+}
+```
+
+#### `POST /accounts/<address>/sign/<signing-address>`
+
+This endpoint signs a transaction that has operations for the account using the
+signing key associated with the signing address specified in the path.
+
+The signing address specified must be one of the signing keys that the server
+has provided as a signer. The client should use the signing address that has
+been added as a signer to the account. The server may generate new signing keys
+over time as a best practice in rotating keys. All keys generated will be
+available for signing. An account should check what signers are available
+periodically and update the signer on the account to be the most recently
+generated signer.
+
+The transaction must only contain operations for the account. The source
+account of the transaction and the source account of all operations in the
+transaction must match the account in the request.
+
+The transaction can contain any operations, but it is anticipated for the use
+cases discussed earlier in this protocol that the transaction will contain an
+operation to add a new signer to the account and possibly to remove an old
+signer or to merge an account. The signature will be generated using the
+signing key that the server generated during registration for the account.
+
+##### Authentication
+[`SEP-10`] or [`External`].
+
+##### Request
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`transaction` | string | A XDR base64 encoded Stellar transaction.
+
+###### Example (JSON)
+
+```json
+{
+  "transaction": "AAAAAHAHhQtYBh5F2zA6...",
+}
+```
+
+###### Example (Form)
+
+```
+transaction=AAAAAHAHhQtYBh5F2zA6...
+```
+
+##### Response
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
+`signer` | string | The signer public key that the server used to sign the transaction.
+`network_passphrase` | string | The network passphrase used when generating a signature.
+
+###### Example
+
+```json
+{
+  "signature": "YpVelqPAKsYTP...",
+  "signer": "GADF...",
+  "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```
 
@@ -554,7 +648,10 @@ See [Common Fields].
     { "role": "sender", "authenticated": true },
     { "role": "receiver" },
   ],
-  "signer": "GADF..."
+  "signer": "GADF...",
+  "signers": [
+    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+  ]
 }
 ```
 
@@ -595,7 +692,10 @@ Name | Type | Description
       "identities": [
         { "authenticated": true }
       ],
-      "signer": "GDJF..."
+      "signer": "GDJF...",
+      "signers": [
+        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+      ]
     },
     {
       "address": "GFDD...",
@@ -603,7 +703,10 @@ Name | Type | Description
         { "role": "sender", "authenticated": true },
         { "role": "receiver" },
       ],
-      "signer": "GADF..."
+      "signer": "GADF...",
+      "signers": [
+        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+      ]
     },
     {
       "address": "GACD...",
@@ -611,7 +714,10 @@ Name | Type | Description
         { "role": "sender" },
         { "role": "receiver", "authenticated": true },
       ],
-      "signer": "GABF..."
+      "signer": "GABF...",
+      "signers": [
+        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+      ]
     }
   ]
 }
@@ -621,14 +727,31 @@ Name | Type | Description
 
 Building, hosting and using this system has numerous security concerns because
 a server is being delegated to be a signer of an account and will handle one or
-more signing keys for many accounts. Implementers should also consider [JWT],
-encryption, secure coding, and general security best practices.
+more signing keys for many accounts.
+
+This list of concerns is not exhaustive.
+
+### JWT
+
+Implementers should also consider [JWT], encryption, secure coding, and general
+security best practices.
+
+### Verifying Identities
 
 Implementers and users of the protocol must consider the risks of relying on
 alternative identities such as phone number or email to be definite proof of
 the identity of a client or user.
 
-This list of concerns is not exhaustive.
+### Signing Key Rotation
+
+Implmeneters may choose to rotate the keys used as signers of the accounts for
+any reason, e.g. as a routine best practice, or in response to a compromised
+key. An implementor should maintain old signing keys so that accounts that have
+not added a new signing key are still able to use them.
+
+A client can query the backend for what signers the server has available for an
+account and should replace the signer on the account with the most recently
+generated signing key at its earliest convenience.
 
 ## Limitations
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -258,10 +258,10 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | Same as request. See above.
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
-`signer` | string | The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
+`signer` | string | **Deprecated.** The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
 `signers[].signer` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
-`signers[].generated_at` | string | The RFC3339/ISO8601 timestamp of when the signer was generated and became available for signing.
+`signers[].added_at` | string | The RFC3339/ISO8601 timestamp of when the signer was added and became available on this server for signing.
 
 ##### Example (With One Role)
 
@@ -273,7 +273,7 @@ Name | Type | Description
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -289,7 +289,7 @@ Name | Type | Description
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -370,7 +370,7 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -386,7 +386,7 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -455,7 +455,7 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -466,6 +466,74 @@ See [Common Fields].
 
 This endpoint signs a transaction that has operations for the account using the
 most recent signing key that the server has generated for the account.
+
+The transaction must only contain operations for the account. The source
+account of the transaction and the source account of all operations in the
+transaction must match the account in the request.
+
+The transaction can contain any operations, but it is anticipated for the use
+cases discussed earlier in this protocol that the transaction will contain an
+operation to add a new signer to the account and possibly to remove an old
+signer or to merge an account. The signature will be generated using the
+signing key that the server generated during registration for the account.
+
+##### Authentication
+[`SEP-10`] or [`External`].
+
+##### Request
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`transaction` | string | A XDR base64 encoded Stellar transaction.
+
+###### Example (JSON)
+
+```json
+{
+  "transaction": "AAAAAHAHhQtYBh5F2zA6...",
+}
+```
+
+###### Example (Form)
+
+```
+transaction=AAAAAHAHhQtYBh5F2zA6...
+```
+
+##### Response
+
+###### Fields
+
+Name | Type | Description
+-----|------|------------
+`signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
+`signer` | string | The signer public key that the server used to sign the transaction.
+`network_passphrase` | string | The network passphrase used when generating a signature.
+
+###### Example
+
+```json
+{
+  "signature": "YpVelqPAKsYTP...",
+  "signer": "GADF...",
+  "network_passphrase": "Test SDF Network ; September 2015"
+}
+```
+
+#### `POST /accounts/<address>/sign/<signing-address>`
+
+This endpoint signs a transaction that has operations for the account using the
+signing key associated with the signing address specified in the path.
+
+The signing address specified must be one of the signing keys that the server
+has provided as a signer. The client should use the signing address that has
+been added as a signer to the account. The server may generate new signing keys
+over time as a best practice in rotating keys. All keys generated will be
+available for signing. An account should check what signers are available
+periodically and update the signer on the account to be the most recently
+generated signer.
 
 The transaction must only contain operations for the account. The source
 account of the transaction and the source account of all operations in the
@@ -551,76 +619,8 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
-}
-```
-
-#### `POST /accounts/<address>/sign/<signing-address>`
-
-This endpoint signs a transaction that has operations for the account using the
-signing key associated with the signing address specified in the path.
-
-The signing address specified must be one of the signing keys that the server
-has provided as a signer. The client should use the signing address that has
-been added as a signer to the account. The server may generate new signing keys
-over time as a best practice in rotating keys. All keys generated will be
-available for signing. An account should check what signers are available
-periodically and update the signer on the account to be the most recently
-generated signer.
-
-The transaction must only contain operations for the account. The source
-account of the transaction and the source account of all operations in the
-transaction must match the account in the request.
-
-The transaction can contain any operations, but it is anticipated for the use
-cases discussed earlier in this protocol that the transaction will contain an
-operation to add a new signer to the account and possibly to remove an old
-signer or to merge an account. The signature will be generated using the
-signing key that the server generated during registration for the account.
-
-##### Authentication
-[`SEP-10`] or [`External`].
-
-##### Request
-
-###### Fields
-
-Name | Type | Description
------|------|------------
-`transaction` | string | A XDR base64 encoded Stellar transaction.
-
-###### Example (JSON)
-
-```json
-{
-  "transaction": "AAAAAHAHhQtYBh5F2zA6...",
-}
-```
-
-###### Example (Form)
-
-```
-transaction=AAAAAHAHhQtYBh5F2zA6...
-```
-
-##### Response
-
-###### Fields
-
-Name | Type | Description
------|------|------------
-`signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
-`signer` | string | The signer public key that the server used to sign the transaction.
-`network_passphrase` | string | The network passphrase used when generating a signature.
-
-###### Example
-
-```json
-{
-  "signature": "YpVelqPAKsYTP...",
-  "signer": "GADF...",
-  "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```
 
@@ -650,7 +650,7 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
 }
 ```
@@ -694,7 +694,7 @@ Name | Type | Description
       ],
       "signer": "GDJF...",
       "signers": [
-        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]
     },
     {
@@ -705,7 +705,7 @@ Name | Type | Description
       ],
       "signer": "GADF...",
       "signers": [
-        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]
     },
     {
@@ -716,7 +716,7 @@ Name | Type | Description
       ],
       "signer": "GABF...",
       "signers": [
-        { "signer": "GADF...", "generated_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]
     }
   ]

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -260,8 +260,8 @@ Name | Type | Description
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signer` | string | The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
-`signers[].signer` | array | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
-`signers[].generated_at` | array | The RFC3339/ISO8601 timestamp of when the signer was generated and became available for signing.
+`signers[].signer` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
+`signers[].generated_at` | string | The RFC3339/ISO8601 timestamp of when the signer was generated and became available for signing.
 
 ##### Example (With One Role)
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -261,7 +261,7 @@ Name | Type | Description
 `signer` | string | The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
 `signers[].signer` | array | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
-`signers[].generated_at` | array | The ISO8601 timestamp of when the signer was generated and became available for signing.
+`signers[].generated_at` | array | The RFC3339/ISO8601 timestamp of when the signer was generated and became available for signing.
 
 ##### Example (With One Role)
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -744,7 +744,7 @@ the identity of a client or user.
 
 ### Signing Key Rotation
 
-Implmeneters may choose to rotate the keys used as signers of the accounts for
+Implementers may choose to rotate the keys used as signers of the accounts for
 any reason, e.g. as a routine best practice, or in response to a compromised
 key. An implementor should maintain old signing keys so that accounts that have
 not added a new signing key are still able to use them.


### PR DESCRIPTION
### What
Add endpoints to support rotating signing keys.

### Why
In any systems with keys it is important to support rotating those keys.
Keys may need rotating for many reasons including:
- Routine best practice.
- In response to a key being leaked.
- In response to a key being compromised.
- As a requirement to meet a compliance standard.

cc @stellar/vega-backend 