### PR TITLE
[SEP-24] Additive changes for XLM deposit and withdrawals

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -142,7 +142,7 @@ Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the code `XLM`.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
-`amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
+`amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.  If the user wants to receive lumens this argument should be ignored.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -468,6 +468,39 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 * `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the `fee` endpoint.
 * `enabled`: `true` if the endpoint is available.
 
+#### Anchoring Lumens
+
+If an anchor wants to offer lumen deposit and withdrawals, their `/info` response should look like:
+
+```json
+{
+  "deposit": {
+    "XLM": {
+      "enabled": true,
+      "USD": {
+        "fee_minimum": 5,
+        "fee_percent": 0.5,
+        "min_amount": 0.1,
+        "max_amount": 1000
+      }
+    }
+  },
+  "withdraw": {
+    "XLM": {
+      "enabled": true,
+      "USD": {
+        "fee_minimum": 5,
+        "fee_percent": 0.5,
+        "min_amount": 0.1,
+        "max_amount": 1000
+      }
+    }
+  }
+}
+```
+
+Each `XLM` key-value pair must contain `enabled` as well as a key-value pair for every non-stellar asset accepted by the anchor in exchange for lumens. Fee information should always be described in the units of the non-stellar asset.
+
 ## Fee
 
 The fee endpoint allows an anchor to report the fee that would be charged for a given deposit or withdraw operation. This is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed`, `fee_percent` or `fee_minimum` fields in the `/info` response, then an anchor should not implement this endpoint.
@@ -483,7 +516,8 @@ Name | Type | Description
 `operation` | string | Kind of operation (`deposit` or `withdraw`).
 `type` | string | (optional) Type of deposit or withdrawal (`SEPA`, `bank_account`, `cash`, etc...).
 `asset_code` | string | Asset code.
-`amount` | float | Amount of the asset that will be deposited/withdrawn.
+`external_asset_code` | string | The asset code of the external asset the user will send or receive, if the value of `asset_code` is `XLM`.
+`amount` | float | Amount of the asset that will be deposited or withdrawn. If `asset_code` is `XLM`, `amount` should be in units of `external_asset_code` if `operation` is `deposit` and in units of XLM if `operation` is `withdraw`.
 
 Example request:
 
@@ -495,7 +529,7 @@ On success the endpoint should return `200 OK` HTTP status code and a JSON objec
 
 Name | Type | Description
 -----|------|------------
-`fee` | float | The total fee (in units of the asset involved) that would be charged to deposit/withdraw the specified `amount` of `asset_code`.
+`fee` | float | The total fee that would be charged to deposit/withdraw the specified `amount`. If `asset_code` is `XLM`, `fee` should be in units of `external_asset_code`.
 
 Example response:
 


### PR DESCRIPTION
The changes implemented provide clarification for supporting XLM deposits and withdraws via SEP-24. This is one way to support this functionality, other ideas are welcome.

One open question:

Should I add clarifications for the `amount_in`, `amount_out`, and `amount_fee` columns returned from `/transaction(s)` for XLM deposit/withdraws?