### PR TITLE
SEP-0030: Remove deprecated fields and endpoint deprecated in v0.3.0

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -7,8 +7,8 @@ Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Created: 2019-12-20
-Updated: 2020-05-18
-Version: 0.3.0
+Updated: 2020-06-04
+Version: 0.4.0
 ```
 
 ## Summary
@@ -258,7 +258,6 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | Same as request. See above.
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
-`signer` | string | **Deprecated.** The most recently added signer public key that the server will sign transactions with for this account when requested by an authenticated user.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
 `signers[].key` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
 `signers[].added_at` | string | The RFC3339/ISO8601 timestamp of when the signer was added and became available on this server for signing.
@@ -271,7 +270,6 @@ Name | Type | Description
   "identities": [
     { "role": "owner", "authenticated": true }
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
@@ -287,7 +285,6 @@ Name | Type | Description
     { "role": "sender", "authenticated": true },
     { "role": "receiver" }
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
@@ -298,7 +295,6 @@ Name | Type | Description
 
 - [`POST /accounts/<address>`](#post-accountsaddress)
 - [`PUT /accounts/<address>`](#put-accountsaddress)
-- [`POST /accounts/<address>/sign`](#post-accountsaddresssign)
 - [`POST /accounts/<address>/sign/<signing-address>`](#post-accountsaddresssignsigningaddress)
 - [`GET /accounts/<address>`](#get-accountsaddress)
 - [`DELETE /accounts/<address>`](#delete-accountsaddress)
@@ -368,7 +364,6 @@ See [Common Fields].
   "identities": [
     { "role": "owner" }
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
@@ -384,7 +379,6 @@ See [Common Fields].
     { "role": "sender" },
     { "role": "receiver" }
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
@@ -453,72 +447,9 @@ See [Common Fields].
     { "role": "sender" },
     { "role": "receiver" },
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
-}
-```
-
-#### `POST /accounts/<address>/sign`
-
-**Deprecated.** Use [`POST /accounts/<address>/sign/<signing-address>`](#post-accountsaddresssignsigningaddress).
-
-This endpoint signs a transaction that has operations for the account using the
-most recent signing key that the server has generated for the account.
-
-The transaction must only contain operations for the account. The source
-account of the transaction and the source account of all operations in the
-transaction must match the account in the request.
-
-The transaction can contain any operations, but it is anticipated for the use
-cases discussed earlier in this protocol that the transaction will contain an
-operation to add a new signer to the account and possibly to remove an old
-signer or to merge an account. The signature will be generated using the
-signing key that the server generated during registration for the account.
-
-##### Authentication
-[`SEP-10`] or [`External`].
-
-##### Request
-
-###### Fields
-
-Name | Type | Description
------|------|------------
-`transaction` | string | A XDR base64 encoded Stellar transaction.
-
-###### Example (JSON)
-
-```json
-{
-  "transaction": "AAAAAHAHhQtYBh5F2zA6...",
-}
-```
-
-###### Example (Form)
-
-```
-transaction=AAAAAHAHhQtYBh5F2zA6...
-```
-
-##### Response
-
-###### Fields
-
-Name | Type | Description
------|------|------------
-`signature` | string | The base64 encoded signature that is the result of the server signing a transaction.
-`signer` | string | The signer public key that the server used to sign the transaction.
-`network_passphrase` | string | The network passphrase used when generating a signature.
-
-###### Example
-
-```json
-{
-  "signature": "YpVelqPAKsYTP...",
-  "signer": "GADF...",
-  "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```
 
@@ -615,7 +546,6 @@ See [Common Fields].
     { "role": "sender", "authenticated": true },
     { "role": "receiver" },
   ],
-  "signer": "GADF...",
   "signers": [
     { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
   ]
@@ -690,7 +620,6 @@ Name | Type | Description
       "identities": [
         { "authenticated": true }
       ],
-      "signer": "GDJF...",
       "signers": [
         { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]
@@ -701,7 +630,6 @@ Name | Type | Description
         { "role": "sender", "authenticated": true },
         { "role": "receiver" },
       ],
-      "signer": "GADF...",
       "signers": [
         { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]
@@ -712,7 +640,6 @@ Name | Type | Description
         { "role": "sender" },
         { "role": "receiver", "authenticated": true },
       ],
-      "signer": "GABF...",
       "signers": [
         { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
       ]


### PR DESCRIPTION
### What
Remove the /sign endpoint and the `signer` field in the common account response.

### Why
The endpoint and field were marked as deprecated in v0.3.0. They make less sense in the new version of SEP-30 where the client selects a signer and in the interest of keeping the API as simple as possible and encourage clients to choose a signer these should be removed. Breaking changes are possible because this SEP is still in draft and the breaking changes were separated out from v0.3.0 to make the proposed change clearer for implementations based on the draft to navigate the change.