### PR TITLE
SEP-24: Remove XLM anchoring clauses

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -140,8 +140,8 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the code `XLM`.
-`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If the user wants to receive lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
@@ -208,8 +208,8 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.  If the user wants to withdraw lumens use the code `XLM`.
-`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If the user wants to withdraw lumens use the issuer `native`.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.


### PR DESCRIPTION
resolves stellar/django-polaris#190

This PR is a result of the discussion at stellar/stellar-protocol#625

Removes mentions of the ability to 'anchor' XLM. This functionality should be more thoroughly discussed to ensure there is sufficient ecosystem demand and a solution that doesn't involve adding exceptions or special-cases to an existing SEP.