### PR TITLE
ALL: Remove use of the terms whitelist/blacklist

### DIFF
--- a/core/cap-0027.md
+++ b/core/cap-0027.md
@@ -130,13 +130,13 @@ Certain addresses that are identical may not look identical.  This
 could confuse client software.  For instance, sending an asset to a
 multiplexed account tied to the issuer will destroy the asset.
 
-Code that blacklists accounts from receiving `AUTH\_REQUIRED` assets
-will need to ensure that multiplexed accounts cannot be used to bypass
-the blacklist.  This is not an issue for non-`AUTH\_REQUIRED` assets,
-as anyone can already evade such blacklists by creating new accounts.
-There is no issue for whitelists, since failure to accommodate
-multiplexed accounts just prohibits people from using them, preserving
-the status quo ante.
+Code that uses a denylist to block specific accounts from receiving
+`AUTH\_REQUIRED` assets will need to ensure that multiplexed
+accounts cannot be used to bypass the denylist.  This is not an
+issue for non-`AUTH\_REQUIRED` assets, as anyone can already evade
+such denylists by creating new accounts.  There is no issue for
+allowlists, since failure to accommodate multiplexed accounts just
+prohibits people from using them, preserving the status quo ante.
 
 People commonly assume that base-32 decoding libraries will reject
 inputs with invalid lengths or invalid trailing bits, but this is

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -80,7 +80,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 
 ### Basic Wallet Implementation
 
-* Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
+* Identify anchors you want to support manually, and test them with your wallet to be sure they work before allowing them to be used with your wallet. We encourage you to support as many anchors as possible.
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file and its [`/info`](#info) endpoint to display useful information to the user about the asset they've picked.
 * Provide an interface that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The interface should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file.
 * **Use the `/info` endpoint**

--- a/ecosystem/sep-0007.md
+++ b/ecosystem/sep-0007.md
@@ -140,7 +140,7 @@ Here are some specific attacks that would compromise the security of the user. W
 
 5. **_Threat_**: The destination address owned by a trusted domain is compromised.
 
-    **_Suggested Precaution_**: Wallets should keep track of all destination addresses that the user has paid to in the past and should alert the user if they are trying to pay to an address that they have not seen before. This can be combined with the map/dictionary of `origin_domain` to `URI_REQUEST_SIGNING_KEY`. Additionally, wallets should also  maintain a `blacklist` of addresses which they should update regularly. This will ensure that the community can be proactive about identifying malicious actors on the network.
+    **_Suggested Precaution_**: Wallets should keep track of all destination addresses that the user has paid to in the past and should alert the user if they are trying to pay to an address that they have not seen before. This can be combined with the map/dictionary of `origin_domain` to `URI_REQUEST_SIGNING_KEY`. Additionally, wallets should also  maintain a `denylist` of addresses which they should update regularly. This will ensure that the community can be proactive about identifying malicious actors on the network.
 
 6. **_Threat_**: A malicious application tricks the user and registers as the default handler for the `web+stellar` scheme name.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -157,7 +157,7 @@ In the future, this requirement can be replaced by introducing protocol level [C
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
-Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to whitelist specific accounts to hold their issued assets.
+Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
 ### Why doesn’t the approval service submit transactions to the network?
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -74,7 +74,7 @@ SEP-24 lays out many options for how deposit and withdrawal can work. These are 
 
 ### Basic Wallet Implementation
 
-* Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
+* Identify anchors you want to support manually, and test them with your wallet to be sure they work before allowing them to be used with your wallet. We encourage you to support as many anchors as possible.
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file and its [`/info`](#info) endpoint to display useful information to the user about the asset they've picked.
 * Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file.
 * **Use the `/info` endpoint**

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -518,7 +518,7 @@ SEP-26 lays out many options for how deposit and withdrawal can work non-interac
 
 ### Basic Wallet Implementation
 
-* Identify anchors you want to support manually, and test them with your wallet to be sure they work before whitelisting them. We encourage you to support as many anchors as possible.
+* Identify anchors you want to support manually, and test them with your wallet to be sure they work before allowing them to be used with your wallet. We encourage you to support as many anchors as possible.
 * For each anchor, use information from its [`stellar.toml`](sep-0001.md) file  and [SEP-27](sep-0027.md) response to display useful information to the user about the asset they've picked. Asset information obtained via SEP-27 takes precendence over the same information found in stellar.toml. This is especially true for fields that need localization.
 * Provide a UI that allows users to pick an asset, anchor, and amount to use for deposit or withdraw. The UI should display the asset's fee structure (if possible) as well as information such as the address of the anchor and description of the asset from the `stellar.toml` file and SEP-27 response.
 * **Use the `SEP-27` response to:**


### PR DESCRIPTION
### What
Remove use of the terms whitelist and blacklist, replacing them with other descriptions of what functionality is intended or with other terms allowlist and denylist.

### Why
The terms whitelist and blacklist make many people feel unwelcome and can trigger racial stereotyping. A similar change was made on the Go repository which prompted me to check if we used these terms in our documentation or code. golang/go@608cdcaede1e7133dc994b5e8894272c2dce744b

The terms whitelist and blacklist are not better at communicating intent than simply describing the behavior we're looking for or than using another term. This seems like an easy change to make with no cost that improves the general language of our documentation. An example of how this generally improves the documentation is this sentence where we state:

>...test them with your wallet to be sure they work before allowing them to be used with your wallet.

Which is much clearer and easier to read than the original:

>...test them with your wallet to be sure they work before whitelisting them.

This changes previously accepted documents. I don't think that is particularly an issue given than the meaning of the documents remains the same.