### PR TITLE
[SEP31] Add callback for transactions

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -202,7 +202,7 @@ Content-Type: application/json
       "type": "SEPA"
     }
   },
-  "callback": "https://myanchor.com/sep31/callback/423253235"
+  "callback": "https://sendinganchor.com/sep31/callback/423253235"
 }
 ```
 
@@ -219,6 +219,25 @@ Name | Type | Description
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `callback` | string | (optional) A URL to POST transaction status updates to.  When the status of this transaction changes, the receiving server should POST the full contents of the transaction, as specified in the [`/transaction`](#transaction) endpoint, to this URL.  This is useful so the sending anchors don't need to constantly poll every transaction.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
+
+##### Callback Details
+
+The `callback` parameter is a URL that will get updated transaction information POSTed to it.  Example of the callback body:
+
+```
+{
+  "transaction": {
+      "id": "82fhs729f63dh0v4",
+      "status": "completed",
+      "status_eta": 3600,
+      "external_transaction_id": "ABCDEFG1234567890",
+      "amount_in": "18.34",
+      "amount_out": "18.24",
+      "amount_fee": "0.1",
+      "started_at": "2017-03-20T17:05:32Z",
+    }
+}
+```
 
 #### Responses
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -84,6 +84,7 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 1. Once all needed information is provided and the receiving anchor is ready to complete this transaction, the `POST /send` call will return a `200` status along with information needed to complete the transaction over the stellar network.
 1. The sending anchor should collect the fiat from the sending client, and perform the specified stellar transaction to send the money to the receiving anchor.  This is usually a path payment, but can be done with a regular payment as well, so long as the receiving anchor gets the token they expect.
 1. Once the stellar transaction is completed, the receiving anchor should deposit the money in the receivers bank account.
+1. If the sending anchor has specified a callback URL, the receiving anchor should POST updates to this endpoint.
 1. If the receiver finds out during a bank deposit that some of the receivers information is incorrect, the transaction should be placed in the `pending_info_update` status so the sender can correct it.
 1. The sending anchor can query the status of this transaction via the [`/transaction`](#transaction) endpoint, and should communicate updates to the sending client as that progresses.  If the status is `pending_info_update` it should request that info from the sending client and provide it to the receiving anchor via the [`/update`](#update) endpoint.
 1. Once the [`/transaction`](#transaction) endpoint returns a `completed` status the transaction has been completed.
@@ -200,7 +201,8 @@ Content-Type: application/json
       "account_number": "0029483242",
       "type": "SEPA"
     }
-  }
+  },
+  "callback": "https://myanchor.com/sep31/callback/423253235"
 }
 ```
 
@@ -215,6 +217,7 @@ Name | Type | Description
 `require_receiver_info` | array | A list of [SEP-9](sep-0009.md) values requested for the receiving client
 `amount` | number | Amount of payment in destination currency
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
+`callback` | string | (optional) A URL to POST transaction status updates to.  When the status of this transaction changes, the receiving server should POST the full contents of the transaction, as specified in the [`/transaction`](#transaction) endpoint, to this URL.  This is useful so the sending anchors don't need to constantly poll every transaction.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 
 #### Responses


### PR DESCRIPTION
Currently in SEP31 sending anchors need to poll each transactions status to see when it's changed, in case it wants to send email updates to their clients.  This can be a lot of network requests, so it is useful to allow for a callback URL so the receiving anchor can push updates to them rather than polling.