### PR TITLE
SEP31: Add asset_code and asset_issuer to /send request parameters

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -227,7 +227,7 @@ Name | Type | Description
 `require_receiver_info` | array | A list of [SEP-9](sep-0009.md) values requested for the receiving client
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
-`asset_issuer` | string | optional. The issuer of the stellar asset the sending anchor intends to send. If not specified, the the asset sent must be issued by the receiving anchor.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the the asset sent must be issued by the receiving anchor.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -194,6 +194,8 @@ Content-Type: application/json
 
 {
   "amount": 100,
+  "asset_code": "USD",
+  "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
   "require_receiver_info": ["address", "tax_id"],
   "fields": {
     "sender": {
@@ -224,6 +226,8 @@ Name | Type | Description
 -----|-----|------
 `require_receiver_info` | array | A list of [SEP-9](sep-0009.md) values requested for the receiving client
 `amount` | number | Amount of payment in destination currency
+`asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
+`asset_issuer` | string | optional. The issuer of the stellar asset the sending anchor intends to send. If not specified, the the asset sent must be issued by the receiving anchor.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -227,7 +227,7 @@ Name | Type | Description
 `require_receiver_info` | array | A list of [SEP-9](sep-0009.md) values requested for the receiving client
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
-`asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the the asset sent must be issued by the receiving anchor.
+`asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 


### PR DESCRIPTION
These changes are not strictly necessary because SEP31 requires the 2 participating anchors to come to an agreement prior to facilitating transactions on behalf of their users. This agreement would presumably include a list of acceptable assets and their respective issuers.

However, it is better for the receiving anchor to reject `/send` requests when they made rather than having to refund payments of an unaccepted asset. It also allows receiving anchors to create transaction records in their database including the asset expected.