### PR TITLE
Change SEP-8 to submit transactions from server

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -30,11 +30,12 @@ Implementing a Regulated Asset consists of these parts:
 ## Regulated Assets Approval Flow
 
 1. User creates and signs a transaction.
-2. Wallet resolves asset information and detects that it's a regulated asset.
-3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
-5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
+1. Wallet resolves asset information and detects that it's a regulated asset.
+1. Wallet sends the transaction to the approval server.
+1. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
+1. If the transaction is approved by the approval server it gets signed and submitted to horizon
+1. Wallet handles approval response:
+    1. *Success?* Transaction has been approved, signed, and submitted to horizon by the issuer.
     2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
     3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
     4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
@@ -64,7 +65,7 @@ approval_criteria="The goat approval server will ensure that transactions are co
 The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
 
 ### Possible results
-- Success: Transaction was found compliant and signed by service.
+- Success: Transaction was found compliant and signed and submitted by service.
 - Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
 - Pending: The issuer will asynchronously validate the transaction and respond later.
 - Action Required: The user must complete an action in order to have the transaction approved.
@@ -144,7 +145,6 @@ error|string|A human readable string explaining why the transaction is not compl
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
 - Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
-- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
 
 ## Account Setup
 
@@ -159,8 +159,8 @@ In the future, this requirement can be replaced by introducing protocol level [C
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
 Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
-### Why doesn’t the approval service submit transactions to the network?
+### Why does the approval service submit transactions to the network?
 
-- Separation of concerns between signing transactions and submitting them.
-- Transactions might require more signatures from further regulated asset issuers.
+- The complicating factor of having approved, but not submitted transactions makes it difficult for approval servers to keep track of the state of the world.
+- One downside is that transactions involving multiple regulated assets are no longer possible.
 


### PR DESCRIPTION
One of the complicating factors of SEP-8 is keeping an accurate state of the world.  Currently we have the wallet/client submit the transaction, but this adds the ability for a wallet to hold on to a transaction and submit another transaction for approval.  The server needs to keep track of all outstanding, signed transactions which makes servers a lot more complicated and error prone.  This approach means the server only needs to check the state of the ledger as the source of truth.