### PR TITLE
[SEP12] Add GET method for customers

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -152,16 +152,7 @@ Property | Type | Description
 
 #### Errors
 
-If the client specifies an ID of a non-existent customer, return a 404 error response.
-For example:
-
-```json
-{
-   "error": "customer not found"
-}
-```
-
-For invalid requests, return a 400 error response.
+For invalid requests, return an error describing the issue.
 For example:
 
 ```json

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -66,7 +66,7 @@ Name | Type | Description
 `account` | `G...` string | The Stellar account ID used to identify this user
 `memo` | string | (optional) Unique identifier for user being identified, necessary for custodial, multi-user accounts.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
-`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions and messages should be in this language.
+`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions, choices, and messages should be in this language.
 
 ### Response
 
@@ -87,13 +87,26 @@ Name | Type | Description
 // The case when an anchor requires more info a bout a user
 {
    "status": "NEEDS_INFO",
-   "fields": [
-      {
-         "name": "email_address",
+   "fields": {
+      "email_address": {
          "description": "Email address of the user",
          "type": "string"
+         "optional": true
+      },
+      "id_type": {
+         "description": "Government issued ID",
+         "type": "string",
+         "choices": [
+            "Passport",
+            "Drivers License",
+            "State ID"
+         ]
+      },
+      "photo_id_front": {
+         "description": "A clear photo of the front of the government issued ID",
+         "type": "binary"
       }
-   ]
+   }
 }
 ```
 
@@ -116,13 +129,14 @@ REJECTED | This users KYC has failed and will never succeed.  The `message` must
 
 #### Fields
 
-The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an array of objects containing the following properties:
+The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
 
 Property | Description
 ---------|------------
-`name` | Field name, ideally from SEP-9 if available
 `type` | `string | binary | number | date`
 `description` | A user readable description of this field, especially important if this is not a SEP-9 field.
+`choices` | An array of valid values for this field.
+`optional` | A boolean whether this field is required to proceed or not.
 
 
 ## Customer PUT

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -53,7 +53,7 @@ Alternatively, if the client cannot add the authorization header. The JWT should
 
 Checks the status of a customers information. This allows clients to check whether the customers information was accepted, rejected, or still needs more info.  Lookups are done via the stellar account ID and memo that were used for the initial PUT request.
 
-This also gives you the information needed as far as what information a KYC provider requires to KYC a user.  If you fetch an account that has never been KYC'd the server should respond with `NEEDS_INFO` and a list of all the fields you will need to provide.
+This also provides the information needed from a KYC provider to KYC a user.  If a new account that has never been KYC'd is fetched,the server should respond with `NEEDS_INFO` and a list of all the fields the client will need to provide.
 
 ### Request
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -139,10 +139,10 @@ The fields entry is required for the `NEEDS_INFO` status.  Fields should be spec
 
 Property | Type | Description
 -----|------|------------
-`type` | `string | binary | number | date` | The data type of the field value
-`description` | `string` | A user readable description of this field, especially important if this is not a SEP-9 field.
-`choices` | `array` | (optional) An array of valid values for this field.
-`optional` | `boolean` | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
+`type` | enum | The data type of the field value. Can be `string`, `binary`, `number`, or `date`
+`description` | string | A user readable description of this field, especially important if this is not a SEP-9 field.
+`choices` | array | (optional) An array of valid values for this field.
+`optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
 
 
 ## Customer PUT

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -152,7 +152,7 @@ Property | Type | Description
 
 #### Errors
 
-For invalid requests, return an error describing the issue.
+For invalid requests, return a 400 response describing the issue.
 For example:
 
 ```json

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -178,6 +178,10 @@ If the anchor received and stored the data successfully, it should respond with 
 }
 ```
 
+Name | Type | Description
+-----|------|------------
+`id` | `string` or `integer` | An identifier for the updated or created customer
+
 This ID can be used in future `GET /customer` requests to retrieve the status of the customer. It may also be used in other SEPs to identify the customer.
 
 Every other HTTP status code will be considered an error. The body should contain error details.

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -170,7 +170,15 @@ When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` ty
 
 ### Response
 
-If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and an empty body.
+If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and a response body containing the customer ID:
+
+```json
+{
+   "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
+}
+```
+
+This ID can be used in future `GET /customer` requests to retrieve the status of the customer. It may also be used in other SEPs to identify the customer.
 
 Every other HTTP status code will be considered an error. The body should contain error details.
 For example:

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -122,7 +122,7 @@ Name | Type | Description
 
 Status | Description
 -------|------------
-ACCEPTED | KYC has been accepted and user can be identified by stellar account and optional memo in future transactions
+ACCEPTED | KYC has been accepted and user can be identified by stellar account and optional memo in future transactions.  It is possible for an accepted user to move back to another status if the KYC provider determines it needs more info at a later date, or if the user shows up on a sanctions list.
 PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed
 NEEDS_INFO | More info needs to be provided to finish KYC for this user.  The `fields` entry is required in this case.
 REJECTED | This users KYC has failed and will never succeed.  The `message` must be supplied in this case.

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -64,11 +64,17 @@ GET [KYC_SERVER]/customer?stellar_account_id=<public_key>&memo=<memo>&type=sep31
 
 Name | Type | Description
 -----|------|------------
-`account` | `G...` string | The Stellar account ID used to identify this user
+`id` | `string` or `integer` | (optional) The ID of the customer, if the record was already created via a `PUT` request
+`account` | `G...` string | (optional) The Stellar account ID used to identify this user
 `memo` | string | (optional) Unique identifier for user being identified, necessary for custodial, multi-user accounts.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
 `type` | string | (optional) the type of action the user is being KYCd for.  See below.
 `lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions, choices, and messages should be in this language.
+
+#### ID vs. Account & Memo
+
+The client can always use the `account`, `memo`, and `memo_type` parameters to uniquely identify a customer. However, if a `PUT /customer` request has already been made for the customer, the client may use the `id` returned
+in the response instead.
 
 #### Type specification
 
@@ -144,6 +150,25 @@ Property | Type | Description
 `choices` | array | (optional) An array of valid values for this field.
 `optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
 
+#### Errors
+
+If the client specifies an ID of a non-existent customer, return a 404 error response.
+For example:
+
+```json
+{
+   "error": "Customer not found"
+}
+```
+
+For invalid requests, return a 400 error response.
+For example:
+
+```json
+{
+   "error": "Unrecognized 'type' value. See valid values in the /info response"
+}
+```
 
 ## Customer PUT
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -66,7 +66,7 @@ Name | Type | Description
 `account` | `G...` string | The Stellar account ID used to identify this user
 `memo` | string | (optional) Unique identifier for user being identified, necessary for custodial, multi-user accounts.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
-`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions and reasons should be in this language.
+`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions and messages should be in this language.
 
 ### Response
 
@@ -74,7 +74,7 @@ Name | Type | Description
 -----|------|------------
 `status` | string | Status of the customers KYC process.
 `fields` | array<object> | An array of fields still needed to finish KYC Process
-`reason` | string | Human readable reason for rejection
+`message` | string | Human readable reason for rejection
 
 ```js
 // The case when a user has been successfully KYC'd and approved
@@ -101,7 +101,7 @@ Name | Type | Description
 // The case when a user has been rejected and cannot be KYC'd
 {
    "status": "REJECTED",
-   "reason": "This person is on a sanctions list"
+   "message": "This person is on a sanctions list"
 }
 ```
 
@@ -112,7 +112,7 @@ Status | Description
 ACCEPTED | KYC has been accepted and user can be identified by stellar account and optional memo in future transactions
 PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed
 NEEDS_INFO | More info needs to be provided to finish KYC for this user.  The `fields` entry is required in this case.
-REJECTED | This users KYC has failed and will never succeed.  The `reason` must be supplied in this case.
+REJECTED | This users KYC has failed and will never succeed.  The `message` must be supplied in this case.
 
 #### Fields
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -170,17 +170,17 @@ When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` ty
 
 ### Response
 
-If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and a response body containing the customer ID:
+If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and a response body containing the customer ID.
+
+Name | Type | Description
+-----|------|------------
+`id` | `string` or `integer` | An identifier for the updated or created customer
 
 ```json
 {
    "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
 }
 ```
-
-Name | Type | Description
------|------|------------
-`id` | `string` or `integer` | An identifier for the updated or created customer
 
 This ID can be used in future `GET /customer` requests to retrieve the status of the customer. It may also be used in other SEPs to identify the customer.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -157,7 +157,7 @@ For example:
 
 ```json
 {
-   "error": "Customer not found"
+   "error": "customer not found"
 }
 ```
 
@@ -166,7 +166,7 @@ For example:
 
 ```json
 {
-   "error": "Unrecognized 'type' value. See valid values in the /info response"
+   "error": "unrecognized 'type' value. see valid values in the /info response"
 }
 ```
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -59,6 +59,7 @@ This also provides the information needed from a KYC provider to KYC a user.  If
 
 ```
 GET [KYC_SERVER]/customer?stellar_account_id=<public_key>&memo=<memo>
+GET [KYC_SERVER]/customer?stellar_account_id=<public_key>&memo=<memo>&type=sep31-receiver
 ```
 
 Name | Type | Description
@@ -66,14 +67,19 @@ Name | Type | Description
 `account` | `G...` string | The Stellar account ID used to identify this user
 `memo` | string | (optional) Unique identifier for user being identified, necessary for custodial, multi-user accounts.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
+`type` | string | (optional) the type of action the user is being KYCd for.  See below.
 `lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions, choices, and messages should be in this language.
+
+#### Type specification
+
+Different types of actions may have different kyc requirements.  The type parameter is used to signify what type of transaction this user needs to be KYC'd for.  For example, if a user is being KYC'd as a SEP31 sender, they may only require full name, but a SEP31 receiver needs to be fully KYCd with comprehensive data.  It can also be used to specify if this is a business being KYC'd or a person which can require different fields.  The value used for `type` is up to the implementor to signify the types of transactions their services support, and is optional.
 
 ### Response
 
 Name | Type | Description
 -----|------|------------
 `status` | string | Status of the customers KYC process.
-`fields` | array<object> | An array of fields still needed to finish KYC Process
+`fields` | array<object> | An array of fields still needed to finish KYC Process for the given KYC type
 `message` | string | Human readable reason for rejection
 
 ```js

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -79,8 +79,8 @@ Different types of actions may have different kyc requirements.  The type parame
 Name | Type | Description
 -----|------|------------
 `status` | string | Status of the customers KYC process.
-`fields` | array<object> | An array of fields still needed to finish KYC Process for the given KYC type
-`message` | string | Human readable reason for rejection
+`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
+`message` | string | (optional) Human readable reason for rejection
 
 ```js
 // The case when a user has been successfully KYC'd and approved
@@ -137,12 +137,12 @@ REJECTED | This users KYC has failed and will never succeed.  The `message` must
 
 The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
 
-Property | Description
----------|------------
-`type` | `string | binary | number | date`
-`description` | A user readable description of this field, especially important if this is not a SEP-9 field.
-`choices` | An array of valid values for this field.
-`optional` | A boolean whether this field is required to proceed or not.
+Property | Type | Description
+-----|------|------------
+`type` | `string | binary | number | date` | The data type of the field value
+`description` | `string` | A user readable description of this field, especially important if this is not a SEP-9 field.
+`choices` | `array` | (optional) An array of valid values for this field.
+`optional` | `boolean` | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
 
 
 ## Customer PUT

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -53,7 +53,7 @@ Alternatively, if the client cannot add the authorization header. The JWT should
 
 Checks the status of a customers information. This allows clients to check whether the customers information was accepted, rejected, or still needs more info.  Lookups are done via the stellar account ID and memo that were used for the initial PUT request.
 
-If a user has never been KYC'd on this server, return the NEEDS_INFO endpoint with all the fields required.
+This also gives you the information needed as far as what information a KYC provider requires to KYC a user.  If you fetch an account that has never been KYC'd the server should respond with `NEEDS_INFO` and a list of all the fields you will need to provide.
 
 ### Request
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -17,7 +17,7 @@ This SEP defines a standard way for stellar wallets to upload KYC (or other) inf
 This SEP was made with these goals in mind:
 
 * interoperability
-* Allow a user to enter their KYC information once and use it across many anchors without re-entering information manually
+* Allow a user to enter their KYC information to their wallet once and use it across many anchors without re-entering information manually
 * handle the most common 80% of use cases
 * handle image and binary data
 * support the set of fields defined in [SEP-9](sep-0009.md)
@@ -33,8 +33,9 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## API Endpoints
 
+* [`GET /customer`](#customer-get): Check the status of a customers info
 * [`PUT /customer`](#customer-put): Idempotent upload of customer info
-* [`DELETE /customer`](#customer-delete): Idempotent upload of customer info
+* [`DELETE /customer`](#customer-delete): Deletion of customer info
 
 ## Authentication
 
@@ -47,6 +48,82 @@ Alternatively, if the client cannot add the authorization header. The JWT should
 ```
 ?jwt=<token>
 ```
+
+## Customer GET
+
+Checks the status of a customers information. This allows clients to check whether the customers information was accepted, rejected, or still needs more info.  Lookups are done via the stellar account ID and memo that were used for the initial PUT request.
+
+If a user has never been KYC'd on this server, return the NEEDS_INFO endpoint with all the fields required.
+
+### Request
+
+```
+GET [KYC_SERVER]/customer?stellar_account_id=<public_key>&memo=<memo>
+```
+
+Name | Type | Description
+-----|------|------------
+`account` | `G...` string | The Stellar account ID used to identify this user
+`memo` | string | (optional) Unique identifier for user being identified, necessary for custodial, multi-user accounts.
+`memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
+`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions and reasons should be in this language.
+
+### Response
+
+Name | Type | Description
+-----|------|------------
+`status` | string | Status of the customers KYC process.
+`fields` | array<object> | An array of fields still needed to finish KYC Process
+`reason` | string | Human readable reason for rejection
+
+```js
+// The case when a user has been successfully KYC'd and approved
+{
+   "status": "ACCEPTED",
+}
+```
+
+```js
+// The case when an anchor requires more info a bout a user
+{
+   "status": "NEEDS_INFO",
+   "fields": [
+      {
+         "name": "email_address",
+         "description": "Email address of the user",
+         "type": "string"
+      }
+   ]
+}
+```
+
+```js
+// The case when a user has been rejected and cannot be KYC'd
+{
+   "status": "REJECTED",
+   "reason": "This person is on a sanctions list"
+}
+```
+
+#### Status
+
+Status | Description
+-------|------------
+ACCEPTED | KYC has been accepted and user can be identified by stellar account and optional memo in future transactions
+PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed
+NEEDS_INFO | More info needs to be provided to finish KYC for this user.  The `fields` entry is required in this case.
+REJECTED | This users KYC has failed and will never succeed.  The `reason` must be supplied in this case.
+
+#### Fields
+
+The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an array of objects containing the following properties:
+
+Property | Description
+---------|------------
+`name` | Field name, ideally from SEP-9 if available
+`type` | `string | binary | number | date`
+`description` | A user readable description of this field, especially important if this is not a SEP-9 field.
+
 
 ## Customer PUT
 


### PR DESCRIPTION
resolves stellar/integration-meta#146

Many anchors need the ability to KYC customers ahead of time, before doing any transactions with them.  This is especially important for B2B where kyc is manual and takes a while.  SEP-12 starts to provide this, but is underpowered, particularly in that the client has no understanding of what the anchor requires for KYC, or what additional fields it might need, it only has the ability to send fields blindly.

This adds a `GET /customer` method in order to check the status of an existing users KYC, or to find out what fields are needed to KYC a new user, or complete an in progress KYC attempt.

Discussion here: https://docs.google.com/document/d/1LuTKU5E_cOgQYlWBUol1dwUVO5FrVpUE4XZSXRuoNqA/edit 