### PR TITLE
SEP-0030: Add security section about external authentication methods

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -41,6 +41,7 @@ The registration flow is as follows:
       - One or more other Stellar addresses.
       - And/or, one or more phone numbers.
       - And/or, one or more email addresses.
+      - And/or, one or more other external authentication methods.
 - The server verifies the [JWT] is valid according to [SEP-10].
 - The server verifies that the account the [JWT] proves control of is the account being registered.
 - The server verifies that the account is not already registered.
@@ -55,9 +56,9 @@ A client can register with multiple servers and give each signing key a weight t
 The signing flow is as follows:
 - The client uses the servers phone or email authentication provider to get a [JWT] proving possession of the phone number or email address.
 - Alternatively, the client uses [SEP-10] to get a [JWT] proving high threshold control of another account that is listed as an alternative identity of the account to be accessed.
-- The client, authenticated as the phone, email, or another account, requests the server to sign a transaction.
+- The client, authenticated as the external authentication method (e.g. phone, email, etc) or another account, requests the server to sign a transaction.
 - The server verifies that the [JWT] is valid according to the authentication provider's specification.
-- The server verifies that the phone, email, or account in the [JWT] is an alternative identity of the account.
+- The server verifies that the external authentication method (e.g. phone, email, etc) or account in the [JWT] is an alternative identity of the account.
 - The server verifies that the source account of the transaction is the account.
 - The server verifies that the source account of all operations on the transaction are not set or set to the account.
 - The server signs the transaction with the signing secret key.
@@ -190,7 +191,7 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
 `identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
-`identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, or `email`.
+`identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, `email`, or other.
 `identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either another stellar address, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 
 ##### Example (With One Identity)
@@ -678,6 +679,28 @@ not added a new signing key are still able to use them.
 A client can query the server for what signers the server has available for an
 account and should replace the signer on the account with the most recently
 generated signing key at its earliest convenience.
+
+### External Authentication
+
+Implementers choose the external authentication methods supported by their
+implementation.
+
+Implementers should consider the risks posed by the external authentication
+methods that are supported by their implementation. An implementation, and the
+client using the implementation, are responsible for evaluating whether the
+authentication method provides a level of security suitable for accounts that
+will be registered.
+
+If an implementation supports a variety of external authentication methods the
+client must evaluate which are suitable for the account it is registering. For
+example, if a client considers one type of authentication to carry unacceptable
+risk for an account, it may choose to not use that form of authentication.
+
+Clients can update an account registered, adding or removing external
+authentication methods. For example, if a client registered an account with a
+phone number and then later collects an email address from the account holder,
+the client could add email alongside the phone number, or it could add email
+and remove the phone number so that the account can only be recovered by email.
 
 ## Limitations
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -686,7 +686,7 @@ Implementers choose the external authentication methods supported by their
 implementation.
 
 Implementers should consider the risks posed by the external authentication
-methods that are supported by their implementation. An implementation, and the
+methods that are supported by their implementation. An implementer, and the
 client using the implementation, are responsible for evaluating whether the
 authentication method provides a level of security suitable for accounts that
 will be registered.


### PR DESCRIPTION
### What
Add security section about external authentication methods and highlighting that a SEP-30 implementation chooses what external authentication methods to support and clients choose which to use when registering accounts.

### Why
The intention is that the external authentication methods are flexible and the methods use make sense for the use case, both functionally, and from the perspective of security and risk. The document already takes this position but this section clarifies that intent. 

cc @capybaraz @accordeiro 