### PR TITLE
SEP31 - Remove require_receiver_info

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -190,7 +190,6 @@ Content-Type: application/json
   "amount": 100,
   "asset_code": "USD",
   "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
-  "require_receiver_info": ["address", "tax_id"],
   "fields": {
     "sender": {
       "first_name": "Alice",
@@ -210,7 +209,7 @@ Content-Type: application/json
 }
 ```
 
-This post requests attempts to initiate a payment through this anchor.  It should provide the amount and all the required fields (specified in the [`/info`](#info) endpoint).  The sending anchor can also provide a `require_receiver_info` object if it needs information on the receiver client that the receiving anchor can provide.
+This post requests attempts to initiate a payment through this anchor.  It should provide the amount and all the required fields (specified in the [`/info`](#info) endpoint).
 
 If the request describes a valid transaction that this anchor can fulfill, we return a success response with details on what to send. If the request is not valid, or we need more info, we can return with an error response and expect the sending anchor to try again with updated values.
 
@@ -218,7 +217,6 @@ If the request describes a valid transaction that this anchor can fulfill, we re
 
 Name | Type | Description
 -----|-----|------
-`require_receiver_info` | array | A list of [SEP-9](sep-0009.md) values requested for the receiving client
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
@@ -236,7 +234,6 @@ Name | Type | Description
 `stellar_account_id` | string | Stellar account to send payment to
 `stellar_memo_type` | string | Type of memo to attach to the stellar payment `(text | hash | id)`
 `stellar_memo` | string | The memo to attach to the stellar payment
-`receiver_info` | object | Key-value pairs of the information the sender requested via `require_receiver_info`
 
 ##### Customer Info Needed (400 Bad Request)
 


### PR DESCRIPTION
`require_receiver_info` is a controversial feature of SEP31.  It is used when a sending anchor requires information about a receiving client, and assumes the receiving anchor can fetch that information from their banking rails or other source, and can legally share it with them.  

Given that no one has a hard requirement for it right now, and it seems unlikely too many anchors will have this capability or want to share this kind of user info, I propose we remove this until someone actually has a pressing need for it, then we can put it back.