### PR TITLE
SEP-0030: Remove the added_at field from signers

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-06-04
-Version: 0.4.0
+Updated: 2020-06-30
+Version: 0.5.0
 ```
 
 ## Summary
@@ -261,7 +261,6 @@ Name | Type | Description
 `identities[].authenticated` | boolean | Optional. Present and true if the currently authenticated client is authenticated with the identity.
 `signers` | array | The signers' public keys that the server can sign transactions with for this account when requested by an authenticated user, ordered from most recently added to least recently added.
 `signers[].key` | string | The signer public key that the server can sign transactions with for this account when requested by an authenticated user.
-`signers[].added_at` | string | The RFC3339/ISO8601 timestamp of when the signer was added and became available on this server for signing.
 
 ##### Example (With One Role)
 
@@ -272,7 +271,7 @@ Name | Type | Description
     { "role": "owner", "authenticated": true }
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -287,7 +286,7 @@ Name | Type | Description
     { "role": "receiver" }
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -366,7 +365,7 @@ See [Common Fields].
     { "role": "owner" }
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -381,7 +380,7 @@ See [Common Fields].
     { "role": "receiver" }
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -449,7 +448,7 @@ See [Common Fields].
     { "role": "receiver" },
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -548,7 +547,7 @@ See [Common Fields].
     { "role": "receiver" },
   ],
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -579,7 +578,7 @@ See [Common Fields].
   ],
   "signer": "GADF...",
   "signers": [
-    { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+    { "key": "GADF..." }
   ]
 }
 ```
@@ -622,7 +621,7 @@ Name | Type | Description
         { "authenticated": true }
       ],
       "signers": [
-        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF..." }
       ]
     },
     {
@@ -632,7 +631,7 @@ Name | Type | Description
         { "role": "receiver" },
       ],
       "signers": [
-        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF..." }
       ]
     },
     {
@@ -642,7 +641,7 @@ Name | Type | Description
         { "role": "receiver", "authenticated": true },
       ],
       "signers": [
-        { "key": "GADF...", "added_at": "2006-01-02T15:04:05Z" }
+        { "key": "GADF..." }
       ]
     }
   ]


### PR DESCRIPTION
### What
Remove the `added_at` field from signers.

### Why
The field adds a burden on the implementer to keep track of when a signing key is generated and stored but without any substantial value to the client.

Servers that use shared signing keys are likely to store and configure their signing keys through systems that don't store metadata like time alongside them. For example if a key is simply stored as a secret in their deployment system it may not have a time. In our reference implementation this has resulted in us returning a zero time in some cases.

We originally included the field on the assumption that a client may like to know when a key became available. In practice however that information is irrelevant to a client. A client, especially used by a consumer, isn't going to display the time the signer became available to the user. The presence of the time also doesn't change the recommended action which is to update to the first key in the list.

We can always revisit re-adding the field if a real need and use case arise but with our existing use cases it doesn't look like the field
provides any utility and is one more requirement for implementers, albeit small.

cc @accordeiro @fnando 