### PR TITLE
CAP-0023 clarifications

### DIFF
--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -83,9 +83,9 @@ case CLAIM_PREDICATE_AND:
 case CLAIM_PREDICATE_OR:
     ClaimPredicate orPredicates<2>;
 case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
-    int64 absBefore;
+    int64 absBefore; // Will return true if closeTime < absBefore
 case CLAIM_PREDICATE_AFTER_ABSOLUTE_TIME:
-    int64 absAfter;
+    int64 absAfter; // Will return true if closeTime >= absAfter
 case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
     int64 relBefore;    // Seconds since closeTime of the ledger in which the
                         // ClaimableBalanceEntry was created
@@ -313,8 +313,8 @@ operation. `CreateClaimableBalanceOp` is invalid with
 - `claimants[i].destination = claimants[j].destination` (for any `i != j`)
 - `claimants[i].predicate` has depth greater than 4 (for any `i`)
 - `claimants[i].predicate` contains a predicate of type `CLAIM_PREDICATE_AND`
-  with `andPredicates.size() < 2` or `CLAIM_PREDICATE_OR` with
-  `orPredicates.size() < 2` (for any `i`)
+  with `andPredicates.size() != 2` or `CLAIM_PREDICATE_OR` with
+  `orPredicates.size() != 2` (for any `i`)
 - `claimants[i].predicate` contains a predicate of type
   `CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME`, `CLAIM_PREDICATE_AFTER_ABSOLUTE_TIME`,
   `CLAIM_PREDICATE_BEFORE_RELATIVE_TIME`, or
@@ -338,7 +338,7 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
 7. Create a claimable balance entry with the following properties:
     - `balanceID` of type `CLAIMABLE_BALANCE_ID_TYPE_V0`. `balanceID.v0()` equal to the SHA256 hash
        of the `OperationID`, which is created with the `type` `ENVELOPE_TYPE_OP_ID`, `sourceAccount` 
-       of the transaction, the `seqNum` of the transaction, and the index of this operation
+       of the transaction (not the operation), the `seqNum` of the transaction, and the index of this operation
        in the transaction as `opNum`.
     - `createdBy = sourceAccount`
     - `claimants` as specified, with the exception that


### PR DESCRIPTION
This PR contains a couple clarifications, along with a slightly stricter check for the `andPredicate` and `orPredicate` size. No value other than 2 makes sense here, so `!=` is clearer than using `<`.