### PR TITLE
SEP31: Use 403 for unauthenticated requests instead of 401

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -41,13 +41,7 @@ The JWT should be included as a request header:
 Authorization: Bearer <JWT>
 ```
 
-Any API request the fails to meet proper authentication should return a 403 Forbidden response with the following body
-
-```
-{
-  "type": "authentication_required"
-}
-```
+Any API request the fails to meet proper authentication should return a 403 Forbidden response.
 
 ## HTTPS Only
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -41,7 +41,13 @@ The JWT should be included as a request header:
 Authorization: Bearer <JWT>
 ```
 
-Any API request the fails to meet proper authentication should return a 401 Unauthorized response.
+Any API request the fails to meet proper authentication should return a 403 Forbidden response with the following body
+
+```
+{
+  "type": "authentication_required"
+}
+```
 
 ## HTTPS Only
 


### PR DESCRIPTION
All our other SEPs use 403 to represent a request that hasn't been authorized with sep10.  Technically, 401 is more accurate but 403 seems to be widely used as an unauthorized request response code, so I don't think there's any reason to complicate implementation details.