### PR TITLE
SEP8 Remove multisig notes

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -148,9 +148,7 @@ error|string|A human readable string explaining why the transaction is not compl
 
 ## Account Setup
 
-Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
-
-In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
+Previously, SEP-8 required the issuer to be added as a signer on the account to prevent un-approved transactions from being sent by the user, however the modern approach is to use the sandwich method. Account balances should be left in the AUTHORIZED_TO_MAINTAIN_LIABILITIES state, and any operations that get approved should be sandwiched between `allowTrust(true)` and `allowTrust(false)` operations.  This way only operations that are explicitly approved can ever be processed.  This new transaction can be sent back to the client with a `REVISED` response, and the client can sign the revised transaction and submit it.  
 
 ## Discussion
 


### PR DESCRIPTION
We no longer recommend using multi-sig for regulated assets.  The approach still works but there's much cleaner solutions now, so I updated it to recommend the sandwich method.