### PR TITLE
SEP31: Moved 'sender_id' and 'receiver_id' outside of 'fields' in /send request

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -177,9 +177,9 @@ Content-Type: application/json
   "amount": 100,
   "asset_code": "USD",
   "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
+  "sender_id": 123,
+  "receiver_id": 456,
   "fields": {
-    "sender_id": 123,
-    "receiver_id": 456,
     "transaction": {
       "receiver_routing_number": "442928834",
       "receiver_account_number": "0029483242",
@@ -200,6 +200,8 @@ Name | Type | Description
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
+`sender_id` | string | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
+`receiver_id` | string | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 


### PR DESCRIPTION
Forgot to do this in the initial SEP-12 changes PR.