### PR TITLE
SEP-31: Small changes for SEP-12 compatibility

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -155,6 +155,8 @@ The JSON object contains an entry for each asset that the anchor supports for re
 * `receiver_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
 * `fields`: as explained below.
 
+If `sender_sep12_type` or `receiver_sep12_type` are present in the response, the client must register the sender and receiver via SEP-12 using the `type` argument provided.
+
 The `fields` object allows an anchor to describe fields that must be passed into `POST /send`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
 
 Each `fields` sub-object contains a key for each field name and an object with the following fields as the value:
@@ -200,8 +202,8 @@ Name | Type | Description
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
-`sender_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
-`receiver_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
+`sender_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client. If `sender_sep12_type` was included in the `/info` response, this field is required.
+`receiver_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client. If `receiver_sep12_type` was included in the `/info` response, this field is required.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint containing a single `"transaction"` object.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -202,7 +202,7 @@ Name | Type | Description
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
 `sender_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
 `receiver_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
-`fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
+`fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint containing a single `"transaction"` object.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 
 #### Responses

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -151,8 +151,8 @@ The JSON object contains an entry for each asset that the anchor supports for re
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the received asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
-* `sender_sep12_type`: The value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request.
-* `receiver_sep12_type`: The value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request.
+* `sender_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
+* `receiver_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
 * `fields`: as explained below.
 
 The `fields` object allows an anchor to describe fields that must be passed into `POST /send`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
@@ -200,8 +200,8 @@ Name | Type | Description
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
-`sender_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
-`receiver_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
+`sender_id` | `string` or `integer` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
+`receiver_id` | `string` or `integer` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint containing a single `"transaction"` object.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -200,8 +200,8 @@ Name | Type | Description
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
-`sender_id` | `string` or `integer` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
-`receiver_id` | `string` or `integer` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
+`sender_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
+`receiver_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint containing a single `"transaction"` object.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -177,8 +177,8 @@ Content-Type: application/json
   "amount": 100,
   "asset_code": "USD",
   "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
-  "sender_id": 123,
-  "receiver_id": 456,
+  "sender_id": "d2bd1412-e2f6-4047-ad70-a1a2f133b25c",
+  "receiver_id": "137938d4-43a7-4252-a452-842adcee474c",
   "fields": {
     "transaction": {
       "receiver_routing_number": "442928834",
@@ -200,8 +200,8 @@ Name | Type | Description
 `amount` | number | Amount of payment in destination currency
 `asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
-`sender_id` | string | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
-`receiver_id` | string | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
+`sender_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client.
+`receiver_id` | `string` or `integer` | The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client.
 `fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint, broken out by sender, receiver, and transacton.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human readable error codes or field descriptions will be returned in this language.
 


### PR DESCRIPTION
[SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put)'s documentation specifies that the `id` returned from `PUT /customer` can be a string or integer.

We also need to clarify that the SEP-12 args like `sender_sep12_type` and `sender_id` are optional, since the anchor may not require KYC for the sender, or even the receiver.