### PR TITLE
SEP-12 return id in GET

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -84,6 +84,7 @@ Different types of actions may have different kyc requirements.  The type parame
 
 Name | Type | Description
 -----|------|------------
+`id` | string | ID of the user, if the user has been created (ie once a PUT request for this user has been completed).  It should be null for users that haven't been created on the server yet.
 `status` | string | Status of the customers KYC process.
 `fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
 `message` | string | (optional) Human readable reason for rejection
@@ -91,12 +92,13 @@ Name | Type | Description
 ```js
 // The case when a user has been successfully KYC'd and approved
 {
+   "id": "123456"
    "status": "ACCEPTED",
 }
 ```
 
 ```js
-// The case when an anchor requires more info a bout a user
+// The case when an anchor requires more info about a user, either because the user hasn't been created yet, or the info already provided doesn't meet the minimum requirements for the type being verified.
 {
    "status": "NEEDS_INFO",
    "fields": {
@@ -125,6 +127,7 @@ Name | Type | Description
 ```js
 // The case when a user has been rejected and cannot be KYC'd
 {
+   "id": "567890",
    "status": "REJECTED",
    "message": "This person is on a sanctions list"
 }


### PR DESCRIPTION
Return the id used to identify the KYC client in the GET requests when its available.  Currently the ID is only returned in the PUT request, but if a SEP-12 GET call is done to check the status of the user we should still give the identifier back so it can be used in sep31 et al.