### PR TITLE
SEP1: properly name home_domain

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -12,7 +12,7 @@ Version: 2.1.0
 
 ## Simple Summary
 
-The `stellar.toml` file is used to provide a common place where the Internet can find information about your organization’s Stellar integration. By setting the homedomain of your Stellar account to the domain that hosts your `stellar.toml`, you can create a definitive link between this information and that account. Any website can publish Stellar network information, and the `stellar.toml` is designed to be readable by both humans and machines.
+The `stellar.toml` file is used to provide a common place where the Internet can find information about your organization’s Stellar integration. By setting the home_domain of your Stellar account to the domain that hosts your `stellar.toml`, you can create a definitive link between this information and that account. Any website can publish Stellar network information, and the `stellar.toml` is designed to be readable by both humans and machines.
 
 If you are an anchor or issuer, the `stellar.toml` file serves a very important purpose: it allows you to publish information about your organization and token(s) that help to legitimize your offerings. Clients and exchanges can use this information to decide whether a token should be listed. Fully and truthfully disclosing contact and business information is an essential step in responsible token issuance.
 


### PR DESCRIPTION
The SEP lists the accounts `home_domain` property as `homedomain`.  This is important to fix because its not googleable if someone wants to find where we talk about `home_domain`