### PR TITLE
SEP24: Add home_domain instructions

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -29,6 +29,7 @@ To support this protocol an anchor acts as a server and implements the specified
 
 ## Prerequisites
 
+* The assets issuing account should [have a home_domain set](https://www.stellar.org/developers/guides/issuing-assets.html#discoverablity-and-meta-information) so the clients can find the toml file to begin the process.
 * An anchor must define the location of their `TRANSFER_SERVER_SEP0024` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
 * Anchors and clients must support [SEP-10](sep-0010.md) web authentication to enable authenticated deposits, withdrawals, or transaction history lookups.
 


### PR DESCRIPTION
Without a home_domain, a wallet has no way to find the toml file needed to start the SEP24 process.  While this instruction is mentioned in the SEP1 documentation it's very easily missed.  This is exacerbated by the fact that our tools let you plug the toml file in directly which makes it seem like you don't actually need the  home domain.