### PR TITLE
CAP-0023 - return balanceID on successful CreateClaimableBalanceOp

### DIFF
--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -258,7 +258,7 @@ enum CreateClaimableBalanceResultCode
 union CreateClaimableBalanceResult switch (CreateClaimableBalanceResultCode code)
 {
 case CREATE_CLAIMABLE_BALANCE_SUCCESS:
-    void;
+    ClaimableBalanceID balanceID;
 default:
     void;
 };
@@ -353,7 +353,7 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
     - `asset` as specified in the operation
     - `amount` as specified in the operation
     - `reserve` equal to `claimants.size() * baseReserve`
-8. Succeed with `CREATE_CLAIMABLE_BALANCE_SUCCESS`
+8. Succeed with `CREATE_CLAIMABLE_BALANCE_SUCCESS` and the `balanceID` from the previous step.
 
 `CreateClaimableBalanceOp` requires medium threshold because it can be used to
 send funds.


### PR DESCRIPTION
Return the `balanceID` if `CreateClaimableBalanceOp` succeeds. This will make claimable balances easier to use since the user of the operation can use the result instead of deriving the `balanceID` from the transaction.