### PR TITLE
Third draft of CAP-0034 document

### DIFF
--- a/core/cap-0034.md
+++ b/core/cap-0034.md
@@ -43,7 +43,7 @@ vulnerable to inconsistencies because of this race.
 A less catastrophic problem, but an inefficiency, is that externalizing
 transaction sets that contain significant numbers of transactions that are
 doomed to return `txTOO_LATE` during ledger close might mean that we're
-choosing sets that we would have considered worse than other available
+choosing sets that we would have not have chosen over other available
 candidates if we had taken into account that those transactions were doomed.
 
 More cosmetically, it might also come across as unfair, or at least
@@ -88,17 +88,26 @@ It also aligns with the following Stellar Network Value:
 ## Abstract
 
 Currently, the nomination protocol produces, from a set of candidate
-`StellarValue`s, a nominated `StellarValue` comprising the best transaction
-set (as selected by a deterministic heuristic which favors larger sets) of
-any candidate, the maximum `closeTime` of any candidate, and a set of
-"maximal" ledger `upgrades` from all candidates.
+`StellarValue`s, a nominated `StellarValue` comprising the composited
+transaction set (as selected by a deterministic heuristic which chooses
+one particular input set and favors larger sets), the maximum `closeTime` of any
+candidate, and a set of "maximal" ledger `upgrades` from all candidates.
 
 We propose to change the protocol to take the `closeTime` from the same
-candidate `StellarValue` as the best transaction set (the heuristic which
-decides which transaction set is best does not change; nor does the method of
+candidate `StellarValue` as the chosen transaction set (the heuristic which
+decides which transaction set to choose does not change; nor does the method of
 generating `upgrades`).  The protocol would then validate all transaction sets
 against their associated `closeTime`s, and could use `SIGNED` `StellarValue`s
 throughout the ballot protocol as well as the nomination protocol.
+
+The effect is that all trimming and validating of transaction sets during the
+nomination and ballot protocols use the exact same conditions as the validation
+of transactions does during ledger close.  (Today, they differ:  the nomination
+and ballot protocols use the last ledger close time, whereas ledger close uses
+the new ledger close time.  This CAP allows this precise alignment because it
+allows the nomination and ballot protocols to predict exactly what the next
+ledger close time will be _if_ the transaction set that they are validating is
+ultimately externalized.)
 
 In particular, this affects how soon the core notices when transactions expire.
 
@@ -109,14 +118,19 @@ in the `StellarValue` XDR in some code paths changes, as does the use of
 `SIGNED` `StellarValue`s in some places where `BASIC` ones are currently used,
 but the XDR itself does not change.
 
-This CAP proposes to change the nominated-value generation to remove the
-current combining of closetimes and simply select the one from the same
-nominated value as the best transaction set.  (It proposes to preserve the
-selection heuristic for "best transaction set" unchanged.)
+This CAP proposes to change the compositing function, which chooses a
+`StellarValue` to start the ballot protocol on, to remove the current combining
+of closetimes and simply select the one from the same `StellarValue` as the
+selected transaction set.  (This CAP proposes to preserve the existing selection
+heuristic for "composited transaction set" unchanged.)
 
 This CAP also proposes to trim and validate transaction sets in `StellarValue`s
 (in all places where such trimming or validating is currently done) against the
-`closeTime` in the same `StellarValue`.
+`closeTime` in the same `StellarValue`.  The `closeTime` affects whether a
+transaction with an upper time bound (`maxTime`) returns `txTOO_LATE`, and
+whether a transaction with a lower time bound (`minTime`) returns `txTOO_EARLY`.
+Those are therefore the two transaction-validity tests which are affected by
+the change in which `closeTime` is used to validate transactions.
 
 This CAP also proposes to make the nomination protocol produce a signed
 value (currently we nominate an unsigned, or "basic", value, because, as a
@@ -147,14 +161,13 @@ CAP.  **Bold** text indicates a semantic change from the previous stage.  The
 proposal in this CAP embodies the **bold** semantics in the last column only;
 the **bold** semantics in the middle column are for context.
 
-| Index (for later reference) | Decision point                                                                                      | Released behavior                           | Latest unreleased behavior (PR 2608)                        | CAP behavior                                                                 |
-| --------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| 1                           | Which transactions to flood?                                                                        | Unexpired with respect to last ledger close | **Unexpired with respect to estimate of next ledger close** | Unexpired with respect to estimate of next ledger close                      |
-| 2                           | Which transactions to include (not to trim) in nominated `StellarValue`?                            | Unexpired with respect to last ledger close | **Unexpired with respect to estimate of next ledger close** | **Unexpired with respect to `closeTime` to nominate in same `StellarValue`** |
-| 3                           | Which close time to validate transaction sets against in nomination and ballot protocols?           | Last ledger close time                      | Last ledger close time                                      | **`closeTime` in same `StellarValue` as transaction set**                    |
-| 4                           | Which close time to produce when compositing candidates into single nominee?                        | maximum of all candidates' `closeTime`s     | maximum of all candidates' `closeTime`s                     | **`closeTime` in same `StellarValue` as chosen ("best") transaction set**    |
-| 5                           | Generate `BASIC` or `SIGNED` `StellarValue`s when combining candidates (in "compositing" function)? | `BASIC`                                     | `BASIC`                                                     | **`SIGNED`**                                                                 |
-| 6                           | Expect `BASIC` or `SIGNED` `StellarValue`s in ballot protocol?                                      | `BASIC`                                     | `BASIC`                                                     | **`SIGNED`**                                                                 |
+| Index (for later reference) | Decision point                                                                                                             | Released behavior                       | Latest unreleased behavior (PR 2608)                                                                 | CAP behavior                                                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 1                           | Which transactions to flood?                                                                                               | Valid with respect to last ledger close | **Valid with respect to last ledger close; unexpired with respect to estimate of next ledger close** | Valid with respect to last ledger close; unexpired with respect to estimate of next ledger close |
+| 2                           | Which time bounds to require for transactions to be included (not trimmed) in the `StellarValue` a node votes to nominate? | Valid with respect to last ledger close | **Valid with respect to last ledger close; unexpired with respect to estimate of next ledger close** | **Valid with respect to `closeTime` to nominate in same `StellarValue`**                         |
+| 3                           | Which close time to validate transaction sets against in nomination and ballot protocols?                                  | Last ledger close time                  | Last ledger close time                                                                               | **`closeTime` in same `StellarValue` as transaction set**                                        |
+| 4                           | Which close time to produce in composite value?                                                                            | maximum of all candidates' `closeTime`s | maximum of all candidates' `closeTime`s                                                              | **`closeTime` in same `StellarValue` as chosen ("composited") transaction set**                  |
+| 5                           | Expect `BASIC` or `SIGNED` `StellarValue` in a composite value to be used in the ballot protocol?                          | `BASIC`                                 | `BASIC`                                                                                              | **`SIGNED`**                                                                                     |
 
 ## Design Rationale
 
@@ -169,45 +182,69 @@ through consensus.
 cases that a transaction that returns `txTOO_LATE` does not consume a sequence
 number and does not pay a fee.  This is ensured because before a transaction
 set gets to the point of having its transaction fees paid (which happens when a
-ledger is closing), we combine the candidate `<txSet,closeTime>` pairs into
+ledger is closing), we composite the candidate `<txSet,closeTime>` pairs into
 one, and with the CAP behavior we do so by simply selecting one candidate.
-And every candidate has by the time of combining been validated, including
+And every candidate has by the time of compositing been validated, including
 against the new condition that it contains no transactions that are expired
 with respect to its `closeTime`.
 
-2. The proposal additionally repairs a degree of lack of Byzantine fault
-tolerance which we shall call "maximum `closeTime` injection":  an ill-behaved
-validator can no longer reduce the quality of transaction sets produced by the
-compositing function by nominating as large a `closeTime` as allowed (the
-maximum time slip is currently one minute) and thus possibly causing some other
-nodes' nominated transactions to expire.  As explained below in the "Detailed
-illustration of failure mode" section, a node would have to provide a
-transaction set with the best set of _unexpired_ transactions in order to
-influence the composited `closeTime`.
+2. The proposal prevents an ill-behaved validator from intentionally triggering
+the race that motivated the CAP through what we shall call "maximum `closeTime`
+injection": the ill-behaved validator could previously try to force transactions
+in transaction sets proposed by other nodes to fail during ledger close by
+proposing as large a `closeTime` as allowed (the maximum time slip is currently
+one minute).
 
-3. This proposal refines [PR 2608](https://github.com/stellar/stellar-core/pull/2608)'s
+3. This proposal refines
+[PR 2608](https://github.com/stellar/stellar-core/pull/2608)'s
 trimming of transactions prior to initial nomination by changing the
 next-ledger-`closeTime` estimate (which PR2608 itself had changed from
 last-ledger-`closeTime`) to `closeTime`-within-`StellarValue`.  Given this CAP's
 semantics, we know at this point that that `closeTime` is the _exact_ one that
-will be chosen as the ledger close time _if_ the transaction set wins, so we can
-trim precisely the most efficient set of transactions:  we trim all of those
-which would have later returned `txTOO_LATE` if the transaction set were
-ultimately externalized, and we are guaranteed that none of those which survives
-trimming will return `txTOO_LATE` if the transaction set is ultimately
-externalized.
+will be chosen as the ledger close time _if_ the transaction set is ultimately
+externalized, so we can trim precisely the most efficient set of transactions:
+we trim all of those which would have later returned `txTOO_LATE` if the
+transaction set were ultimately externalized, and we are guaranteed that none of
+those which survives trimming will return `txTOO_LATE` if the transaction set is
+ultimately externalized.
 
 4. This CAP in general makes changes to transaction set composition and validity
 in the earliest protocol phases possible, making use of knowledge as soon as we
-have it.  The previous point is an example -- we trim transactions prior to
+have it.  The previous point is an example -- we trim a transaction set prior to
 first nomination precisely when we decide on which `closeTime` to nominate
-first, which also tells us precisely which transactions it would be best to
-include, and which to trim.  The change in the validation of transaction sets
-in the nomination and ballot protocols is a similar example; we can do stronger
-validation than we could before this CAP, when all we could validate against was
-the last ledger close time.
+in the same `StellarValue` with it, which also tells us precisely which
+transactions we may as well trim because they'll be expired at ledger close time
+if that `StellarValue` is ultimately externalized. The change in the validation
+of transaction sets in the nomination and ballot protocols is a similar example;
+we can do more accurate validation than we could before this CAP, when all we
+could validate against was the last ledger close time.
 
-5. This CAP has had a modest "test" in that it is the third proposal that we
+5. This CAP makes the `closeTime`-related transaction validity checks (the
+tests for `txTOO_EARLY` and `txTOO_LATE`) throughout consensus exactly
+equivalent to those used during ledger close.  Previously, the tests used during
+consensus (which this CAP changes to align with those used during ledger close)
+were weaker than the tests used during ledger close with respect to
+`maxTime`/`txTOO_LATE` (the consensus checks could admit transactions which,
+if they were ultimately externalized, ledger close would later reject with
+`txTOO_LATE`), and stronger than the tests used during ledger close with respect
+to `minTime`/`txTOO_EARLY` (the consensus checks could reject transactions with
+`txTOO_EARLY` which, had they been allowed and ultimately externalized, would
+_not_ have been rejected with `txTOO_EARLY` during ledger close).
+
+6. This CAP, in both the change it proposes to protocol semantics and the
+changes it would induce in the code structure, facilitates the option to
+perform a follow-on change to the work done in PR 2608 which would further
+refine our heuristic for choosing which transactions to flood by allowing
+some transactions to be flooded which would be `txTOO_EARLY` if the next ledger
+were to close immediately, but which we estimate will no longer be `txTOO_EARLY`
+by the time the next ledger actually does close.  (That would not introduce any
+race analogous to the one that this CAP fixes with respect to `txTOO_LATE`,
+because the nomination and ballot protocols would still discover that a
+transaction would be invalid with `txTOO_EARLY` before it reached the point of
+being in a closing ledger and therefore failing validation while nevertheless
+consuming a sequence number and being charged a fee.)
+
+7. This CAP has had a modest "test" in that it is the third proposal that we
 have considered, and appears not to suffer from any of the weaknesses which led
 us to reject the first two; see "Rejected alternatives" below for details.
 
@@ -231,10 +268,11 @@ course the network can not foresee that this will eventually be the case) that
 the next ledger will close.
 
 3. `T1` happens at that point to be in the transaction queue of the validator
-who (though again this is not predictable yet) will turn out to win nomination.
-That node builds a transaction set that contains `T1`.
+who (though again this is not predictable yet) will turn out to nominate the
+`StellarValue` that will ultimately be externalized. That node builds a
+transaction set that contains `T1`.
 
-4. The transaction set containing `T1` wins nomination, but (at least) one of
+4. The transaction set containing `T1` is externalized, but (at least) one of
 the candidate `closeTime`s is greater than `T1`'s expiration time.
 
 5. Transactions are applied using the maximum of all candidate `closeTime`s as
@@ -285,21 +323,20 @@ choosing the maximum.  That means in particular that a single bad _validator_
 can open this race window significantly, with the consequences including both
 the failure of more transactions with `txTOO_LATE` and the potential for
 inconsistent smart contract behavior.  This reflects that the current
-protocol's choice of the maximum candidate `closeTime` is, in a sense, _not_
-Byzantine fault-tolerant:  it externalizes a value that could have been
-manipulated by a single bad actor.  We refer to such manipulation as "maximum
-`closeTime` injection". The proposal in this CAP is less sensitive:
-a node can affect the composite `closeTime` only if it provides the transaction
-set that the network as a whole agrees is the best.  We force a node to do a
-"good deed" for the network's clients in order to influence the eventual
-externalized `closeTime`.  In the presence of this CAP, one node's increasing
-the `closeTime` significantly no longer triggers the smart-contract race because
-that is closed completely by this CAP, and it no longer reduces the number of
-applicable transactions in a ledger because a node can only increase the
-`closeTime` by providing at least as good a transaction set as any other node
-provided, with those transaction sets already guaranteed to be composed entirely
-of unexpired transactions if they win nomination (because each of them has been
-validated against its own associated `closeTime`).
+protocol's choice of the maximum candidate `closeTime` is, in a sense, too
+sensitive:  it can externalize a value that could have been manipulated by a
+single bad actor.  We refer to such manipulation as "maximum `closeTime`
+injection". The proposal in this CAP is less sensitive: a node can affect the
+composite `closeTime` only if it manages to provide a transaction set that the
+network as a whole selects as a composited one for the ballot protocol.  We
+force a node to do a "good deed" (putting together a transaction set which the
+compositing function selects over any other node's candidate) for the network's
+clients in order to influence the eventual externalized `closeTime`. In the
+presence of this CAP, one node's increasing the `closeTime` significantly no
+longer triggers the smart-contract race because that is closed completely by
+this CAP, and it no longer reduces the number of applicable transactions in a
+ledger because the high `closeTime` provided by the bad actor does not affect
+the validity of transactions in transaction sets proposed by other nodes.
 
 ### Detailed argument in favor of this proposal
 
@@ -338,40 +375,39 @@ point we do not yet know the rest of the `StellarValue` that we will end up
 nominating -- in particular we do not yet know the `closeTime` -- so an estimate
 is the best that we can do.)  And because that value is optimal -- all the
 transactions that it leads to being trimmed would have been guaranteed to have
-returned `txTOO_LATE` if the transaction set had been externalized, and all the
-transactions that it leads to _not_ being trimmed are guaranteed _not_ to return
-`txTOO_LATE` if the transaction set is externalized -- it is clearly desirable
-to use it.
+returned `txTOO_EARLY`/`txTOO_LATE` if the transaction set had been
+externalized, and all the transactions that it leads to _not_ being trimmed are
+guaranteed _not_ to return `txTOO_EARLY`/`txTOO_LATE` if the transaction set is
+ultimately externalized -- it is clearly desirable to use it.
 
-3. In the presence of change #2, which trims any expired transactions before
-nominating a `StellarValue`, it is only an ill-behaved node that would nominate
-a `StellarValue` containing a transaction which is expired with respect to its
-own `closeTime`, so it becomes sensible for such a value to fail validation.
-There is no loss in this, since we would not want to accept a `StellarValue`
-from an ill-behaved node in any case; this change (given change #2) simply
-represents a strict improvement in our ability to detect a particular incorrect
-behavior.
+3. In the presence of change #2, which trims any premature/expired transactions
+before nominating a `StellarValue`, it is only an ill-behaved node that would
+nominate a `StellarValue` containing a transaction which is premature/expired
+with respect to its own `closeTime`, so it becomes sensible for such a value to
+fail validation. There is no loss in this, since we would not want to accept a
+`StellarValue` from an ill-behaved node in any case; this change (given change
+\#2) simply represents a strict improvement in our ability to detect a particular
+incorrect behavior.
 
-4. In the presence of change #3, which causes any `StellarValue` which contains
-any transaction which is expired with respect to the `closeTime` in the same
-`StellarValue` to fail validation, the change to use the `closeTime` from the
-`StellarValue` which contains the chosen best transaction set becomes optimal.
-Given that we preserve the previous protocol's heuristic for "best transaction
-set", and that all transaction sets are being compared on equal footing with
-respect to expiration -- all have been validated, so none contains any
-transaction that will expire if the set is chosen -- the `closeTime` in the
-chosen `StellarValue` becomes precisely the earliest one which can be guaranteed
-to allow the choice of the transaction set which we consider to be the best.
-By comparison, the old protocol's choice of the maximal `closeTime` of all
-candidates' is simply a loss -- it increases the ledger close time without
-producing any benefit such as a better transaction set, and that increase has
-costs:
+4. In the presence of change #3, any candidate transaction set passed in to
+the compositing function consists only of transactions which are valid
+with respect to the `closeTime` in the same `StellarValue` as the transaction
+set.  Therefore, once the compositing function has chosen one of the candidate
+transaction sets, the choice of a composited `closeTime` equal to the
+`closeTime` in the same `StellarValue` as the chosen transaction set becomes
+optimal in the following sense: it is precisely the latest `closeTime` with
+respect to which all of the transactions in the chosen transaction set are
+valid (unexpired). By comparison, the old protocol's choice of the maximal
+`closeTime` of all candidates' is simply a loss:
+
+    - It might render some of the transactions in the composited set expired,
+      which is the `txTOO_LATE` race that motivated this CAP.
 
     - It might render some transactions still in the memory pools of some nodes
     expired, when they might have had a chance of getting into a future ledger
     if the `closeTime` had not been needlessly increased.
 
-    - It makes the ledger close time sensitive to the choice of a large
+    - It makes the ledger close time more sensitive to the choice of a large
     `closeTime` by a single bad actor, which we have called the "maximum
     `closeTime` injection" problem, and discussed above in the "Detailed
     illustration of failure mode".
@@ -381,16 +417,15 @@ costs:
 combining multiple ones in producing the `closeTime`) in the output of the
 compositing function, there is little cost to doing so (we have the signature
 in memory and have already checked it), so we may as well lose as little
-information as possible.
-
-6. Given that we have preserved the signature on `StellarValue`s throughout the
-nomination protocol and into the ballot protocol, we must expect `SIGNED`
-`StellarValue`s in the ballot protocol, and we must check the signatures again
-in the ballot protocol, to make sure that the additional information that we
-are preserving is _correct_ information.  The additional signature-checking,
-however, will be on a signature that we just checked during the preceding
-nomination round, so we will likely simply hit in cache nearly all the time,
-and not have to do significantly more signature checks.
+information as possible.  And given that we have preserved the signature on
+`StellarValue`s throughout the nomination protocol and into the ballot protocol,
+we must expect `SIGNED` `StellarValue`s in the ballot protocol, and we must
+check the signatures again in the ballot protocol, to make sure that the
+additional information that we are preserving is _correct_ information.  The
+additional signature-checking, however, will be on a signature that we just
+checked during the preceding nomination round, so we will likely simply hit in
+cache nearly all the time, and not have to do significantly more signature
+checks.
 
 Therefore, we argue that each successive change represents a clear
 improvement, given the previous one (and the first represents a clear
@@ -419,7 +454,7 @@ falls within the time bounds of the transaction.
 
 #### Trimming transactions rendered expired by combining nominated candidates
 
-The second idea was to remove transactions from the best transaction set
+The second idea was to remove transactions from the composited transaction set
 selected by the combine-candidates code in the nomination protocol, based on the
 (maximal) `closeTime` just selected by that code. However, that would seem to
 have opened up a new denial-of-service attack on the ledger:
@@ -446,11 +481,11 @@ consensus protocol.
 ### Aside: Changing the combining of `upgrades` is feasible, but unnecessary
 
 Considering the `closeTime`-related changes in this CAP also raised a further
-because the `SIGNED` `StellarValue`, besides the transaction set and close time,
-also contains a set of ledger `upgrades`, we could choose additionally to change
-`upgrades` to come from the single winning `StellarValue` rather than being
-combined in a way similar to the `closeTime`s, as they are in the current
-protocol.
+discussion: because the `SIGNED` `StellarValue`, besides the transaction set and
+close time, also contains a set of ledger `upgrades`, we could choose
+additionally to change `upgrades` to come from the single selected
+`StellarValue` rather than being combined in a way similar to the `closeTime`s,
+as they are in the current protocol.
 
 Upgrades do happen independently of the transactions: we could view the ledger
 closes as an optimization of alternating transaction set applies and ledger
@@ -469,14 +504,8 @@ make sense just to combine each parameter individually -- the simple union of
 individual changes could produce a result which was inconsistent. In that case,
 the right way to combine them consistently would become ambiguous; there could
 be multiple options of which none would include all candidate parameter changes.
-That would not be inherently wrong -- we have the same situation with
-transaction sets, and we make a heuristic but deterministic choice as to which
-is the best. But it might be some argument for choosing a single nominated
-upgrade in the same way as we already choose a single nominated tx set, and are
-proposing to choose a single nominated closetime, just because choosing the best
-single nominated set of upgrades could be simpler (there might be far fewer
-options to choose among) than choosing the best consistent combination of all
-tx sets.
+Choosing the best single nominated set of upgrades might be the simplest way
+of choosing a consistent composite of all candidate upgrades.
 
 Overall, changing the selection of `upgrades` to match that of `closeTime`
 could be said to make the resulting protocol simpler -- but it would make the
@@ -504,24 +533,33 @@ then rejected, as described above in the "Design Rationale".
 
 - A test is added to confirm that when a node selects a `StellarValue`
 to nominate, it trims from the selected transaction set precisely those
-transactions which would be expired according to the `closeTime` in that
+transactions which would be invalid according to the `closeTime` in that
 `StellarValue`, and no others (in previous protocol versions, it should
-trim only those which are expired according to the last ledger close time).
+continue to trim those which are invalid according to the last ledger close
+time).
 
 - A test is added to confirm that nominated `StellarValue`s are checked
 for internal consistency between their close times and transaction sets --
-that is, that they contain no transactions which are expired according to
+that is, that they contain no transactions which are invalid according to
 their own close times (a nominated `StellarValue` that does not meet that
 condition should be rejected by other nodes).  (In old protocols, transactions
-in a nominated `StellarValue` are checked for non-expiration only against the
-last ledger close time.)
+in a nominated `StellarValue` are checked for validity against the last ledger
+close time.)
+
+- A test is added to confirm that the new code which builds upon PR 2608
+to allow a client to choose the `closeTime` to compare with a transaction's
+`minTime` correctly alters which transactions are considered `txTOO_EARLY` and
+which are not.  (PR 2608 introduced the option for clients to choose a
+`closeTime` other than the last ledger close time to compare with a
+transaction's `maxTime` when determining which transactions are considered
+`txTOO_LATE`.)
 
 - The existing test for the compositing/combining function, which confirms that
-a set of candidate `StellarValue`s produces the expected combined `closeTime`,
+a set of candidate `StellarValue`s produces the expected composited `closeTime`,
 changes in three ways:
 
   - It tests that old protocols continue to behave the same way, but that
-  in new protocol versions, the combined `closeTime` is simply that of the
+  in new protocol versions, the composited `closeTime` is simply that of the
   `StellarValue` containing the best transaction set, not the maximum
   `closeTime` of all candidates.
 
@@ -565,15 +603,15 @@ are `SIGNED`.
 which `closeTime` to validate the transactions in the `StellarValue` against
 from the last ledger close time to the `closeTime` in the `StellarValue`.
 
-- The herder's combining of candidate `StellarValue`s into a single value to
+- The herder's compositing of candidate `StellarValue`s into a single value to
 nominate, in new protocols only (it preserves its old behavior in old
 protocols), changes in the following ways:
 
-  - It chooses a "combined" `closeTime` directly from the `StellarValue`
-  containing the winning transaction set.  In particular, it does not need
-  any trimming of the winning transaction set.  (That set should already be
+  - It chooses a composited `closeTime` directly from the `StellarValue`
+  containing the selected transaction set.  In particular, it does not need
+  any trimming of the selected transaction set.  (That set should already be
   consistent with `closeTime`, since it came from one nominated `StellarValue`,
-  which the herder has already validated by the time it combines them.)
+  which the herder has already validated by the time it composites them.)
 
   - It returns `SIGNED` `StellarValue`s.
 


### PR DESCRIPTION
# Integrate CAP-0034 second draft review comments

- Make the effect of the proposal on
`minTime`/`txTOO_EARLY` validation explicit; formerly it
had mentioned only `maxTime`/`txTOO_LATE`.  Point out that
the change makes the nomination and ballot protocols use
the exact same `closeTime`-related conditions to trim and
validate transactions as the externalization (ledger close)
code does.

- Incorporate further code review comments to correct and
clarify several pieces of SCP-related wording and
presentation.

- Correct "maximal `closeTime` injection" sections to
explain the attack and the degree of amelioration more
accurately.

- Clean up confusing (and in at least one place, just
wrong) section #4 of "Detailed argument in favor".

- Remove misleading references to transaction sets or
`StellarValue`s "winning"; specify that it is being
selected for the ballot protocol, or is being externalized
(whichever is correct in the specific contexts).

- Remove misleading references to "best" transaction sets
in favor of simply "composited".