### PR TITLE
[SEP31] Update URL schema for transactions and replace update HTTP method with a PATCH.

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -58,9 +58,9 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 
 ### Setting up rails
 
-1. To create a rail find a counterparty who implmements this SEP in the region you wish to provide access to, and agrees to do business with you.
+1. To create a rail find a counterparty who implements this SEP in the region you wish to provide access to, and agrees to do business with you.
 1. Trade public keys with each other in order to identify and securely interoperate with each other
-1. Keep a mapping of region to home_domain, using home_domain as your intial entry point to interoperating.
+1. Keep a mapping of region to home_domain, using home_domain as your initial entry point to interoperating.
 
 ### User Onboarding
 
@@ -80,16 +80,16 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 1. Once the sending anchor has provided all the required information and the receiving anchor is ready to complete this transaction, the `POST /send` call will return a `200` status along with information needed to complete the transaction over the stellar network.
 1. The sending anchor should collect the fiat from the sending client, and perform the specified stellar transaction to send the money to the receiving anchor.  This is usually a path payment, but can be done with a regular payment as well, so long as the receiving anchor gets the token they expect.
 1. Once the stellar transaction is completed, the receiving anchor should deposit the money in the receivers bank account.
-1. If the sender finds out during a bank deposit that some of the receivers information is incorrect, the transaction should be placed in either the `pending_customer_info_update` or `pending_transaction_info_update` status so the sender can correct it. More information on these status values can be found in the [/transaction](#transaction) section.
-1. The sending anchor can query the status of this transaction via the [`/transaction`](#transaction) endpoint, and should communicate updates to the sending client as it changes.
-1. Once the [`/transaction`](#transaction) endpoint returns a `completed` status the transaction has been completed.
+1. If the sender finds out during a bank deposit that some of the receivers information is incorrect, the transaction should be placed in either the `pending_customer_info_update` or `pending_transaction_info_update` status so the sender can correct it. More information on these status values can be found in the [/transactions/:id](#transaction) section.
+1. The sending anchor can query the status of this transaction via the [`/transactions/:id`](#transaction) endpoint, and should communicate updates to the sending client as it changes.
+1. Once the [`/transactions/:id`](#transaction) endpoint returns a `completed` status the transaction has been completed.
 
 ## API Endpoints
 
 * [`GET /info`](#info)
 * [`POST /send`](#send)
-* [`GET /transaction`](#transaction)
-* [`PUT /update`](#update)
+* [`GET /transactions/:id`](#transaction)
+* [`PATCH /transactions/:id`](#update)
 
 ### Info
 #### Request
@@ -228,7 +228,7 @@ Name | Type | Description
 
 ##### Transaction Info Needed (400 Bad Request)
 
-In the case where the sending anchor didn't provide all the information requested in `/info`, or if the transacton requires extra information, the request should fail with a 400 status code and the following body in JSON format.  The sender should then retry the entire request including all the previously sent fields plus the fields described in the response.
+In the case where the sending anchor didn't provide all the information requested in `/info`, or if the transaction requires extra information, the request should fail with a 400 status code and the following body in JSON format.  The sender should then retry the entire request including all the previously sent fields plus the fields described in the response.
 
 Name | Type | Description
 -----|------|------------
@@ -237,7 +237,7 @@ Name | Type | Description
 
 ##### Error (400 Bad Request)
 
-In the case where the transacton just cannot be completed, return an error response with a JSON object containing an `error` key describing the error in human readable format in the language indicated in the request.
+In the case where the transaction just cannot be completed, return an error response with a JSON object containing an `error` key describing the error in human readable format in the language indicated in the request.
 
 ```
 {
@@ -254,7 +254,7 @@ In the case where the transacton just cannot be completed, return an error respo
 The transaction endpoint enables senders to query/validate a specific transaction at a receiving anchor.
 
 ```
-GET DIRECT_PAYMENT_SERVER/transaction
+GET DIRECT_PAYMENT_SERVER/transactions/:id
 ```
 
 Request parameters:
@@ -357,7 +357,7 @@ Another possibility is that the bank tells the receiving anchor that the provide
 This endpoint should only be used when the receiver requests more info via the `pending_transaction_info_update` status.  The `required_info_updates` transaction field should contain the fields required for the update. If the sender tries to update at a time when no info is requested the receiver should fail with an error response.
 
 ```
-PUT DIRECT_PAYMENT_SERVER/update
+PATCH DIRECT_PAYMENT_SERVER/transactions/:id
 ```
 
 Request parameters:
@@ -365,20 +365,17 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `id` | string | The id of the transaction.
-`fields` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/send`](#send).
+`transaction` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/send`](#send).
 
 #### Example
 
 ```
-PUT DIRECT_PAYMENT_SERVER/update
+PATCH DIRECT_PAYMENT_SERVER/transactions/82fhs729f63dh0v4
 
 {
-   id: "82fhs729f63dh0v4",
-   fields: {
-      transaction: {
-         receiver_bank_account: 12345678901234,
-         receiver_routing_number: 021000021
-      }
+   transaction: {
+      receiver_bank_account: 12345678901234,
+      receiver_routing_number: 021000021
    }
 }
 ```
@@ -393,7 +390,7 @@ If the transaction specified by `"id"` does not exist, return a 404 response.
 
 #### Error 400
 
-If the information was malformed, or if the sender tried to update data that isn't updateable, return a 400 with an object containing an error message.
+If the information was malformed, or if the sender tried to update data that isn't updatable, return a 400 with an object containing an error message.
 
 ```
 {


### PR DESCRIPTION
This pull-request updates the URL schema for transactions to make it look more like a resource rather than use custom URLs for different interactions with the same resource. It also makes it more clear how to collect/update a given resource.

The following are the changes included in this PR and the rationale behind:

1. Pluralize resource URL to `/transactions`: this could look more like bikeshedding but since I was going to propose a change on the URL schema I went for plural, keeping the doors open to eventually allow a new end-point to query transactions in bulk.
2. Change `GET /transaction` to `GET /transactions/:id`: The current SEP is not clear on how the `ID` should be pass is it in the URL is it as a query param? This change makes it explicit that the resource ID should be pass as part of the URL
3. Remove `/update` in favor of `PATCH /transactions/:id`: Using `/update` to update a resource is counter-intuitive to API design, using the resource identifier help a `PATCH` instead of a `PUT` conveys the intention behind this end-point which is updating specific parts of the given transactions instead of changing the whole thing.

The changes here could be considered breaking, but we are still at a point where this is fine since nobody has implemented yet this in production. We know there are a couple of anchors who are almost ready with this, I reached out to them and they support this change. So let's get this which is a low-hanging fruit and will leave us with a better API.
