### PR TITLE
[SEP31] Change URL end-point to create a new transactions.

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -75,9 +75,9 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 1. For each `_sep12_type` value specified in the relevant asset's [`/info`](#info) object, the sending anchor makes a [`SEP-12 GET /customer`](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) request.
 1. The sending anchor collects all information specified in the `GET /customer` response(s).
 1. The sending anchor PUTs all that information to the [`/customer`](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) endpoint of the receiving anchor.
-1. The sending anchor POSTs the transaction information to the [/send](#send) endpoint of the receiving anchor.
-1. If some of the information POSTed was missing or incorrect, or the `amount` is value is large enough to require additional information, the receiving anchor returns a `400` error response using either the `transaction_info_needed` or `customer_info_needed` status strings. More information about these responses can be found in the [/send](#send) section.
-1. Once the sending anchor has provided all the required information and the receiving anchor is ready to complete this transaction, the `POST /send` call will return a `200` status along with information needed to complete the transaction over the stellar network.
+1. The sending anchor POSTs the transaction information to the [/transactions](#transactions) endpoint of the receiving anchor.
+1. If some of the information POSTed was missing or incorrect, or the `amount` is value is large enough to require additional information, the receiving anchor returns a `400` error response using either the `transaction_info_needed` or `customer_info_needed` status strings. More information about these responses can be found in the [/transactions](#transactions) section.
+1. Once the sending anchor has provided all the required information and the receiving anchor is ready to complete this transaction, the `POST /transactions` call will return a `200` status along with information needed to complete the transaction over the stellar network.
 1. The sending anchor should collect the fiat from the sending client, and perform the specified stellar transaction to send the money to the receiving anchor.  This is usually a path payment, but can be done with a regular payment as well, so long as the receiving anchor gets the token they expect.
 1. Once the stellar transaction is completed, the receiving anchor should deposit the money in the receivers bank account.
 1. If the sender finds out during a bank deposit that some of the receivers information is incorrect, the transaction should be placed in either the `pending_customer_info_update` or `pending_transaction_info_update` status so the sender can correct it. More information on these status values can be found in the [/transactions/:id](#transaction) section.
@@ -87,7 +87,7 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 ## API Endpoints
 
 * [`GET /info`](#info)
-* [`POST /send`](#send)
+* [`POST /transactions`](#transactions)
 * [`GET /transactions/:id`](#transaction)
 * [`PATCH /transactions/:id`](#update)
 
@@ -155,7 +155,7 @@ The JSON object contains an entry for each asset that the anchor supports for re
 * `receiver_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
 * `fields`: as explained below.
 
-The `fields` object allows an anchor to describe fields that must be passed into `POST /send`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
+The `fields` object allows an anchor to describe fields that must be passed into `POST /transactions`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
 
 Each `fields` sub-object contains a key for each field name and an object with the following fields as the value:
 
@@ -165,12 +165,12 @@ Each `fields` sub-object contains a key for each field name and an object with t
  
 If `sender_sep12_type` or `receiver_sep12_type` are present in the response, the client must register the sender and receiver via [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) using the `type` argument provided. The receiving anchor uses this parameter to know what information needs to be collected on the customer.
 
-### Send
+### Transactions
 
 #### Request
 
 ```
-POST DIRECT_PAYMENT_SERVER/send
+POST DIRECT_PAYMENT_SERVER/transactions
 Content-Type: application/json
 
 {
@@ -207,7 +207,7 @@ Name | Type | Description
 
 #### Responses
 
-##### Success (200 ok)
+##### Success (201 Created)
 This is the successful case where a receiving anchor confirms that they can fulfill this payment as described. The response body should be a JSON object with the following values
 
 Name | Type | Description
@@ -350,7 +350,7 @@ In certain cases the receiver might need to request updated information.  For ex
 
 #### Pending transaction info update
 
-Another possibility is that the bank tells the receiving anchor that the provided account or routing number is incorrect. Since this information was sent via a `POST /send` request, the transaction should go into the `pending_transaction_info_update` state until the sender makes a request to the endpoint outlined below. 
+Another possibility is that the bank tells the receiving anchor that the provided account or routing number is incorrect. Since this information was sent via a `POST /transactions` request, the transaction should go into the `pending_transaction_info_update` state until the sender makes a request to the endpoint outlined below. 
 
 ### Update
 
@@ -365,7 +365,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `id` | string | The id of the transaction.
-`transaction` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/send`](#send).
+`transaction` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/transactions`](#transactions).
 
 #### Example
 


### PR DESCRIPTION
This is a follow up on https://github.com/stellar/stellar-protocol/pull/692 -- the proposal is to create new transactions through a `POST` request on `/transactions`.

This PR also updates the response code to a 201, meaning a new transaction has been created and can be processed.