### PR TITLE
[SEP31] Put back fields in patch request to transaction.

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -365,7 +365,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `id` | string | The id of the transaction.
-`transaction` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/transactions`](#transactions).
+`fields` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/transactions`](#transactions).
 
 #### Example
 
@@ -373,9 +373,11 @@ Name | Type | Description
 PATCH DIRECT_PAYMENT_SERVER/transactions/82fhs729f63dh0v4
 
 {
-   transaction: {
-      receiver_bank_account: 12345678901234,
-      receiver_routing_number: 021000021
+   "fields": {
+      "transaction": {
+         "receiver_bank_account": "12345678901234",
+         "receiver_routing_number": "021000021"
+      }
    }
 }
 ```


### PR DESCRIPTION
I deleted this key from the request, but it is part of the transaction resource and that's what the request is patching. 