### PR TITLE
SEP-12: Added 'id' param to PUT /customer

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -193,6 +193,7 @@ The fields below should be placed in the request body using the `multipart/form-
 
 Name | Type | Description
 -----|------|------------
+`id` | string | The `id` value returned from a previous call to this endpoint
 `account` | `G...` string | The Stellar account ID to upload KYC data for
 `memo` | string | (optional) Uniquely identifies individual customer in schemes where multiple wallet users share one Stellar address. If included, the KYC data will only apply to deposit/withdraw requests that include this `memo`.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
@@ -215,9 +216,16 @@ Name | Type | Description
 }
 ```
 
-This ID can be used in future `GET /customer` requests to retrieve the status of the customer. It may also be used in other SEPs to identify the customer.
+This ID can be used in future requests to retrieve the status of the customer or update the customer's information. It may also be used in other SEPs to identify the customer.
 
-Every other HTTP status code will be considered an error. The body should contain error details.
+Anchors should return `404 Not Found` for requests including an `id` value that does not exist in the database. Anchors should also return `404` when the `id` specified in the request was initially used to create a customer for a different stellar account.
+```json
+{
+   "error":  "customer with `id` not found"
+}
+```
+
+All error responses should contain details under the `error` key.
 For example:
 
 ```json


### PR DESCRIPTION
resolves stellar/stellar-protocol#704

`GET /customer` allows clients to specify the `id` returned when creating the customer via the `PUT` method. This change allows anchors to update existing customers using the same argument on `PUT /customer`.