### PR TITLE
SEP-12: Clarify optional nature of 'id' parameter for PUT /customer

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -193,8 +193,8 @@ The fields below should be placed in the request body using the `multipart/form-
 
 Name | Type | Description
 -----|------|------------
-`id` | string | The `id` value returned from a previous call to this endpoint
-`account` | `G...` string | The Stellar account ID to upload KYC data for
+`id` | string | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.
+`account` | `G...` string | (optional) The Stellar account ID to upload KYC data for. If specified, `id` should not be specified.
 `memo` | string | (optional) Uniquely identifies individual customer in schemes where multiple wallet users share one Stellar address. If included, the KYC data will only apply to deposit/withdraw requests that include this `memo`.
 `memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
 


### PR DESCRIPTION
Ensures readers do not think `id` is required.