### PR TITLE
SEP-24: Remove mention of short-lived token as acceptable

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -708,7 +708,8 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.
 1. `Transaction` properties `more_info_url, amount_in, amount_out, amount_fee, and stellar_transaction_id` are now non-optional.
-1. It is now recommended to use a one-time use JWT in the context of the interactive webapp.
+1. It is now recommended to use a short-lived, one-time JWT in the context of the interactive webapp.
+    - Anchors should not accept JWT's that have expired or been used before.
 1. `/transactions` endpoint no longer accepts an `account` query.  The account is pulled from the JWT.
 
 ## Implementations

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -708,7 +708,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 1. Changed the response of the deposit and withdraw endpoints from 403 to 200 since this is the expected flow.
 1. `/transactions` and `/transaction` are now required endpoints.
 1. `Transaction` properties `more_info_url, amount_in, amount_out, amount_fee, and stellar_transaction_id` are now non-optional.
-1. It is now recommended to use a one-time use or short-lived JWT in the context of the interactive webapp.
+1. It is now recommended to use a one-time use JWT in the context of the interactive webapp.
 1. `/transactions` endpoint no longer accepts an `account` query.  The account is pulled from the JWT.
 
 ## Implementations


### PR DESCRIPTION
A one-time token is a more secure approach.