### PR TITLE
SEP-24: design /transaction/attribution endpoint for SEP-34

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -704,7 +704,7 @@ Anchors can then attribute future requests related to that particular transactio
 
 ### Request 
 
-The request must be made after receiving the transaction `id` but before opening the `url` from the `POST /transactions/deposit/interactive` or `/transactions/withdraw/interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
+The request must be made after receiving the transaction `id` but before opening the `url` returned from the `POST /transactions/deposit/interactive` or `/transactions/withdraw/interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
 
 ```
 POST /transaction/attribution

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -696,6 +696,71 @@ For example:
 }
 ```
 
+## Wallet Attribution
+
+[SEP-34](sep-0034.md) defines how anchors can cryptographically attribute HTTPS requests to wallet applications. Specifically, anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) token passed by the wallet to verify the HTTPS requests made for a particular transaction were made by the wallet application. Anchors can then attribute future requests related to that particular transaction with the same wallet application, enabling anchors to improve their monitoring and analytics systems, give discounts to users initiating transactions from a particular wallet, or require all other client applications to attribute their requests.
+
+### Request 
+
+The request must be made after receiving the transaction `id` but before opening the `url` from the `POST /interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
+
+```
+POST /transaction/attribution
+```
+
+Request parameters:
+
+Name | Type | Description
+-----|------|------------
+`token` | string | The JWS token signed by the Wallet Server
+`id` | string | The transaction ID returned by the Anchor Server's `/interactive` endpoint response
+
+### Response 
+
+If verification is successful and the request is valid, a `204 No Content` or `200 Success` HTTP status code should be returned. Anchors should use `204` if they do not want to communicate the effects of the attribution.
+
+Attribution effects are changes in the way the anchor intends to process or has already processed the user based on the identity of the wallet. For example, an anchor could charge no fees to facilitate deposit or withdraw transactions from a particular wallet. In this case, the anchor may want to notify the wallet of the effects with a `200` status and response.
+
+Example response:
+```json
+{
+  "effects": [
+    {
+      "name": "no-fees",
+      "description": "The user will not be charged a service fee for transaction 82fhs729f63dh0v4",
+      "expiration": "2020-08-26T21:39:19Z"
+    }
+  ]
+}
+```
+
+Each item in the `effects` list should have the following attributes:
+
+Name | Type | Description
+-----|------|------------
+`name` | string | The anchor-defined name for the effect applied
+`description` | string | The human-readable description of the effect on the user or transaction
+`expiration` | string | (optional) The UTC ISO 8601 formatted date and time at which the effect will no longer apply to the user
+
+If the verification is successful but the request is made after the transaction is processed by the anchor, return a `422` HTTP status code.
+
+```json
+{
+  "error": "transaction 82fhs729f63dh0v4 has already been processed"
+}
+```
+
+If verification is unsuccessful, the request is valid, and the anchor has verified that it has the current `SIGNING_KEY` from the Wallet Server's [stellar.toml](sep-0001.md), a `400` response should be returned. 
+
+Example response:
+```json
+{
+  "error": "the token's signature does not match the home domain's 'SIGNING_KEY'"
+}
+```
+
+If the anchor's `SIGNING_KEY` has been updated, retry the signature verification with the new `SIGNING_KEY`, save it locally, and return the appropriate response.
+
 ## Changes from SEP-6
 
 There is a small set of changes when upgrading from SEP-6 to SEP-24.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -704,7 +704,7 @@ Anchors can then attribute future requests related to that particular transactio
 
 ### Request 
 
-The request must be made after receiving the transaction `id` but before opening the `url` from the `POST /interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
+The request must be made after receiving the transaction `id` but before opening the `url` from the `POST /transactions/deposit/interactive` or `/transactions/withdraw/interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
 
 ```
 POST /transaction/attribution

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -698,7 +698,7 @@ For example:
 
 ## Wallet Attribution
 
-[SEP-34](sep-0034.md) defines how anchor can cryptographically attribute HTTPS requests to wallet applications. Specifically, an anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) (JWS) token passed by the wallet to verify HTTPS requests made for a particular transaction were made by the wallet application passing the JWS. 
+[SEP-34](sep-0034.md) defines how an anchor can cryptographically attribute HTTPS requests to wallet applications. Specifically, an anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) (JWS) token passed by the wallet to verify HTTPS requests made for a particular transaction were made by the wallet application passing the JWS. 
 
 Anchors can then attribute future requests related to that particular transaction with the same wallet application, enabling anchors to improve their monitoring and analytics systems, give discounts to users initiating transactions from a particular wallet, or require all other client applications to attribute their requests.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -698,7 +698,7 @@ For example:
 
 ## Wallet Attribution
 
-[SEP-34](sep-0034.md) defines how anchors can cryptographically attribute HTTPS requests to wallet applications. Specifically, an anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) (JWS) token passed by the wallet to verify HTTPS requests made for a particular transaction were made by the wallet application passing the JWS. 
+[SEP-34](sep-0034.md) defines how anchor can cryptographically attribute HTTPS requests to wallet applications. Specifically, an anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) (JWS) token passed by the wallet to verify HTTPS requests made for a particular transaction were made by the wallet application passing the JWS. 
 
 Anchors can then attribute future requests related to that particular transaction with the same wallet application, enabling anchors to improve their monitoring and analytics systems, give discounts to users initiating transactions from a particular wallet, or require all other client applications to attribute their requests.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -698,7 +698,9 @@ For example:
 
 ## Wallet Attribution
 
-[SEP-34](sep-0034.md) defines how anchors can cryptographically attribute HTTPS requests to wallet applications. Specifically, anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) token passed by the wallet to verify the HTTPS requests made for a particular transaction were made by the wallet application. Anchors can then attribute future requests related to that particular transaction with the same wallet application, enabling anchors to improve their monitoring and analytics systems, give discounts to users initiating transactions from a particular wallet, or require all other client applications to attribute their requests.
+[SEP-34](sep-0034.md) defines how anchors can cryptographically attribute HTTPS requests to wallet applications. Specifically, an anchors can use the [JSON Web Signature](https://tools.ietf.org/html/rfc7515) (JWS) token passed by the wallet to verify HTTPS requests made for a particular transaction were made by the wallet application passing the JWS. 
+
+Anchors can then attribute future requests related to that particular transaction with the same wallet application, enabling anchors to improve their monitoring and analytics systems, give discounts to users initiating transactions from a particular wallet, or require all other client applications to attribute their requests.
 
 ### Request 
 
@@ -742,7 +744,7 @@ Name | Type | Description
 `description` | string | The human-readable description of the effect on the user or transaction
 `expiration` | string | (optional) The UTC ISO 8601 formatted date and time at which the effect will no longer apply to the user
 
-If the verification is successful but the request is made after the transaction is processed by the anchor, return a `422` HTTP status code.
+If the verification is successful but the request is made after the transaction is processed by the anchor, return a `422 Unprocessable Entity`  HTTP status code.
 
 ```json
 {
@@ -750,7 +752,7 @@ If the verification is successful but the request is made after the transaction 
 }
 ```
 
-If verification is unsuccessful, the request is valid, and the anchor has verified that it has the current `SIGNING_KEY` from the Wallet Server's [stellar.toml](sep-0001.md), a `400` response should be returned. 
+If verification is unsuccessful, the request is valid, and the anchor has verified that it has the current `SIGNING_KEY` from the Wallet Server's [stellar.toml](sep-0001.md), a `400 Bad Request` response should be returned. 
 
 Example response:
 ```json

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -707,7 +707,7 @@ Anchors can then attribute future requests related to that particular transactio
 The request must be made after receiving the transaction `id` but before opening the `url` returned from the `POST /transactions/deposit/interactive` or `/transactions/withdraw/interactive` response. Anchors should reject attribution requests made before receiving a valid transaction ID or after the interactive popup has been displayed to the user. This ensures anchors are able to apply any effects to the user and transaction during the interactive portion of the flow.
 
 ```
-POST /transaction/attribution
+POST TRANSFER_SERVER_SEP0024/transaction/attribution
 ```
 
 Request parameters:

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -41,6 +41,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /fee`](#fee): optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history)
 * [`GET /transaction`](#single-historical-transaction)
+* [`POST /transaction/attribution`](#wallet-attribution): optional (only needed for anchors implementing [SEP-34](sep-0034.md))
 
 ## Authentication
 

--- a/ecosystem/sep-0034.md
+++ b/ecosystem/sep-0034.md
@@ -116,7 +116,7 @@ Once verified, the Anchor Server can use the JWT attributes with confidence that
 
 If Wallet Servers change or rotate their `SIGNING_KEY`, Anchor Servers receiving JWS tokens from these Wallets may have to update the local copies of the Wallet Servers' public keys when initial verification fails. Anchors must ensure the updated `SIGNING_KEY` is collected from the same service the previous `SIGNING_KEY` was collected from. Therefore, Anchors should retain a mapping of known Wallet Server home domains and public signing keys.
 
-### Expiration
+## Token Expiration
 Wallet Servers should select an expiration time for the JWT that is appropriate for the assumptions and risk of the interactions a user can perform with it. A Wallet application that owns the request for a deposit or withdrawal transaction at the time the JWT is issued may not own it in the future. While unlikely, a user could continue processing a transaction initiated previously with a different wallet application.
 
 Expiration times that are too long increase the risk that control of the transaction request will change. Expiration times that are too short increase the number of reauthentication attempts required by the wallet, which creates a poor user experience.


### PR DESCRIPTION
resolves stellar/integration-meta#182
resolves stellar/stellar-protocol#685

The diagram below outlines the beginning of a SEP-24 transaction flow that uses SEP-34 for wallet attribution.

![sep34](https://user-images.githubusercontent.com/10968980/91362279-01942300-e7af-11ea-9a9b-b32711264851.png)

The main idea is that:
- the wallet receives the transaction `id` and interactive `url`
- the wallet authenticates with the wallet server
- the wallet receives a JWS token
- the wallet passes the token to the anchor's `/transaction/attribution` endpoint
- the anchor validates the token
- the user opens the interactive flow and is charged no fees