### PR TITLE
Add SEP-31's DIRECT_PAYMENT_SERVER attribute to the TOML attribute list

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -60,6 +60,7 @@ SIGNING_KEY | Stellar public key | The signing key is used for [SEP-3](sep-0003.
 HORIZON_URL | url | Location of public-facing Horizon instance (if you offer one)
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
 URI_REQUEST_SIGNING_KEY | Stellar public key | The signing key is used for [SEP-7](sep-0007.md) delegated signing
+DIRECT_PAYMENT_SERVER | uses `https://` |  The server used for receiving [SEP-31](sep-0031.md) direct fiat-to-fiat payments. Requires [SEP-12](sep-0012.md) and hence a `KYC_SERVER` TOML attribute.
 
 ### Organization Documentation
 


### PR DESCRIPTION
Is `DIRECT_PAYMENT_SERVER` the way we want to go? Its assumed in Polaris, but thats the only released software that uses it currently.