### PR TITLE
SEP-31: Add fee endpoint and info attributes

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -72,7 +72,10 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 1. The sending client chooses a destination region.
 1. The sending anchor fetches the TOML file to find the DIRECT_PAYMENT_SERVER API root and [`/info`](#info) endpoint fields for the receiving anchor for this region.
 1. For each `_sep12_type` value specified in the relevant asset's [`/info`](#info) object, the sending anchor makes a [`SEP-12 GET /customer`](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) request.
-1. The sending anchor collects all information specified in the `GET /customer` response(s).
+1. The sending anchor collects the amount of the selected asset to send to the receiving client.
+1. If the [`/fee`](#fee) endpoint is enabled, the sending anchor uses the amount collected and appropriate key value from `/info`'s `fee_types` response object to request the fee the receiving anchor will charge the sending client.
+1. Optionally, the sending anchor verifies the `fee` returned with the sending client before proceeding.
+1. The sending anchor collects all information specified in the `GET /customer` response(s) and the `fields` returned from `/info`.
 1. The sending anchor PUTs all that information to the [`/customer`](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) endpoint of the receiving anchor.
 1. The sending anchor POSTs the transaction information to the [/transactions](#transactions) endpoint of the receiving anchor.
 1. If some of the information POSTed was missing or incorrect, or the `amount` value is large enough to require additional information, the receiving anchor returns a `400` error response using either the `transaction_info_needed` or `customer_info_needed` status strings. More information about these responses can be found in the [/transactions](#transactions) section.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -31,7 +31,6 @@ NigeriaPay will utilize its European rail, enabled with EuroPay Anchor service, 
 * Anchors will create bi-lateral agreements to interoperate with each other.  This differs from other protocols in that there is no concept of 'discoverability'.  Anchors should keep a mapping of their partnerships in different regions to their home domains.
 * Each anchor registers a Stellar key with each counterparty anchor they interact with in order to identify themselves via [SEP-10 Web Authentication](sep-0010.md).
 
-
 ## Authentication
 
 Anchors should support [SEP-10](sep-0010.md) web authentication to ensure the counterparty they're interoperating with is actually who they say they are.  Clients must submit the JWT obtained via the SEP-10 authentication flow to all API endpoints except `/info`.
@@ -90,6 +89,7 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 * [`POST /transactions`](#transactions)
 * [`GET /transactions/:id`](#transaction)
 * [`PATCH /transactions/:id`](#update)
+* [`GET /fee`](#fee): optional (only needed for complex fee structures)
 
 ### Info
 #### Request
@@ -137,8 +137,19 @@ The response should be a JSON object like:
                   ]
                }
             }
+         },
+         "fee_types": {
+            "cash_pickup": {
+               "description": "The fee for processing the payment with cash pickup service providers"
+            },
+            "SEPA": {
+               "description": "The fee charged to processing the payment using SEPA"
+            },
+            "in_app_rewards": {
+               "description": "The fee charged for depositing the payment funds the receiver's in-app account balance"
+            },
          }
-      }
+      },
    }
 }
 ```
@@ -153,7 +164,10 @@ The JSON object contains an entry for each asset that the anchor supports for re
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
 * `sender_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
 * `receiver_sep12_type`: Optional value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary.
-* `fields`: as explained below.
+* `fee_types`: Optional fee `type` values and descriptions for `GET /fee` requests
+* `fields`: Explained in the Fields subsection
+
+##### Fields
 
 The `fields` object allows an anchor to describe fields that must be passed into `POST /transactions`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
 
@@ -162,6 +176,8 @@ Each `fields` sub-object contains a key for each field name and an object with t
 * `description`: (required) description of field to show to user.
 * `choices`: (optional) list of possible values for the field.
 * `optional`: (optional) false if not specified.
+
+##### SEP-12 Types
  
 If `sender_sep12_type` or `receiver_sep12_type` are present in the response, the client must register the sender and receiver via [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) using the `type` argument provided. The receiving anchor uses this parameter to know what information needs to be collected on the customer.
 
@@ -185,7 +201,7 @@ Content-Type: application/json
       "receiver_account_number": "0029483242",
       "type": "SEPA"
     }
-  }
+  },
 }
 ```
 
@@ -246,6 +262,51 @@ In the case where the transaction just cannot be completed, return an error resp
 
 {
   'error': "That bank account is restricted via AML laws"
+}
+```
+
+### Fee
+
+The fee endpoint allows an receiving anchor to report the fee that would be charged for processing the payment of an asset. This endpoint is important to allow a sending anchor to accurately report fees to a sending user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
+
+```
+GET TRANSFER_SERVER_SEP0024/fee
+```
+
+Request parameters:
+
+Name | Type | Description
+-----|------|------------
+`type` | string | (optional) Type of payment method, optionally described in the `GET /info` endpoint
+`asset_code` | string | Asset code of the payment
+`amount` | float | Amount of the asset that would be sent to the receiving user
+
+Example request:
+
+```
+GET https://api.example.com/fee?asset_code=USD&amount=110.0&type=cash_pickup
+```
+
+On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
+
+Name | Type | Description
+-----|------|------------
+`fee` | float | The total fee (in units of the asset sent) that would be charged on top of the specified `amount` of `asset_code` sent to the user.
+
+Example response:
+
+```json
+{
+  "fee": 0.013
+}
+```
+
+Every HTTP status code other than `200 OK` will be considered an error. The body should contain error details.
+For example:
+
+```json
+{
+   "error": "This anchor doesn't support the given currency code: USD"
 }
 ```
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -270,7 +270,7 @@ In the case where the transaction just cannot be completed, return an error resp
 The fee endpoint allows an receiving anchor to report the fee that would be charged for processing the payment of an asset. This endpoint is important to allow a sending anchor to accurately report fees to a sending user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
 
 ```
-GET TRANSFER_SERVER_SEP0024/fee
+GET DIRECT_PAYMENT_SERVER/fee
 ```
 
 Request parameters:


### PR DESCRIPTION
resolves stellar/stellar-protocol#716

Adds a `fee_types` dictionary to the `GET /info` response as well as the SEP-24 `/fee` endpoint, minus the `operation` parameter.