### PR TITLE
SEP-12: added 404 response to SEP-12 GET /customer

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -169,7 +169,14 @@ Property | Type | Description
 
 #### Errors
 
-For invalid requests, return a 400 response describing the issue.
+For requests containing an `id` parameter value that does not exist or exists for a customer created by another anchor, return a `404` response.
+```json
+{
+   "error": "customer not found for id: 7e285e7d-d984-412c-97bc-909d0e399fbf"
+}
+```
+
+For invalid requests, return a `400` response describing the issue.
 For example:
 
 ```json


### PR DESCRIPTION
This PR adds a 404 response to the `GET /customer` endpoint which should be used when the `id` passed is for a nonexistent customer or for a customer created by another anchor, determined by the `sub` JWT key.

This response code will allow clients to determine if a customer exists as opposed to getting 400 back, which could mean the request was bad.