### PR TITLE
SEP-24: Communicate KYC status

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -337,7 +337,7 @@ As an alternative to using the `callback` parameter, the wallet can poll the tra
 
 Anchors should only send responses to `callback` when the user is finished with the interactive flow, and it's safe for the wallet to close the window. It should only be called zero or one time.
 
-`on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction should change. It can be called any number of times.
+`on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
 
 
 #### Guidance for wallets: completing an interactive withdrawal

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -593,7 +593,6 @@ Name | Type | Description
 `status` should be one of:
 
 * `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
-* `pending_kyc` -- the user has submitted their KYC information and the anchor is verifying it.
 * `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
 * `pending_external` -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
 * `pending_anchor` -- deposit/withdrawal is being processed internally by anchor. This can also be used when the anchor must verify KYC information prior to deposit/withdrawal.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -305,7 +305,9 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. Can also be set to `postMessage`.
+`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`. 
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. Can also be set to `postMessage`.
+
 
 **`callback` details**
 
@@ -330,6 +332,13 @@ target.postMessage({
 ```
 
 As an alternative to using the `callback` parameter, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
+
+**Differences between `callback` and `on_change_callback`**
+
+Anchors should only send responses to `callback` when the user is finished with the interactive flow, and it's safe for the wallet to close the window. It should only be called zero or one time.
+
+`on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction should change. It can be called any number of times.
+
 
 #### Guidance for wallets: completing an interactive withdrawal
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -549,6 +549,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
+`kyc_verified` | boolean | (optional) Whether or not the deposit/withdraw subject has been verified by the anchor.
 `more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -313,7 +313,15 @@ Name | Type | Description
 
 If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. If `callback=postMessage` is passed, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
-In either case, the JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
+**Differences between `callback` and `on_change_callback`**
+
+Anchors should only send responses to `callback` when the user is finished with the interactive flow, and it's safe for the wallet to close the window. It should only be called zero or one time.
+
+`on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
+
+**`callback` / `on_change_callback` example**
+
+The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 ```javascript
 // Example postMessage callback at the end of an interactive withdraw, indicating that the anchor is waiting for the wallet to send a payment in the amount of 80 of the asset in question. 
@@ -331,13 +339,7 @@ target.postMessage({
 }, "*");
 ```
 
-As an alternative to using the `callback` parameter, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
-
-**Differences between `callback` and `on_change_callback`**
-
-Anchors should only send responses to `callback` when the user is finished with the interactive flow, and it's safe for the wallet to close the window. It should only be called zero or one time.
-
-`on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
+As an alternative to using the `callback` or `on_change_callback` parameters, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
 
 #### Guidance for wallets: completing an interactive withdrawal
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -305,7 +305,7 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property changes, or when the `kyc_verified` property changes and the `status` property is incomplete or pending. Can also be set to `postMessage`.
+`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. Can also be set to `postMessage`.
 
 **`callback` details**
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -315,7 +315,7 @@ If the wallet wants to be notified that the user has completed the anchor's inte
 
 **Differences between `callback` and `on_change_callback`**
 
-Anchors should only send responses to `callback` when the user is finished with the interactive flow, and it's safe for the wallet to close the window. It should only be called zero or one time.
+Anchors may make _at most one request_ containing a `/transaction` response body to `callback` when the user is finished with the interactive flow _and_ the anchor has verified that it is safe for the wallet to close the popup window. 
 
 `on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -583,6 +583,7 @@ Name | Type | Description
 `status` should be one of:
 
 * `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
+* `pending_kyc` -- the user has submitted their KYC information and the anchor is verifying it.
 * `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
 * `pending_external` -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
 * `pending_anchor` -- deposit/withdrawal is being processed internally by anchor. This can also be used when the anchor must verify KYC information prior to deposit/withdrawal.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -558,7 +558,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`kyc_verified` | boolean | (optional) Whether or not the user's KYC information has been verified by the anchor.
+`kyc_verified` | boolean | (optional) Whether or not the anchor has verified the user's KYC information and has authorized them for this transaction.
 `more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -305,7 +305,7 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`.
+`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property changes, or when the `kyc_verified` property changes and the `status` property is incomplete or pending. Can also be set to `postMessage`.
 
 **`callback` details**
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -549,7 +549,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`kyc_verified` | boolean | (optional) Whether or not the deposit/withdraw subject has been verified by the anchor.
+`kyc_verified` | boolean | (optional) Whether or not the user's KYC information has been verified by the anchor.
 `more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -308,6 +308,7 @@ Name | Type | Description
 `callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`. 
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. Can also be set to `postMessage`.
 
+The postMessage or URL supplied by both callback parameters should receive the full transaction object.
 
 **`callback` details**
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -558,7 +558,7 @@ Name | Type | Description
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
 `status_eta` | number | (optional) Estimated number of seconds until a status change is expected.
-`kyc_verified` | boolean | (optional) Whether or not the anchor has verified the user's KYC information and has authorized them for this transaction.
+`kyc_verified` | boolean | (optional) True if the anchor has verified the user's KYC information for this transaction.
 `more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction. 
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -339,7 +339,6 @@ Anchors should only send responses to `callback` when the user is finished with 
 
 `on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
 
-
 #### Guidance for wallets: completing an interactive withdrawal
 
 Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Interactive Anchor/Wallet Asset Transfer Server
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2019-09-18
-Version 1.0.0
+Updated: 2020-10-06
+Version 1.1.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
Wallets need visibility into the user's KYC status to alert users when they can continue or re-request their deposit / withdrawal intent after being approved. This adds two things that help do this:

- A boolean `kyc_verified` field on transaction objects
- A `on_change_callback` that calls back each time the transaction object's `status` or `kyc_verified` fields change