### PR TITLE
SEP-0030: Make compatible with CAP-33

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -486,7 +486,7 @@ need to sign transactions that contain other accounts, like a sponsoring
 account used with CAP-33. In those cases a server may be implemented to allow
 transactions to contain that specific sponsoring account as a source account,
 but the server operator must ensure that the signing keys used by the server
-are never capable of authorizing operations for the sponsoring account.
+are never signers of the sponsoring account.
 
 The transaction can contain any operations, but it is anticipated for the use
 cases discussed earlier in this protocol that the transaction will contain an

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-06-30
-Version: 0.5.0
+Updated: 2020-10-09
+Version: 0.6.0
 ```
 
 ## Summary
@@ -59,8 +59,13 @@ The signing flow is as follows:
 - The client, authenticated as the external authentication method (e.g. phone, email, etc) or another account, requests the server to sign a transaction.
 - The server verifies that the [JWT] is valid according to the authentication provider's specification.
 - The server verifies that the external authentication method (e.g. phone, email, etc) or account in the [JWT] is an alternative identity of the account.
-- The server verifies that the source account of the transaction is the account.
-- The server verifies that the source account of all operations on the transaction are not set or set to the account.
+- The server verifies that the source account of the transaction is one of:
+  - The account the client has authenticated for.
+  - In some unique cases an account the server knows definitively for the validity period of the transaction will not be authorized by the signing key.<sup>[1](#note1)</sup>
+- The server verifies that the source account of each operation in the transaction are one of:
+  - Not set.
+  - The account the client has authenticated for.
+  - In some unique cases an account the server knows definitively for the validity period of the transaction will not be authorized by the signing key.<sup>[1](#note1)</sup>
 - The server signs the transaction with the signing secret key.
 - The server responds to the client with the signature.
 
@@ -77,6 +82,9 @@ A client can also use the endpoints in the specification to:
 - Update the identities associated with an account.
 - Find out if a new signing key is available due to signing key rotation.
 - Delete accounts.
+
+Notes:
+1. <a name="note1"></a>See [Endpoints `POST /accounts/<address>/sign/<signing-address>`](#post-accountsaddresssignsigning-address) for more details.
 
 ## Use Cases
 
@@ -467,9 +475,18 @@ available for signing. An account should check what signers are available
 periodically and update the signer on the account to be the most recently
 generated signer.
 
-The transaction must only contain operations for the account. The source
-account of the transaction and the source account of all operations in the
-transaction must match the account in the request.
+A server must only authorize operations in signed transactions that operate on
+the registered account that the client has authenticated for. This is to ensure
+that the server does not authorize operations for an account the client is not
+authorized. Generally to achieve this the transaction must only be signed if it
+contain operations for the authenticated account. The server can verify that
+the source account of the transaction and the source account of all operations
+in the transaction match the account in the request. In some cases servers may
+need to sign transactions that contain other accounts, like a sponsoring
+account used with CAP-33. In those cases a server may be implemented to allow
+transactions to contain that specific sponsoring account as a source account,
+but the server operator must ensure that the signing keys used by the server
+are never capable of authorizing operations for the sponsoring account.
 
 The transaction can contain any operations, but it is anticipated for the use
 cases discussed earlier in this protocol that the transaction will contain an

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -467,6 +467,7 @@ See [Common Fields].
 This endpoint signs a transaction that has operations for the account using the
 signing key associated with the signing address specified in the path.
 
+##### `<signing-address>`
 The signing address specified must be one of the signing keys that the server
 has provided as a signer. The client should use the signing address that has
 been added as a signer to the account. The server may generate new signing keys
@@ -478,15 +479,20 @@ generated signer.
 A server must only authorize operations in signed transactions that operate on
 the registered account that the client has authenticated for. This is to ensure
 that the server does not authorize operations for an account the client is not
-authorized. Generally to achieve this the transaction must only be signed if it
-contain operations for the authenticated account. The server can verify that
-the source account of the transaction and the source account of all operations
-in the transaction match the account in the request. In some cases servers may
-need to sign transactions that contain other accounts, like a sponsoring
-account used with CAP-33. In those cases a server may be implemented to allow
-transactions to contain that specific sponsoring account as a source account,
-but the server operator must ensure that the signing keys used by the server
-are never signers of the sponsoring account.
+authorized. There are multiples ways to achieve this depending on the use cases
+of the server.
+
+The simplest approach is to require the transaction to only contain operations
+for the authenticated account. The server can verify that the source account of
+the transaction and the source account of all operations in the transaction
+match the account in the request.
+
+In some cases a server may need to sign transactions that contain other
+accounts. For example, a sponsoring account using operations defined in CAP-33.
+A server could be implemented to allow transactions to contain that specific
+sponsoring account as a source account. The server operator must ensure that
+the signing keys used by the server are never signers of the sponsoring account
+to ensure an authenticated client cannot sign for the sponsoring account.
 
 The transaction can contain any operations, but it is anticipated for the use
 cases discussed earlier in this protocol that the transaction will contain an


### PR DESCRIPTION
### What
Allow SEP-30 servers to sign transactions that contain source accounts other than the authenticated account, at the discretion of the SEP-30 server operator.

### Why
SEP-30 is not compatible with CAP-33 because SEP-30 requires servers to reject transactions that contain other accounts as source accounts. For accounts that have signers sponsored by a sponsoring account as supported by CAP-33, changing a sponsor requires operations with the sponsoring account as a source account. This means it is not possible to change a sponsored signer via a SEP-30 server.

The limitation within SEP-30 is to address the confused deputy problem. The SEP-30 server is signing a transaction, potentially with a shared key, and it must ensure that it only signs a transaction for a user that relate to accounts that the user is authenticated for.

In the case that a SEP-30 server operator is also the operator of a solution that is utilizing CAP-33, it is highly unlikely that the operator needs the sponsoring account to be registered with the SEP-30 server. In that case it is simple for the operator to ensure that the signing keys used by the SEP-30 server are never signers of the sponsoring account and therefore it doesn't matter if the SEP-30 server signs transactions containing the sponsoring account.

There may be other features of Stellar that make it easier to sign for specific operations on transactions and not an entire transaction, and if they ever eventuate this change would become redundant and could be deprecated. At the moment this appears to be the simplest path forward.

If this change is accepted, then the reference implementation should be updated to match. The issue for that work is stellar/go#2796.

Close #668