### PR TITLE
SEP-0036: Use sandwich transactions and simplify approval server responses

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -66,7 +66,7 @@
 | [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Draft |
 | [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Final Comment Period |
 | [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
-
+| [SEP-0036](sep-0036.md) | Regulated Assets Transacting | Howard Chen | Standard | Draft |
 
 
 ### Rejected and Deprecated Proposals
@@ -74,6 +74,7 @@
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
 | [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Deprecated |
+| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Standard | Deprecated |
 | [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Rejected |
 
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -66,7 +66,7 @@
 | [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Draft |
 | [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Final Comment Period |
 | [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
-| [SEP-0036](sep-0036.md) | Regulated Assets Transacting | Howard Chen | Standard | Draft |
+| [SEP-0036](sep-0036.md) | Transaction Approval for Regulated Assets | Howard Chen | Standard | Draft |
 
 
 ### Rejected and Deprecated Proposals
@@ -74,7 +74,6 @@
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
 | [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Deprecated |
-| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Standard | Deprecated |
 | [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Rejected |
 
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -4,15 +4,10 @@
 SEP: 0008
 Title: Regulated Assets
 Author: Interstellar.com
-Status: Deprecated
+Status: Final
 Created: 2018-08-22
-Updated: 2020-10-26
-Version 1.0.1
+Version 1.0.0
 ```
-
-## Deprecation Notice
-
-For most use cases, we recommend the workflow specified in [SEP-0036](sep-0036.md) instead of SEP-0008.
 
 ## Simple Summary
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -136,8 +136,7 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 
 - We should define the request and the response format in this case.
 
-### How should the rule server obtain the KYC information in order to make a decision?
-
+### How should issuers obtain the KYC information from the wallet in order to make a decision?
 
 [Stellar.toml]: #stellartoml
 [Approval Server]: #approval-server

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,12 +3,16 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com, Howard Chen <@howardtw>
-Status: Active
+Author: Interstellar.com
+Status: Deprecated
 Created: 2018-08-22
-Updated: 2020-10-20
-Version 2.0.0
+Updated: 2020-10-26
+Version 1.0.1
 ```
+
+## Deprecation Notice
+
+For most use cases, we recommend the workflow specified in [SEP-0036](sep-0036.md) instead of SEP-0008.
 
 ## Simple Summary
 
@@ -23,22 +27,25 @@ Stellar aims to be an ideal platform for issuing securities. As such, it must pr
 ## Overview
 
 Implementing a Regulated Asset consists of these parts:
-- [Stellar.toml]: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- [Approval Server]: HTTP protocol for transaction signing.
-- [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
+- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+- **Approval Server**: HTTP protocol for transaction signing.
+- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/>
+**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented.
 
 ## Regulated Assets Approval Flow
 
 1. User creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the compliance ruleset and looks up the current state of the ledger if necessary.
+4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
 5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer.
-    2. *Rejected?* Wallet should display given error message to the user.
+    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
+    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
+    3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
+    4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
+    5. *Rejected?* Wallet should display given error message to the user.
 
 ## Stellar.toml
-
 Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
 
 ### Fields:
@@ -59,20 +66,23 @@ approval_criteria="The goat approval server will ensure that transactions are co
 ```
 
 ## Approval Server
-
-The transaction approval server receives a signed transaction and checks for compliance and signs it on success.
+The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
 
 ### Possible results
 - Success: Transaction was found compliant and signed by service.
+- Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
+- Pending: The issuer will asynchronously validate the transaction and respond later.
+- Action Required: The user must complete an action in order to have the transaction approved.
 - Rejected: Transaction was rejected.
 
 ### Request
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed if possible.
 
 ### Responses
 
 HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
+
 
 #### Success Response
 
@@ -83,62 +93,79 @@ Parameters:
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"success"`
-tx|string|Transaction envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
+tx|string|Transaction Envelope XDR, Base64 encoded. This transaction will have both the original signature(s) from the request, as well as an additional issuer signature.
 message|string|A human readable string containing information to pass on to the user (optional).
+
+#### Revised Response
+
+A Revised response will have a `200` HTTP status code and `revised` as the `status` value. It means that the transaction was revised to be made compliant. The user should examine and resign the transaction.
+
+Parameters:
+
+Name | Data Type | Description
+-----|-----------|------------
+status|string|`"revised"`
+tx|string|Transaction Envelope XDR, Base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
+message|string|A human readable string explaining the modifications made to the transaction to make it compliant.
+
+#### Pending Response
+
+A Pending response will have a `200` HTTP status code and `pending` as the `status` value. It means that the issuer needs to asynchronously validate the transaction. The user should resubmit the transaction after a given timeout.
+
+Parameters:
+
+Name | Data Type | Description
+-----|-----------|------------
+status|string|`"pending"`
+timeout|integer|Number of milliseconds to wait before submitting the same transaction again.
+message|string|A human readable string containing information to pass on to the user (optional).
+
+#### Action Required Response
+
+An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+
+Parameters:
+
+Name | Data Type | Description
+-----|-----------|------------
+status|string|`"action_required"`
+message|string|A human readable string containing information regarding the action required.
+action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
 
 #### Rejected Response
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
-
-The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
+A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and could not be revised to be made compliant.
 
 Parameters:
 
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"rejected"`
-error|string|A human readable string explaining why the transaction is not compliant.
+error|string|A human readable string explaining why the transaction is not compliant and could not be made compliant.
 
-## Transaction Composition
+### Best practices
 
-Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction. In other words, wallets can build transactions where a single operation, which has been approved by the issuer, can be run. If wallets compose transactions this way, there will be no point where accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity.
+- If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
+- Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
+- Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
+- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
+- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
 
-Depending on whether issuers want to allow the accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+## Account Setup
 
-Here is an example of the transaction:
+Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
 
-```
-Operation 1: Issuer uses AllowTrust to fully authorize account A, asset X
-Operation 2: Issuer uses AllowTrust to fully authorize account B, asset X
-Operation 3: Payment from A to B
-Operation 4: Issuer uses AllowTrust to set account B, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
-Operation 5: Issuer uses AllowTrust to set account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
-```
+In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
 
 ## Discussion
 
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
+Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
-### Why doesn’t the approval server submit transactions to the network?
+### Why doesn’t the approval service submit transactions to the network?
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
-- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
 
-### Should the ruleset simply sit in the approval server?
-
-- Issuers can configure the ruleset with server configs.
-- The server can read the ruleset from a file and we can format the file so that it has a section about ledger state under Horizon.
-
-### Should the approval server make an API call to the issuer's server for rule checking if any?
-
-- We should define the request and the response format in this case.
-
-### How should issuers obtain the KYC information from the wallet in order to make a decision?
-
-[Stellar.toml]: #stellartoml
-[Approval Server]: #approval-server
-[Transaction Composition]: #transaction-composition
-[CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -32,7 +32,7 @@ Implementing a Regulated Asset consists of these parts:
 1. User creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the compliance ruleset and look up the current state of the ledger if necessary.
+4. Approval server determines whether the transaction is compliant based on the compliance ruleset and looks up the current state of the ledger if necessary.
 5. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by issuer.
     2. *Rejected?* Wallet should display given error message to the user.
@@ -68,7 +68,7 @@ The transaction approval server receives a signed transaction and checks for com
 
 ### Request
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
 ### Responses
 
@@ -83,12 +83,14 @@ Parameters:
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"success"`
-tx|string|Transaction Envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
+tx|string|Transaction envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
 message|string|A human readable string containing information to pass on to the user (optional).
 
 #### Rejected Response
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server. The client should act accordingly based on the error message or retry if the issuer needs more time to validate the transaction.
+A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
+
+The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
 
 Parameters:
 
@@ -99,7 +101,19 @@ error|string|A human readable string explaining why the transaction is not compl
 
 ## Transaction Composition
 
-WIP.
+Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction. In other words, wallets can build transactions where a single operation, which has been approved by the issuer, can be run. If wallets compose transactions this way, there will be no point where accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity.
+
+Depending on whether issuers want to allow the accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+
+Here is an example of the transaction:
+
+```
+Operation 1: Issuer uses AllowTrust to fully authorize account A, asset X
+Operation 2: Issuer uses AllowTrust to fully authorize account B, asset X
+Operation 3: Payment from A to B
+Operation 4: Issuer uses AllowTrust to set account B, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+Operation 5: Issuer uses AllowTrust to set account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+```
 
 ## Discussion
 
@@ -111,11 +125,11 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
-- Wallets can handle the failure from transaction submission differently based on the type of errors.
+- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
 
 ### Should the ruleset simply sit in the approval server?
 
-- Issuers can configure the rules with server configs.
+- Issuers can configure the ruleset with server configs.
 - The server can read the ruleset from a file and we can format the file so that it has a section about ledger state under Horizon.
 
 ### Should the approval server make an API call to the issuer's server for rule checking if any?
@@ -128,3 +142,4 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 [Stellar.toml]: #stellartoml
 [Approval Server]: #approval-server
 [Transaction Composition]: #transaction-composition
+[CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -23,25 +23,22 @@ Stellar aims to be an ideal platform for issuing securities. As such, it must pr
 ## Overview
 
 Implementing a Regulated Asset consists of these parts:
-- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- **Approval Server**: HTTP protocol for transaction signing.
-- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/>
-**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented.
+- [Stellar.toml]: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+- [Approval Server]: HTTP protocol for transaction signing.
+- [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
 
 ## Regulated Assets Approval Flow
 
 1. User creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
+4. Approval server determines whether the transaction is compliant based on the compliance ruleset and look up the current state of the ledger if necessary.
 5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
-    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
-    3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
-    4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
-    5. *Rejected?* Wallet should display given error message to the user.
+    1. *Success?* Transaction has been approved and signed by issuer.
+    2. *Rejected?* Wallet should display given error message to the user.
 
 ## Stellar.toml
+
 Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
 
 ### Fields:
@@ -62,23 +59,20 @@ approval_criteria="The goat approval server will ensure that transactions are co
 ```
 
 ## Approval Server
-The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
+
+The transaction approval server receives a signed transaction and checks for compliance and signs it on success.
 
 ### Possible results
 - Success: Transaction was found compliant and signed by service.
-- Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
-- Pending: The issuer will asynchronously validate the transaction and respond later.
-- Action Required: The user must complete an action in order to have the transaction approved.
 - Rejected: Transaction was rejected.
 
 ### Request
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed if possible.
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
 ### Responses
 
 HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
-
 
 #### Success Response
 
@@ -89,79 +83,48 @@ Parameters:
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"success"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction will have both the original signature(s) from the request, as well as an additional issuer signature.
+tx|string|Transaction Envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
 message|string|A human readable string containing information to pass on to the user (optional).
-
-#### Revised Response
-
-A Revised response will have a `200` HTTP status code and `revised` as the `status` value. It means that the transaction was revised to be made compliant. The user should examine and resign the transaction.
-
-Parameters:
-
-Name | Data Type | Description
------|-----------|------------
-status|string|`"revised"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
-message|string|A human readable string explaining the modifications made to the transaction to make it compliant.
-
-#### Pending Response
-
-A Pending response will have a `200` HTTP status code and `pending` as the `status` value. It means that the issuer needs to asynchronously validate the transaction. The user should resubmit the transaction after a given timeout.
-
-Parameters:
-
-Name | Data Type | Description
------|-----------|------------
-status|string|`"pending"`
-timeout|integer|Number of milliseconds to wait before submitting the same transaction again.
-message|string|A human readable string containing information to pass on to the user (optional).
-
-#### Action Required Response
-
-An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
-
-Parameters:
-
-Name | Data Type | Description
------|-----------|------------
-status|string|`"action_required"`
-message|string|A human readable string containing information regarding the action required.
-action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
 
 #### Rejected Response
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and could not be revised to be made compliant.
+A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server. The client should act accordingly based on the error message or retry if the issuer needs more time to validate the transaction.
 
 Parameters:
 
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"rejected"`
-error|string|A human readable string explaining why the transaction is not compliant and could not be made compliant.
+error|string|A human readable string explaining why the transaction is not compliant.
 
-### Best practices
+## Transaction Composition
 
-- If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
-- Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
-- Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
-- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
-- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
-
-## Account Setup
-
-Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
-
-In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
+WIP.
 
 ## Discussion
 
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
-Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
-### Why doesn’t the approval service submit transactions to the network?
+### Why doesn’t the approval server submit transactions to the network?
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
+- Wallets can handle the failure from transaction submission differently based on the type of errors.
 
+### Should the ruleset simply sit in the approval server?
+
+- Issuers can configure the rules with server configs.
+- The server can read the ruleset from a file and we can format the file so that it has a section about ledger state under Horizon.
+
+### Should the approval server make an API call to the issuer's server for rule checking if any?
+
+- We should define the request and the response format in this case.
+
+### How should the rule server obtain the KYC information in order to make a decision?
+
+
+[Stellar.toml]: #stellartoml
+[Approval Server]: #approval-server
+[Transaction Composition]: #transaction-composition

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,10 +3,11 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com
-Status: Final
+Author: Interstellar.com, Howard Chen <@howardtw>
+Status: Active
 Created: 2018-08-22
-Version 1.0.0
+Updated: 2020-10-20
+Version 2.0.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -25,7 +25,7 @@ Stellar aims to be an ideal platform for issuing securities. As such, it must pr
 
 Implementing a Regulated Asset consists of these parts:
 - [Stellar.toml]: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- [Approval Server]: HTTP protocol for transaction signing.
+- [Approval Server]: Endpoints defined in this SEP that a client uses to sign a transaction that temporarily authorizes the client to operate with the asset.
 - [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
 
 ## Regulated Assets Approval Flow

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -11,7 +11,7 @@ Version 0.1.0
 
 ## Simple Summary
 
-Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
+Regulated Assets are assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
 
 This SEP is based on [SEP-0008](sep-0008.md), but the issuer no long has to a co-signer on the account holding the regulated asset. It also updates the API of the approval server to better align with other active SEPs.
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -89,7 +89,7 @@ message|string|A human readable string containing information to pass on to the 
 
 #### Rejected Response
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
+A Rejected response will have a `422` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
 
 The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -19,7 +19,7 @@ This SEP is based on [SEP-0008](sep-0008.md), but the issuer no long has to a co
 
 ## Motivation
 
-Stellar aims to be an ideal platform for issuing securities. As such, it must provide tools to comply with various regulatory requirements. Regulation often requires asset issuers to monitor and approve every transaction involving the issued asset and to enforce an assortment of constraints. This SEP provides support for these requirements.
+Stellar is an ideal platform for issuing securities. Regulation sometimes requires asset issuers to monitor and approve each transaction involving issued assets and to enforce constraints. This is possible on the Stellar network today, however there exists no standard interface between wallets and issuers to negotiate approval.
 
 ## Overview
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0036
-Title: Regulated Assets Transacting
+Title: Transaction Approval for Regulated Assets
 Author: Howard Chen <@howardtw>
 Status: Draft
 Created: 2020-10-26

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -24,7 +24,7 @@ Stellar aims to be an ideal platform for issuing securities. As such, it must pr
 ## Overview
 
 Implementing a Regulated Asset consists of these parts:
-- [Stellar.toml]: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+- [SEP-1 stellar.toml]: Issuers advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
 - [Approval Server]: Endpoints defined in this SEP that a client uses to sign a transaction that temporarily authorizes the client to operate with the asset.
 - [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
 
@@ -38,9 +38,9 @@ Implementing a Regulated Asset consists of these parts:
     1. *Success?* Transaction has been approved and signed by issuer.
     2. *Rejected?* Wallet should display given error message to the user.
 
-## Stellar.toml
+## SEP-1 stellar.toml
 
-Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+Issuers advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
 
 ### Fields:
 
@@ -131,7 +131,7 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 
 ### How should issuers obtain the KYC information from the wallet in order to make a decision?
 
-[Stellar.toml]: #stellartoml
+[SEP-1 stellar.toml]: #sep-1-stellartoml
 [Approval Server]: #approval-server
 [Transaction Composition]: #transaction-composition
 [CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -128,15 +128,6 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 - Transactions might require more signatures from further regulated asset issuers.
 - Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
 
-### Should the ruleset simply sit in the approval server?
-
-- Issuers can configure the ruleset with server configs.
-- The server can read the ruleset from a file and we can format the file so that it has a section about ledger state under Horizon.
-
-### Should the approval server make an API call to the issuer's server for rule checking if any?
-
-- We should define the request and the response format in this case.
-
 ### How should issuers obtain the KYC information from the wallet in order to make a decision?
 
 [Stellar.toml]: #stellartoml

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -1,0 +1,145 @@
+## Preamble
+
+```
+SEP: 0036
+Title: Regulated Assets Transacting
+Author: Howard Chen <@howardtw>
+Status: Draft
+Created: 2020-10-26
+Version 0.1.0
+```
+
+## Simple Summary
+
+Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
+
+This SEP is based on [SEP-0008](sep-0008.md), but the issuer no long has to a co-signer on the account holding the regulated asset. It also updates the API of the approval server to better align with other active SEPs.
+
+**Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
+
+## Motivation
+
+Stellar aims to be an ideal platform for issuing securities. As such, it must provide tools to comply with various regulatory requirements. Regulation often requires asset issuers to monitor and approve every transaction involving the issued asset and to enforce an assortment of constraints. This SEP provides support for these requirements.
+
+## Overview
+
+Implementing a Regulated Asset consists of these parts:
+- [Stellar.toml]: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+- [Approval Server]: HTTP protocol for transaction signing.
+- [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
+
+## Regulated Assets Approval Flow
+
+1. User creates and signs a transaction.
+2. Wallet resolves asset information and detects that it's a regulated asset.
+3. Wallet sends the transaction to the approval server.
+4. Approval server determines whether the transaction is compliant based on the compliance ruleset and looks up the current state of the ledger if necessary.
+5. Wallet handles approval response:
+    1. *Success?* Transaction has been approved and signed by issuer.
+    2. *Rejected?* Wallet should display given error message to the user.
+
+## Stellar.toml
+
+Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+
+### Fields:
+
+- `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
+- `approval_server` is the url of an approval service that signs validated transactions.
+- `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
+
+### Example
+
+```toml
+[[CURRENCIES]]
+code="GOAT"
+issuer="GD5T6IPRNCKFOHQWT264YPKOZAWUMMZOLZBJ6BNQMUGPWGRLBK3U7ZNP"
+regulated=true
+approval_server="https://goat.io/tx_approve"
+approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
+```
+
+## Approval Server
+
+The transaction approval server receives a signed transaction and checks for compliance and signs it on success.
+
+### Possible results
+- Success: Transaction was found compliant and signed by service.
+- Rejected: Transaction was rejected.
+
+### Request
+
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+
+### Responses
+
+HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
+
+#### Success Response
+
+A Successful response will have a `200` HTTP status code and `success` as the `status` value. This response means that the transaction was found compliant and signed.
+
+Parameters:
+
+Name | Data Type | Description
+-----|-----------|------------
+status|string|`"success"`
+tx|string|Transaction envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
+message|string|A human readable string containing information to pass on to the user (optional).
+
+#### Rejected Response
+
+A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
+
+The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
+
+Parameters:
+
+Name | Data Type | Description
+-----|-----------|------------
+status|string|`"rejected"`
+error|string|A human readable string explaining why the transaction is not compliant.
+
+## Transaction Composition
+
+Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction. In other words, wallets can build transactions where a single operation, which has been approved by the issuer, can be run. If wallets compose transactions this way, there will be no point where accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity.
+
+Depending on whether issuers want to allow the accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+
+Here is an example of the transaction:
+
+```
+Operation 1: Issuer uses AllowTrust to fully authorize account A, asset X
+Operation 2: Issuer uses AllowTrust to fully authorize account B, asset X
+Operation 3: Payment from A to B
+Operation 4: Issuer uses AllowTrust to set account B, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+Operation 5: Issuer uses AllowTrust to set account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+```
+
+## Discussion
+
+### Should my asset be a regulated asset?
+
+Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
+
+### Why doesn’t the approval server submit transactions to the network?
+
+- Separation of concerns between signing transactions and submitting them.
+- Transactions might require more signatures from further regulated asset issuers.
+- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
+
+### Should the ruleset simply sit in the approval server?
+
+- Issuers can configure the ruleset with server configs.
+- The server can read the ruleset from a file and we can format the file so that it has a section about ledger state under Horizon.
+
+### Should the approval server make an API call to the issuer's server for rule checking if any?
+
+- We should define the request and the response format in this case.
+
+### How should issuers obtain the KYC information from the wallet in order to make a decision?
+
+[Stellar.toml]: #stellartoml
+[Approval Server]: #approval-server
+[Transaction Composition]: #transaction-composition
+[CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -30,7 +30,7 @@ Implementing a Regulated Asset consists of these parts:
 
 ## Regulated Assets Approval Flow
 
-1. User creates and signs a transaction.
+1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 3. Wallet sends the transaction to the approval server.
 4. Approval server determines whether the transaction is compliant based on the compliance ruleset and looks up the current state of the ledger if necessary.

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -69,7 +69,7 @@ The transaction approval server receives a signed transaction and checks for com
 
 ### Request
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `transaction` parameter. `transaction` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
 ### Responses
 
@@ -84,7 +84,7 @@ Parameters:
 Name | Data Type | Description
 -----|-----------|------------
 status|string|`"success"`
-tx|string|Transaction envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
+transaction|string|Transaction envelope XDR, base64 encoded. This transaction will have the original signature(s) from the request as well as the asset issuer's signature.
 message|string|A human readable string containing information to pass on to the user (optional).
 
 #### Rejected Response

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -33,7 +33,7 @@ Implementing a Regulated Asset consists of these parts:
 1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the compliance ruleset and looks up the current state of the ledger if necessary.
+4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by issuer.
     2. *Rejected?* Wallet should display given error message to the user.

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -32,6 +32,7 @@ Implementing a Regulated Asset consists of these parts:
 
 1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
+	1. Wallet can detect whether an asset is a regulated asset by checking the asset issuer's account to see whether it has both `Authorization Required` and `Authorization Revocable` flags set.
 3. Wallet sends the transaction to the approval server.
 4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -69,7 +69,7 @@ The transaction approval server receives a signed transaction and checks for com
 
 ### Request
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `transaction` parameter. `transaction` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type` being `application/x-www-form-urlencoded` or `application/json` and a single `transaction` parameter. `transaction` value is a base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
 ### Responses
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -15,7 +15,9 @@ Regulated Assets are assets that require an issuer’s approval (or a delegated 
 
 This SEP is based on [SEP-0008](sep-0008.md), but the issuer no long has to a co-signer on the account holding the regulated asset. It also updates the API of the approval server to better align with other active SEPs.
 
-**Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
+## Target Audience
+
+Asset issuers, issuance platforms, wallet developers, and exchanges.
 
 ## Motivation
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -24,7 +24,7 @@ Stellar is an ideal platform for issuing securities. Regulation sometimes requir
 ## Overview
 
 Implementing a Regulated Asset consists of these parts:
-- [SEP-1 stellar.toml]: Issuers advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
+- [Identification]: Issuers advertise the existence of an Approval Service and the approval criteria via their [SEP-1 stellar.toml] file. Issuers set the [authorization flags] in the asset issuing account.
 - [Approval Server]: Endpoints defined in this SEP that a client uses to sign a transaction that temporarily authorizes the client to operate with the asset.
 - [Transaction Composition]: Wallets will have to put operations that fully authorize the accounts for the asset, transact the asset, and deauthorize the accounts in a single transaction.
 
@@ -32,24 +32,28 @@ Implementing a Regulated Asset consists of these parts:
 
 1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
-	1. Wallet can detect whether an asset is a regulated asset by checking the asset issuer's account to see whether it has both `Authorization Required` and `Authorization Revocable` flags set.
+	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
 3. Wallet sends the transaction to the approval server.
 4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by issuer.
     2. *Rejected?* Wallet should display given error message to the user.
 
-## SEP-1 stellar.toml
+## Identification
 
-Issuers advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+### SEP-1 stellar.toml
 
-### Fields:
+Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the `[[CURRENCIES]]` section as different assets can have different requirements.
+
+#### Fields
+
+These fields are listed in the `[[CURRENCIES]]` section:
 
 - `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
 - `approval_server` is the url of an approval service that signs validated transactions.
 - `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
 
-### Example
+#### Example
 
 ```toml
 [[CURRENCIES]]
@@ -59,6 +63,10 @@ regulated=true
 approval_server="https://goat.io/tx_approve"
 approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
 ```
+
+### Authorization Flags
+
+Control access to an asset is done in the asset issuer's account. Regulated asset issuers will have both `Authorization Required` and `Authorization Revocable` flags set in their account.
 
 ## Approval Server
 
@@ -132,7 +140,9 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 
 ### How should issuers obtain the KYC information from the wallet in order to make a decision?
 
-[SEP-1 stellar.toml]: #sep-1-stellartoml
+[Identification]: #identification
+[SEP-1 stellar.toml]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[authorization flags]: #authorization-flags
 [Approval Server]: #approval-server
 [Transaction Composition]: #transaction-composition
 [CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -91,7 +91,7 @@ message|string|A human readable string containing information to pass on to the 
 
 A Rejected response will have a `422` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and thus not signed by the server.
 
-The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
+The error message should explain why the transaction is not compliant and advice further actions for the client if possible. If there are further actions that the user must complete before this transaction can be approved, the issuer may provide a URL via `action_url` to faciliate the actions. If the issuer needs to asynchronously validate the transaction, the adviced wait time should be included in the error message if possible so the client would know when to retry.
 
 Parameters:
 
@@ -99,6 +99,7 @@ Name | Data Type | Description
 -----|-----------|------------
 status|string|`"rejected"`
 error|string|A human readable string explaining why the transaction is not compliant.
+action_url|string|A URL that allows the user to complete the actions required to have the transaction approved (optional).
 
 ## Transaction Composition
 

--- a/ecosystem/sep-0036.md
+++ b/ecosystem/sep-0036.md
@@ -137,6 +137,7 @@ Ideally, no. Implementing Regulated Assets should only be used when absolutely n
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
 - Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
+- Scaling concerns as having the approval server submit transactions would require more infrastructure.
 
 ### How should issuers obtain the KYC information from the wallet in order to make a decision?
 


### PR DESCRIPTION
### What
This PR replaces the `Account Setup` section with the `Transaction Composition`. It also simplifies the response of an approval server so that it either accepts or rejects a transaction.

### Why
There are several drawbacks of configuring an asset issuer as a signer as mentioned in [CAP-18](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md#motivation).
```
1. The owner of an account cannot unilaterally utilize assets unrelated to the issuer without the signature of that issuer
2. If multiple issuers want to become signers on a single account, then many signatures are potentially required for simple operations
3. Issuers cannot easily rotate keys, because their keys are on every account holding their asset
```

Having the approval server return a revised transaction is not straightforward as the approval server will have to understand the intention of the received transaction and propose another one. Revising the transaction also means that the original signatures are removed and the client will have to examine the transaction before signing it again. This will complicate the flows on the client side and make them inconsistent.

Finally the original `pending` and `action required` states can be combined with the `rejected` state as those states mean that the transaction was not accepted at the time of the submission. The clients can check the error message to see if the issuer needs more time or what actions to take in order to make the transaction in compliance.

### Notes
There are a few questions in the discussion section which will impact the design of the approval server. Any feedback will be welcome!