### PR TITLE
SEP-0010: Clarify the first manage data operation is the operation containing the client account, home domain, etc

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -23,8 +23,8 @@ The authentication flow is as follows:
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
 1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
 1. The client verifies that the transaction is signed by the `SIGNING_KEY` specified by the requested service's [SEP-1 stellar.toml](sep-0001.md).
-1. The client verifies that the transaction's first Manage Data operation has its source account set to the user's account and value set to a nonce value. The client ignores the home domain included.
-1. The client verifies that if the transaction has other Manage Data operations they all have their source accounts set to the the server's account.
+1. The client verifies that the transaction's first operation is a Manage Data operation that has its source account set to the user's account and value set to a nonce value. The client ignores the home domain included.
+1. The client verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the the server's account.
 1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
 1. The server checks that the user's account exists

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-10-07
-Version 2.1.0
+Updated: 2020-10-23
+Version 2.1.1
 ```
 
 ## Simple Summary
@@ -23,7 +23,7 @@ The authentication flow is as follows:
 1. The client obtains a unique [`challenge`](#challenge), which is represented as specially formed Stellar transaction
 1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
 1. The client verifies that the transaction is signed by the `SIGNING_KEY` specified by the requested service's [SEP-1 stellar.toml](sep-0001.md).
-1. The client verifies that the transaction has a single Manage Data operation with its source account set to the user's account and value set to a nonce value. The client ignores the home domain included.
+1. The client verifies that the transaction's first Manage Data operation has its source account set to the user's account and value set to a nonce value. The client ignores the home domain included.
 1. The client verifies that if the transaction has other Manage Data operations they all have their source accounts set to the the server's account.
 1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint


### PR DESCRIPTION
### What
Clarify that the first manage data operation is the operation containing the client account, nonce, and home domain.

### Why
The first manage data operation has always been the first operation. This is stated explicitly further down in the SEP when the challenge transaction structure is described. All SDKs I have reviewed also follow this pattern. The abstract is somewhat ambiguous though because it states that there is a single manage data operation with those values without stating it is the first.

This change is in response to the discussion here:
https://github.com/stellar/stellar-protocol/pull/746#discussion_r509686786

### Note
This change is only improving the language and is not adding or changing the functionality of the SEP. This change is not urgent and may end up being merged before or after the v3 changes being proposed. If it is merged after the PR needs updating with an appropriate version and timestamp.

cc @nebolsin @JakeUrban @accordeiro 