### PR TITLE
SEP-0012: Make less about SEP-6

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,22 +6,23 @@ Title: Anchor/Client customer info transfer
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2020-04-06
-Version 1.1.1
+Updated: 2020-10-29
+Version 1.1.2
 ```
 
 ## Abstract
 
-This SEP defines a standard way for stellar wallets to upload KYC (or other) information to anchors that implement non-interactive SEP-6.
+This SEP defines a standard way for stellar wallets to upload KYC (or other) information to anchors and other services.
 
 This SEP was made with these goals in mind:
 
 * interoperability
-* Allow a user to enter their KYC information to their wallet once and use it across many anchors without re-entering information manually
+* Allow a user to enter their KYC information to their wallet once and use it across many services without re-entering information manually
 * handle the most common 80% of use cases
 * handle image and binary data
 * support the set of fields defined in [SEP-9](sep-0009.md)
 * support authentication via [SEP-10](sep-0010.md)
+* support the provision of data for [SEP-6](sep-0006.md), [SEP-24](sep-0024.md), [SEP-31](sep-0031.md), and others
 * give users control over their data by supporting complete data erasure
 
 To support this protocol an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.


### PR DESCRIPTION
### What
Remove mentions of SEP-6 from the summary and mention other SEPs that use SEP-12 instead of only SEP-6.

### Why
On a first read of it's easy for someone without context to think that SEP-12 is only intended for use with SEP-6, but it is intended to be used for any data collection that other SEPs might need to do with an authenticated user.