### PR TITLE
SEP-0032: Make explicit that a missing home domain fails reverse resolution

### DIFF
--- a/ecosystem/sep-0032.md
+++ b/ecosystem/sep-0032.md
@@ -6,8 +6,8 @@ Title: Asset Address
 Author: Leigh McCulloch (@leighmcculloch)
 Status: Draft
 Discussion: https://groups.google.com/d/topic/stellar-dev/rWThI_BIs0Y
-Created: 2020-06-11
-Version 0.1.0
+Created: 2020-10-29
+Version 0.1.1
 ```
 
 ## Summary

--- a/ecosystem/sep-0032.md
+++ b/ecosystem/sep-0032.md
@@ -118,6 +118,7 @@ domain given an asset-code and asset-issuer, and constructing ane asset address.
 The flow to reverse resolve an asset is as follows:
 - The client is in possession of an asset code and issuer `G...` address.
 - The client retrieves the home domain for the issuer address.
+- If the issuer address has no home domain reverse resolution fails.
 - The client constructs the asset address in the asset address format using the
   asset code and the home domain as the asset domain.
 - The client verifies that the resolution of an asset address once constructed


### PR DESCRIPTION
### What
Make it explicit that if a home domain is not set for an issuer account the reverse resolution fails.

### Why
This is implied but not explicit leaving an unanswered question to the reader about what a client should do if the client is using the reverse resolution for verification.

This was highlighted by @pitsevich. Thank you!