### PR TITLE
SEP-0032: Allow arbitrary extensions to asset addresses using colon delimiters

### DIFF
--- a/ecosystem/sep-0032.md
+++ b/ecosystem/sep-0032.md
@@ -67,18 +67,30 @@ The format is based on [SEP-11 Txrep]'s definition for rendering assets as
 a string with the parts separated by a colon:
 
 ```
-{asset-code}:{asset-domain}
+{asset-code}:{asset-domain}[:]
 ```
 
 Where:
 - `{asset-code}` is the 1-12 alphanumeric Stellar asset code.
 - `{asset-domain}` the domain name that is hosting a `stellar.toml` file that
   contains a [`CURRENCIES`] section for the asset, as defined by [SEP-1].
+- `[:]` optional, terminates the asset address allowing for extension
+  elements to be included in the asset address using the `:` delimiter, that
+  are ignored by asset address resolution and verification as defined in this
+  protocol, and may or may not be used by applications. (_Applications ignoring
+  extension elements should communicate to a user in some way that extension
+  elements are being ignored by truncating the asset address to the element they
+  are using, e.g. to the asset-domain, so it is clear that the application is
+  only using the reference to the asset code and issuer._)
 
-Example:
+Examples:
 
 ```
 USD:example.com
+```
+
+```
+USD:example.com:...
 ```
 
 ### Asset Address Resolution


### PR DESCRIPTION
### What
Experiment with what changes would be required to SEP-32 to allow asset addresses to be extended with namespaces that conceptually exist off-network within the asset.

### Why
@dandoney [shared](https://groups.google.com/g/stellar-dev/c/rWThI_BIs0Y/m/CrZY9gXBBgAJ) some insights into a more complex asset address scheme that they used and there could be value in allowing more complex asset addresses to exist and be parseable by other applications, encouraging interoperability, without specifying the namespaces and therefore without limiting what they could be.

### Why not
It could be argued that any application supporting an extension to the asset address format could do so on its own terms, and any application not supporting that custom extension could accept data entry of the standard asset address and that a user could know to enter only that portion of the address. It could be argued similarly that a developer connecting two systems where one uses the standard format and one extends the format could easily truncate the address when moving from one system to the next. In both of these situations the protocol doesn't need to do anything and therefore is simpler to implement for the many of applications.

### Draft
This is a draft to illustrate an idea, and isn't planned for merging yet.