### PR TITLE
SEP-0030: Change title to Account Recovery

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0030
-Title: Account Recovery: multi-party account recovery of Stellar accounts
+Title: Account Recovery: multi-party recovery of Stellar accounts
 Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -2,14 +2,14 @@
 
 ```
 SEP: 0030
-Title: Recoverysigner: multi-party key management of Stellar accounts
+Title: Account Recovery: multi-party account recovery of Stellar accounts
 Author: Leigh McCulloch <@leighmcculloch>, Lindsay Lin <@capybaraz>
 Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-10-09
-Version: 0.6.0
+Updated: 2020-11-02
+Version: 0.6.1
 ```
 
 ## Summary


### PR DESCRIPTION
### What
Change the title to `Account Recovery` and remove mention of key management in title.

### Why
The SEPs purpose is to provide a multi-party approach to recovering Stellar accounts, either accounts a user created or owns, or accounts that another user has created and shared with the user. It is not technically key management because it is an interoperability layer that sits in the middle of an approach to key management.

The title `Recoverysigner` has also not been very useful. It was added to the beginning of the title to provide a single word keyword that could be used to reference SEP-30, but it turns out the term is odd, and so isn't being used to reference SEP-30.