### PR TITLE
SEP-0030: Add clearer instruction that other authentication types are supported

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -147,11 +147,11 @@ prove they meet the high threshold on the account.
 - `External`: Defined by the implementer. Proves possession of an identity that
   is external to the Stellar network such as a phone number, email address, or
   any other electronic or physical identity. Any forms of identity may be
-  supported. Authentication may be immediate and synchronous, as would be the
-  case with phone, email, and many OpenID Connect providers. Authentication may
-  be delayed and asynchronous, as would be the case with verifying a physical
-  address, national identity document, passport, or any other non-electronic
-  proof of identity.
+  supported. Authentication may be immediate and synchronous, as is the case with
+  electronic identities such as phone, email, and many OpenID Connect
+  providers. Authentication may be delayed and asynchronous, as might be the
+  case with physical identities such as verifying a physical address, national
+  identity document, passport, etc.
 
 ### Content Type
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-11-02
-Version: 0.6.1
+Updated: 2020-11-16
+Version: 0.6.2
 ```
 
 ## Summary

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -14,7 +14,7 @@ Version: 0.6.1
 
 ## Summary
 
-This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number or email with two or more servers implementing the protocol and add those servers as signers of the account. No individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
+This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number, email, or other form of authentication with two or more servers implementing the protocol and add those servers as signers of the account. No individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
 
 ## Motivation
 
@@ -54,7 +54,7 @@ The registration flow is as follows:
 A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. As an example, if a client is intending to use two servers that should individually have no control of the account but together are able to approve transactions, then the client can configure [account thresholds] to high 20, med 20, low 20, and assign weights 10 to both server signing keys.
 
 The signing flow is as follows:
-- The client uses the servers phone or email authentication provider to get a [JWT] proving possession of the phone number or email address.
+- The client uses the servers authentication provider to get a [JWT] proving possession of the phone number, email address, or other identity.
 - Alternatively, the client uses [SEP-10] to get a [JWT] proving high threshold control of another account that is listed as an alternative identity of the account to be accessed.
 - The client, authenticated as the external authentication method (e.g. phone, email, etc) or another account, requests the server to sign a transaction.
 - The server verifies that the [JWT] is valid according to the authentication provider's specification.
@@ -144,8 +144,14 @@ either. The two issuers are:
 - `SEP-10`: A [SEP-10] Web Auth server for proving high threshold control of an
 account. The [SEP-10] server should be configured to only issue [JWT]s if signers
 prove they meet the high threshold on the account.
-- `External`: Defined by the implementer. Proves control of a phone number,
-email address, or other identity.
+- `External`: Defined by the implementer. Proves possession of an identity that
+  is external to the Stellar network such as a phone number, email address, or
+  any other electronic or physical identity. Any forms of identity may be
+  supported. Authentication may be immediate and synchronous, as would be the
+  case with phone, email, and many OpenID Connect providers. Authentication may
+  be delayed and asynchronous, as would be the case with verifying a physical
+  address, national identity document, passport, or any other non-electronic
+  proof of identity.
 
 ### Content Type
 
@@ -199,8 +205,26 @@ Name | Type | Description
 `identities` | array | A list of identities that if any one is authenticated will be able to gain control of this account.
 `identities[].role` | string | The role of the identity. This value is not used by the server and is stored and echoed back in responses as a way for a client to know conceptually who each identity represents.
 `identities[].auth_methods` | array | A list of authentication methods that can be used to authenticate as this identity.
-`identities[].auth_methods[].type` | string | The type of identity: `stellar_address`, `phone_number`, `email`, or other.
-`identities[].auth_methods[].value` | string | The identity that if authenticated will be given full permissions of the account, either another stellar address, phone number or email address respectively given the type. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`identities[].auth_methods[].type` | string | The type of identity. See [Common Authentication Methods].
+`identities[].auth_methods[].value` | string | The identifier or value that uniquely identifies the identity that if authenticated will be given full permissions of the account. For example if the type of authentication is an email address, the value is the email address.
+
+##### Common Authentication Methods
+
+Implementaters define the external authentication methods supported by the
+implementation. If implementers support any of the following common
+authentication methods the type values below should be used along with the
+specifications for how to format the identifiers.
+
+Type | Description
+-----|------------
+`stellar_address` | A Stellar address in the strkey form `G...`, proven via [SEP-10].
+`phone_number` | A phone number. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
+`email` | An email address.
+`address` | A physical address.
+`passport` | A passport document number in the form `<issuer><number>` where issuer is the ISO 3166-1 alpha-3 of the issuing country and the number is the document number.
+`national_id` | A national identity document in the form `<issuer><number>` where issuer is the ISO 3166-1 alpha-3 of the issuing country and the number is the document number.
+`drivers_license` | TODO: Add details for how to encode an authority and license number, and sufficient details to verify.
+TODO: Are there other common forms of identity we should document standard formats for?
 
 ##### Example (With One Identity)
 
@@ -609,10 +633,10 @@ See [Common Fields].
 #### `GET /accounts`
 
 This endpoint will return a list of accounts that the [JWT] allows access to.
-This includes the account authenticated with a [SEP-10] [JWT], or any account that
-has the account authenticated as an alternative identity, or any account that
-has the phone number or email address as an alternative identity with a [JWT]
-from another authentication provider.
+This includes the account authenticated with a [SEP-10] [JWT], or any account
+that has the account authenticated as an alternative identity, or any account
+that has the phone number or email address or any other supported identity with
+a [JWT] from another authentication provider.
 
 ##### Authentication
 
@@ -741,6 +765,7 @@ Recoverysigner is implemented by the Stellar recoverysigner service, [recoverysi
 [`SEP-10`]: #authentication
 [`External`]: #authentication
 [Common Fields]: #common-fields
+[Common Authentication Methods]: #common-authentication-methods
 [Motivation]: #motivation
 [use case]: #use-cases
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -210,21 +210,17 @@ Name | Type | Description
 
 ##### Common Authentication Methods
 
-Implementaters define the external authentication methods supported by the
-implementation. If implementers support any of the following common
+Implementers define the external authentication methods supported by the
+implementation. If an implementation supports any of the following common
 authentication methods the type values below should be used along with the
-specifications for how to format the identifiers.
+specifications for how to format the identifiers to improve interopability
+between clients and servers that may have multiple integraters.
 
 Type | Description
 -----|------------
 `stellar_address` | A Stellar address in the strkey form `G...`, proven via [SEP-10].
 `phone_number` | A phone number. When encoding a phone number the ITU-T recommendations [E.123] and [E.164] should be followed. The phone number should be formatted in international notation with a leading `+` as demonstrated in E.123 Section 2.5 to ensure phone numbers are consistently encoded and are globally unique. Spaces should be omitted.
 `email` | An email address.
-`address` | A physical address.
-`passport` | A passport document number in the form `<issuer><number>` where issuer is the ISO 3166-1 alpha-3 of the issuing country and the number is the document number.
-`national_id` | A national identity document in the form `<issuer><number>` where issuer is the ISO 3166-1 alpha-3 of the issuing country and the number is the document number.
-`drivers_license` | TODO: Add details for how to encode an authority and license number, and sufficient details to verify.
-TODO: Are there other common forms of identity we should document standard formats for?
 
 ##### Example (With One Identity)
 


### PR DESCRIPTION
### What
Add clearer instruction that other authentication types are supported and recommended formats for their use.

### Why
SEP-30 has always stated that implementers may choose any authentication methods, and there are no limitations within SEP-30 that require an authentication method to be synchronous and immediate. However this has not been clear as the SEP only discusses phone and email authentication in any real detail.

This change does not yet improve interoperability when other authentication methods are used because the formats for those authentication methods are not yet defined. I'll follow up with that in separate PRs.

Note: SEP-30 has other issues regarding interoperability in that external authentication is not defined in anyway within this SEP, however this change does not address that and that issue remains to be address by https://github.com/stellar/stellar-protocol/issues/573.