### PR TITLE
SEP-0010: Require the server hostname manage data operation (v4.0.0)

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -36,7 +36,7 @@ The authentication flow is as follows:
    1. Source account set to the user's account.
    1. Key set to `<home domain> auth` where the home domain is the home domain from the discovery flow.
    1. Value set to a nonce value.
-1. The client verifies that if the transaction has a Manage Data operation with key `server_domain` that has its:
+1. The client verifies that if the transaction has a Manage Data operation with key `server_domain` that it has:
    1. Source account set to the server's account.
    1. Key set to `server_domain`.
    1. Value set to the domain name of the SEP-10 server from which the client requested the challenge.

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-11-06
-Version 3.0.0
+Updated: 2020-11-09
+Version 3.1.0
 ```
 
 ## Simple Summary
@@ -115,7 +115,10 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
     * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
       * The value of key is the home domain the challenge is authenticating, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
-    * zero or more `manage_data(source: server_account, ...)` reserved for future use
+    * subsequent operations, order unimportant:
+      * `manage_data(source: server_account, key: 'server_domain', value: server_domain)`
+        * The value is the domain name of the SEP-10 server that issued the challenge transaction. It can be at most 64 characters.
+      * zero or more `manage_data(source: server_account, ...)` reserved for future use
   * signature by the service's stellar.toml `SIGNING_KEY`
 * `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing and is useful for identifying when a client or server have been configured incorrectly.
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -36,6 +36,10 @@ The authentication flow is as follows:
    1. Source account set to the user's account.
    1. Key set to `<home domain> auth` where the home domain is the home domain from the discovery flow.
    1. Value set to a nonce value.
+1. The client verifies that if the transaction has a Manage Data operation with key `server_domain` that has its:
+   1. Source account set to the server's account.
+   1. Key set to `server_domain`.
+   1. Value set to the domain name of the SEP-10 server from which the client requested the challenge.
 1. The client verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the the server's account.
 1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-11-09
-Version 3.1.0
+Updated: 2020-11-??
+Version 4.0.0
 ```
 
 ## Simple Summary
@@ -36,7 +36,7 @@ The authentication flow is as follows:
    1. Source account set to the user's account.
    1. Key set to `<home domain> auth` where the home domain is the home domain from the discovery flow.
    1. Value set to a nonce value.
-1. The client verifies that if the transaction has a Manage Data operation with key `server_domain` that it has:
+1. The client verifies that the transaction has a Manage Data operation with key `server_domain` and that it has:
    1. Source account set to the server's account.
    1. Key set to `server_domain`.
    1. Value set to the domain name of the SEP-10 server from which the client requested the challenge.


### PR DESCRIPTION
### What
Require the server domain be specified in challenge transactions.

### Why
I'm proposing we add the server domain in #767, and after sometime if all servers are providing this field it might be feasible to remove that feature from being optional in clients to verify.

### Why not
If all servers are including the server domain it is not likely to make any difference if we make this change or not since all clients that verify will verify if the field is present. Also, as I think about the trends we want to set with this SEP it's unclear to me if we should do two-step releases where we add a feature as optional and then make it required. We have the capability for many features to make them additive and reach approximately the same goals. This might be one of them. I'd like to hear other thoughts.

### Reviewing
This change includes changes from #767 which is intended to merge first. Look at the final commit on this PR to see the meaningful change: https://github.com/stellar/stellar-protocol/pull/768/commits/f9d51237cd19651f11d38fb3ede3e9969084fa1f

### Merging
There may be other changes we want to introduce into SEP-10 in a new major version. We maybe should consider merging this in conjunction with any other changes we're considering when the time comes.