### PR TITLE
SEP-0030: Be unopinionated about number of servers required by protocol

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -14,7 +14,7 @@ Version: 0.6.2
 
 ## Summary
 
-This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number, email, or other form of authentication with one or more servers implementing the protocol and add those servers as signers of the account. If two or more servers are used no individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
+This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number, email, or other form of authentication with one or more servers implementing the protocol and add those servers as signers of the account. If two or more servers are used with appropriate signer configuration no individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
 
 ## Motivation
 
@@ -51,11 +51,9 @@ The registration flow is as follows:
 - The server responds to the client with the signing public key.
 - The client adds the signing public key as a signer of the account with an appropriate weight.
 
-A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting.
+A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. For example, if a client intends to use two servers that should individually have no control of the account but together are able to approve transactions, then the client could configure [account thresholds] to high 2, med 2, low 2, and assign weights 1 to both server signing keys.
 
-As examples:
-- If a client intends to use two servers that should individually have no control of the account but together are able to approve transactions, then the client could configure [account thresholds] to high 2, med 2, low 2, and assign weights 1 to both server signing keys.
-- If a client intends to use only a single server, giving that server control of the account, then the client could configure [account thresholds] to high 1, med 1, low 1, and assign weight 1 to the server signing key.
+A client can register with a single server and give the servers signing key a weight that is appropriate for the use case the client and server are targeting. For example, if a client intends to use a single server and give that server control of the account, then the client could configure [account thresholds] to high 1, med 1, low 1, and assign weight 1 to the server signing key.
 
 The signing flow is as follows:
 - The client uses the servers authentication provider to get a [JWT] proving possession of the phone number, email address, or other identity.

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-11-16
-Version: 0.6.2
+Updated: 2020-11-17
+Version: 0.7.0
 ```
 
 ## Summary

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -14,7 +14,7 @@ Version: 0.6.1
 
 ## Summary
 
-This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number or email with two or more servers implementing the protocol and add those servers as signers of the account. No individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
+This protocol defines an API that enables an individual (e.g., a user or wallet) to regain access to a Stellar account that it owns after the individual has lost its private key without providing any third party control of the account. Using this protocol, the user or wallet will preregister the account and a phone number or email or other form of authentication with one or more servers implementing the protocol and add those servers as signers of the account. If two or more servers are used no individual server will have control of the account, but collectively, they may help the individual recover access to the account. The protocol also enables individuals to pass control of a Stellar account to another individual.
 
 ## Motivation
 
@@ -51,7 +51,11 @@ The registration flow is as follows:
 - The server responds to the client with the signing public key.
 - The client adds the signing public key as a signer of the account with an appropriate weight.
 
-A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting. As an example, if a client is intending to use two servers that should individually have no control of the account but together are able to approve transactions, then the client can configure [account thresholds] to high 20, med 20, low 20, and assign weights 10 to both server signing keys.
+A client can register with multiple servers and give each signing key a weight that is appropriate for the use case the client and servers are targeting.
+
+As examples:
+- If a client intends to use two servers that should individually have no control of the account but together are able to approve transactions, then the client could configure [account thresholds] to high 2, med 2, low 2, and assign weights 1 to both server signing keys.
+- If a client intends to use only a single server, giving that server control of the account, then the client could configure [account thresholds] to high 1, med 1, low 1, and assign weight 1 to the server signing key.
 
 The signing flow is as follows:
 - The client uses the servers phone or email authentication provider to get a [JWT] proving possession of the phone number or email address.


### PR DESCRIPTION
### What
Be unopinionated about number of servers required by protocol and do not exclude use of the protocol with a single server, but include note that the single server configuration means control of the account.

### Why
The protocol specifies an interface a client and server can use to facilitate account recovery through transaction signing and authentication with providers outside of the Stellar network. It supports a configuration where a client uses multiple servers so that no individual server has control of the account on its own, but that is one use case and the protocol can support being used with a client and server configuration where there is only one server. There is little reason to limit the SEP to only multiple servers as it is up to the client how many servers they integrate with and utilize and are valid use cases where a client may wish to use a single server.

cc @capybaraz