### PR TITLE
SEP-0030: Remove mention of async/sync authentication methods

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -8,8 +8,8 @@ Track: Standard
 Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
-Updated: 2020-11-16
-Version: 0.6.2
+Updated: 2020-11-17
+Version: 0.6.3
 ```
 
 ## Summary
@@ -145,13 +145,12 @@ either. The two issuers are:
 account. The [SEP-10] server should be configured to only issue [JWT]s if signers
 prove they meet the high threshold on the account.
 - `External`: Defined by the implementer. Proves possession of an identity that
-  is external to the Stellar network such as a phone number, email address, or
-  any other electronic or physical identity. Any forms of identity may be
-  supported. Authentication may be immediate and synchronous, as is the case with
-  electronic identities such as phone, email, and many OpenID Connect
-  providers. Authentication may be delayed and asynchronous, as might be the
-  case with physical identities such as verifying a physical address, national
-  identity document, passport, etc.
+  is external to the Stellar network and can be any electronic or physical
+  identity. Examples of authentication identities that could be used are
+  authentication of a phone number, email addres, or with an OpenID Connect
+  provider, or verifying a physical address, national identity document,
+  passport. Any forms of identity may be supported including those not formally
+  specified in this protocol.
 
 ### Content Type
 


### PR DESCRIPTION
### What
Remove mention of async/sync authentication methods and replace it with a more concise list of example authentication methods.

### Why
@JakeUrban pointed out in https://github.com/stellar/stellar-protocol/pull/765#pullrequestreview-531948828 that the section we have here that is being changed focuses on the authentication methods being synchronous or asynchronous and that is not particularly helpful to an integrator. The change in this change refocus the paragraph on what the external authentication can be which is more meaningful.