### PR TITLE
SEP-8: update status to Active

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -4,8 +4,9 @@
 SEP: 0008
 Title: Regulated Assets
 Author: Interstellar.com
-Status: Final
+Status: Active
 Created: 2018-08-22
+Updated: 2020-12-09
 Version 1.0.0
 ```
 


### PR DESCRIPTION
**What**

Update the status of SEP-8 from Final to Active.

**Why**

The current SEP-8 was introduced before CAP-18. The practice we advertise in SEP-8 can be improved with the new protocol support. There are active developments of transacting regulated assets in the ecosystem that surfaces the need to keep SEP-8 up-to-date.

The definitions of Active and Final have not historically been followed, so SEPs created a little while ago may have progressed quicker to Final than newer SEPs have. And It appears that SEP-8 was finalized sooner than it's supposed to be. At this point, due to the ongoing developments, deprecating this SEP and creating a new SEP to replace the current one can create unnecessary noises. As a result, we decided to switch the status of this SEP back to Active in order to prepare for the changes that are going to be added to bring this proposal up-to-date.