### PR TITLE
SEP-8: use CAP-18 instead of making issuers co-signer

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,54 +3,65 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com
+Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2020-12-09
-Version 1.0.0
+Updated: 2020-12-10
+Version 2.0.0
 ```
 
 ## Simple Summary
 
-Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
+Regulated Assets are assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
 
-**Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
+## Target Audience
+
+Asset issuers, issuance platforms, wallet developers, and exchanges.
 
 ## Motivation
 
-Stellar aims to be an ideal platform for issuing securities. As such, it must provide tools to comply with various regulatory requirements. Regulation often requires asset issuers to monitor and approve every transaction involving the issued asset and to enforce an assortment of constraints. This SEP provides support for these requirements.
+Stellar is an ideal platform for issuing securities. Regulation sometimes requires asset issuers to monitor and approve each transaction involving issued assets and to enforce constraints. This is possible on the Stellar network today, however there exists no standard interface between wallets and issuers to negotiate approval.
 
 ## Overview
 
-Implementing a Regulated Asset consists of these parts:
-- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- **Approval Server**: HTTP protocol for transaction signing.
-- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/>
-**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented.
+Implementing a regulated asset consists of these parts:
+- [Identification]: Regulated asset issuers set the [authorization flags] in the asset issuing account. Regulated asset issuers advertise the existence of an approval server and the approval criteria via their [SEP-1 stellar.toml] file.
+- [Transaction Composition]: Transactions consist of operations that authorize the holding account, transact the regulated asset, and deauthorize the holding account.
+- [Approval Server]: Endpoints defined in this SEP that a client uses to obtain a signature for a transaction that temporarily authorizes the client to operate with the asset.
 
 ## Regulated Assets Approval Flow
 
-1. User creates and signs a transaction.
+1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
+	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
+4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
-    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
-    3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
+    1. *Success?* Transaction has been approved and signed by the issuer.
+    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction.
+    3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).
     4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
-    5. *Rejected?* Wallet should display given error message to the user.
+    5. *Rejected?* Wallet should display the associated error message to the user.
 
-## Stellar.toml
-Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+## Identification
 
-### Fields:
+### Authorization Flags
+
+Control access to an asset is done in the asset issuer's account. Regulated asset issuers will have both `Authorization Required` and `Authorization Revocable` flags set in their account.
+
+### SEP-1 stellar.toml
+
+Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the `[[CURRENCIES]]` section as different assets can have different requirements.
+
+#### Fields:
+
+These fields are listed in the `[[CURRENCIES]]` section:
 
 - `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
 - `approval_server` is the url of an approval service that signs validated transactions.
 - `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
 
-### Example
+#### Example
 
 ```toml
 [[CURRENCIES]]
@@ -61,107 +72,213 @@ approval_server="https://goat.io/tx_approve"
 approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
 ```
 
+## Transaction Composition
+
+A transaction that an approval server will approve consists of operations that authorize the holding account, transact the regulated asset, and deauthorize the holding account. If a transactions is built this way, there will be no point where holding accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity.
+
+A sandwich transaction described above can be built by wallets preemptively or by approval servers in order to make it compliant when the [revised](#revised) status is applicable.
+
+Depending on whether issuers want to allow the holding accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+
+Here is an example of the transaction:
+
+```
+Operation 1: AllowTrust op where issuer fully authorizes account A, asset X
+Operation 2: AllowTrust op where issuer fully authorizes account B, asset X
+Operation 3: Payment from A to B
+Operation 4: AllowTrust op where issuer sets account B, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+Operation 5: AllowTrust op where issuer sets account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+```
+
 ## Approval Server
-The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
 
-### Possible results
-- Success: Transaction was found compliant and signed by service.
-- Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
-- Pending: The issuer will asynchronously validate the transaction and respond later.
-- Action Required: The user must complete an action in order to have the transaction approved.
-- Rejected: Transaction was rejected.
+Approval server receives a signed transaction and checks for compliance and signs it on success.
 
-### Request
+### Content Type
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed if possible.
+Approval server accepts requests in the following `Content-Type`s:
 
-### Responses
+- `application/x-www-form-urlencoded`
+- `application/json`
 
-HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
+Approval server responds with content type:
 
+- `application/json`
 
-#### Success Response
+### Endpoints
 
-A Successful response will have a `200` HTTP status code and `success` as the `status` value. This response means that the transaction was found compliant and signed.
+- [POST <approval_server>](#post-approval-server)
 
-Parameters:
+#### `POST <approval_server>`
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"success"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction will have both the original signature(s) from the request, as well as an additional issuer signature.
-message|string|A human readable string containing information to pass on to the user (optional).
+##### Request
 
-#### Revised Response
+This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 
-A Revised response will have a `200` HTTP status code and `revised` as the `status` value. It means that the transaction was revised to be made compliant. The user should examine and resign the transaction.
+Name | Type | Description
+-----|------|------------
+`tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
-Parameters:
+###### Example (JSON)
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"revised"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
-message|string|A human readable string explaining the modifications made to the transaction to make it compliant.
+```json
+{
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
 
-#### Pending Response
+###### Example (Form)
 
-A Pending response will have a `200` HTTP status code and `pending` as the `status` value. It means that the issuer needs to asynchronously validate the transaction. The user should resubmit the transaction after a given timeout.
+```
+tx=AAAAAHAHhQtYBh5F2zA6...
+```
 
-Parameters:
+##### Responses
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"pending"`
-timeout|integer|Number of milliseconds to wait before submitting the same transaction again.
-message|string|A human readable string containing information to pass on to the user (optional).
+All responses will contain a top level `status` parameter that indicates the type of the result.
 
-#### Action Required Response
+*Success*
 
-An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+This response means that the transaction was found compliant and signed without a revise.
+
+A `success` response will have a `200` HTTP status code and `success` as the `status` value.
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"action_required"`
-message|string|A human readable string containing information regarding the action required.
-action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"success"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as an additional signature from the issuer.
+`message` | string | A human readable string containing information to pass on to the user (optional).
 
-#### Rejected Response
+###### Example
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and could not be revised to be made compliant.
+```json
+{
+  "status": "success",
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
+
+*Revised*
+
+This response means that the transaction was revised to be made compliant.
+
+A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
+
+It is important for the user to examine the revised transaction before re-signing it. More specifically, the user should make sure that the revised transaction does not contain any additional operations whose source account matches the source account of the original operation(s).
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"rejected"`
-error|string|A human readable string explaining why the transaction is not compliant and could not be made compliant.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"revised"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
+`message` | string | A human readable string explaining the modifications made to the transaction to make it compliant.
+
+###### Example
+
+```json
+{
+  "status": "revised",
+  "tx": "AAAAAHAHhQtYBh5F2zA6...",
+  "message": "Authorization and deauthorization operations were added."
+}
+```
+
+*Pending*
+
+This response means that the issuer could not determine whether to approve the transaction at the time of receiving it. Wallet can re-submit the same transaction at a later point in time.
+
+A `pending` response will have a `200` HTTP status code and `pending` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"pending"`
+`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again (optional).
+`message` | string |A human readable string containing information to pass on to the user (optional).
+
+###### Example
+
+```json
+{
+  "status": "pending",
+  "message": "Futher verifications are required due to the amount of this transaction."
+}
+```
+
+*Action Required*
+
+This reponse means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+
+An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"action_required"`
+`message` | string | A human readable string containing information regarding the action required.
+`action_url` | string | A URL that allows the user to complete the actions required to have the transaction approved.
+
+###### Example
+
+```json
+{
+  "status": "action_required",
+  "message": "Please sign to the terms of service via the URL.",
+  "action_url": "https://..."
+}
+```
+
+*Rejected*
+
+This response means that the transaction is not compliant and could not be revised to be made compliant.
+
+A `rejected` response will have a `400` HTTP status code and `rejected` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"rejected"`
+`error` | string | A human readable string explaining why the transaction is not compliant and could not be made compliant.
+
+###### Example
+
+```json
+{
+  "status": "rejected",
+  "message": "The destination account is blocked."
+}
+```
 
 ### Best practices
 
-- If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
+- Using the `revised` status to compose a sandwich transaction is encouraged as it can take the burdens away from the wallets.
+- If a transaction was revised, always explain the changes that were made to a transaction through the `message` parameter.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
 - Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
-- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
-
-## Account Setup
-
-Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
-
-In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
 
 ## Discussion
 
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
-Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
 ### Why doesn’t the approval service submit transactions to the network?
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
+- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
+- Scaling concerns as having the approval server submit transactions would require more infrastructure.
 
+[Identification]: #identification
+[SEP-1 stellar.toml]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[authorization flags]: #authorization-flags
+[Transaction Composition]: #transaction-composition
+[CAP-18]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md
+[Approval Server]: #approval-server

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -40,7 +40,7 @@ Implementing a regulated asset consists of these parts:
     1. *Success?* Transaction has been approved and signed by the issuer.
     2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction.
     3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).
-    4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
+    4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action URL as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
     5. *Rejected?* Wallet should display the associated error message to the user.
 
 ## Identification
@@ -58,7 +58,7 @@ Issuers advertise the existence of an Approval Service through their [SEP-1 stel
 These fields are listed in the `[[CURRENCIES]]` section:
 
 - `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
-- `approval_server` is the url of an approval service that signs validated transactions.
+- `approval_server` is the URL of an approval service that signs validated transactions.
 - `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
 
 #### Example
@@ -92,7 +92,9 @@ Operation 5: AllowTrust op where issuer sets account A, asset X to AUTHORIZED_TO
 
 ## Approval Server
 
-Approval server receives a signed transaction and checks for compliance and signs it on success.
+Approval server has one endpoint that it uses to receives a signed transaction and checks for compliance and signs it on success.
+
+The specification of an approval server is defined as follows:
 
 ### Content Type
 
@@ -105,13 +107,9 @@ Approval server responds with content type:
 
 - `application/json`
 
-### Endpoints
+### POST \<approval_server\> Endpoint
 
-- [POST <approval_server>](#post-approval-server)
-
-#### `POST <approval_server>`
-
-##### Request
+#### Request
 
 This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 
@@ -133,11 +131,11 @@ Name | Type | Description
 tx=AAAAAHAHhQtYBh5F2zA6...
 ```
 
-##### Responses
+#### Responses
 
 All responses will contain a top level `status` parameter that indicates the type of the result.
 
-*Success*
+##### Success
 
 This response means that the transaction was found compliant and signed without a revise.
 
@@ -160,7 +158,7 @@ Name | Type | Description
 }
 ```
 
-*Revised*
+##### Revised
 
 This response means that the transaction was revised to be made compliant.
 
@@ -186,7 +184,7 @@ Name | Type | Description
 }
 ```
 
-*Pending*
+##### Pending
 
 This response means that the issuer could not determine whether to approve the transaction at the time of receiving it. Wallet can re-submit the same transaction at a later point in time.
 
@@ -205,11 +203,11 @@ Name | Type | Description
 ```json
 {
   "status": "pending",
-  "message": "Futher verifications are required due to the amount of this transaction."
+  "message": "Futher verifications are required due to..."
 }
 ```
 
-*Action Required*
+##### Action Required
 
 This reponse means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
 
@@ -228,12 +226,12 @@ Name | Type | Description
 ```json
 {
   "status": "action_required",
-  "message": "Please sign to the terms of service via the URL.",
+  "message": "Please sign the terms of service via the provided URL.",
   "action_url": "https://..."
 }
 ```
 
-*Rejected*
+##### Rejected
 
 This response means that the transaction is not compliant and could not be revised to be made compliant.
 
@@ -257,11 +255,11 @@ Name | Type | Description
 
 ### Best practices
 
-- Using the `revised` status to compose a sandwich transaction is encouraged as it can take the burdens away from the wallets.
+- Using the `revised` status to compose a sandwich transaction for authorization purpose is encouraged as it can take the burdens away from the wallets.
 - If a transaction was revised, always explain the changes that were made to a transaction through the `message` parameter.
-- Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
+- Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a messagerather than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
-- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
+- Issuers can enforce additional fees by adding additional operations.
 
 ## Discussion
 


### PR DESCRIPTION
**What**

This PR adds three non-breaking changes/improvement to SEP-8
1. replaces `Account Setup` with `Transaction Composition`
2. makes `timeout` field optional when responding the `pending` status.
3. adds a `application/json` in the request `Content Type`

The rest of the changes are minor and cosmetic. They either delete obsolete descriptions, make the current ones more clear, and introduce examples.

Note that most the changes in the PR are based on the feedback in [this](https://github.com/stellar/stellar-protocol/pull/750) PR.

**Why**

SEP-8 was introduced before CAP-18 was introduced. And we haven't updated SEP-8 since CAP-18 was implemented. 

The `Account Setup` section in the current SEP-8 has a few drawbacks as mentioned in [CAP-18](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0018.md#motivation).
```
1. The owner of an account cannot unilaterally utilize assets unrelated to the issuer without the signature of that issuer
2. If multiple issuers want to become signers on a single account, then many signatures are potentially required for simple operations
3. Issuers cannot easily rotate keys, because their keys are on every account holding their asset
```

We are seeing a few active developments on regulated assets in the ecosystem, and we want to make sure the associated SEP is up-to-date and is easy to use without introducing breaking changes. 