### PR TITLE
Replace ambiguous home domain parameter definition

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -113,7 +113,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
   * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give user time to sign transaction)
   * operations:
     * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
-      * The value of key is the home domain the client would like to authenticating with, followed by `auth`. It can be at most 64 characters.
+      * The value of key is the home domain the client is authenticating with, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
     * zero or more `manage_data(source: server_account, ...)` reserved for future use
   * signature by the service's stellar.toml `SIGNING_KEY`

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -113,7 +113,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
   * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give user time to sign transaction)
   * operations:
     * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
-      * The value of key is the home domain the challenge is authenticating, followed by `auth`. It can be at most 64 characters.
+      * The value of key is the home domain the challenge is authenticating with, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
     * zero or more `manage_data(source: server_account, ...)` reserved for future use
   * signature by the service's stellar.toml `SIGNING_KEY`

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-11-06
-Version 3.0.0
+Updated: 2020-12-14
+Version 3.0.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -95,7 +95,7 @@ Request Parameters:
 Name      | Type          | Description
 ----------|---------------|------------
 `account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
-`home_domain` | string | (optional) The home domain the client would like to authenticate. Servers that generate tokens for multiple home domains can use this parameter to identify which home domain the client hopes to authenticate. If not provided by the client, the server should assume a default for backwards compatibility with older clients.
+`home_domain` | string | (optional) The home domain as defined in the [Abstract](#abstract). Servers that generate tokens for multiple home domains can use this parameter to identify which home domain the client hopes to authenticate. If not provided by the client, the server should assume a default for backwards compatibility with older clients.
 
 Example:
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -113,7 +113,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
   * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give user time to sign transaction)
   * operations:
     * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
-      * The value of key is the home domain the challenge is authenticating with, followed by `auth`. It can be at most 64 characters.
+      * The value of key is the home domain the client would like to authenticating with, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
     * zero or more `manage_data(source: server_account, ...)` reserved for future use
   * signature by the service's stellar.toml `SIGNING_KEY`

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -95,7 +95,7 @@ Request Parameters:
 Name      | Type          | Description
 ----------|---------------|------------
 `account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
-`home_domain` | string | (optional) The home domain as defined in the [Abstract](#abstract). Servers that generate tokens for multiple home domains can use this parameter to identify which home domain the client hopes to authenticate. If not provided by the client, the server should assume a default for backwards compatibility with older clients.
+`home_domain` | string | (optional) The home domain the client would like to authenticate with. Servers that generate tokens for multiple home domains can use this parameter to identify which home domain the client hopes to authenticate. If not provided by the client, the server should assume a default for backwards compatibility with older clients.
 
 Example:
 


### PR DESCRIPTION
Changes the `home_domain` parameter in the SEP-10 `GET` endpoint to reference the definition of "the home domain" in the abstract.