### PR TITLE
SEP-6: Remove all interactive portions

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -14,7 +14,7 @@ Version 3.1.1
 
 This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.
 
-Please note that the interactive components of the SEP are deprecated in favor of [SEP-24](sep-0024.md). For non-interactive integrations, this SEP provides a normalized interface specification that allow wallets and other services to interact with anchors programmatically. 
+Please note that this SEP provides a normalized interface specification that allow wallets and other services to interact with anchors _programmatically_. [SEP-24](sep-0024.md) was created to support use cases where the anchor may want to interact with users _interactively_ using a popup opened within the wallet application.
 
 ## Abstract
 
@@ -55,10 +55,7 @@ The JWT should be included in all requests as request header:
 Authorization: Bearer <JWT>
 ```
 
-In the case of the [interactive webapp](#customer-information-needed-interactive), since the client cannot add the authorization header, The JWT should be passed as a jwt query parameter:
-```
-?jwt=<token>
-```
+The SDF highly recommends all endpoints other than `/info` (and optionally `/fee`) require authentication.
 
 ## Cross-Origin Headers
 
@@ -92,42 +89,26 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
    * If needed, perform [authentication](#authentication) via SEP-10 before hitting those endpoints
 * **Make a request to `/deposit` or `/withdraw`.**
     * As a conservative measure, pass in any optional fields (including amount) that the wallet has on-hand, such as `email_address` and `account`.
-    * In the `/withdraw` request, don't bother providing `dest` or `dest_extra` if the anchor uses an [interactive flow](#3-customer-information-needed-interactive). Otherwise have the user enter the crypto account or bank account where they'd like their withdrawal to end up, and provide that to the anchor via `dest` and `dest_extra`.
+    * In the `/withdraw` request, have the user enter the crypto account or bank account where they'd like their withdrawal to end up and provide that to the anchor via `dest` and `dest_extra`.
 * **For `/deposit`**
     * If the issuer's `/deposit` endpoint immediately returns success:
         * display the deposit info that came back from the endpoint to the user, including fee. You're done! The user will execute the deposit exernally using the instructions if they want to.
-    * If the issuer responds with an interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive). We expect this is the most common flow, and it should work smoothly.
-    * For now, do not handle the non-interactive or status responses to the `/deposit` request.
     * Handle the [special cases](#special-cases), they're relatively common.
 * **For `/withdraw`**
     * If the issuer's `/withdraw` endpoint immediately returns success:
         * Provide an interface to the user that allows them to view the withdrawal details including the computed fee. The user can confirm and then the wallet will initiate the withdrawal by sending the Stellar payment to the address provided by the issuer.
-    * If the anchor responds with an interactive flow, handle it as [described in detail](#3-customer-information-needed-interactive).
-    * For now, do not handle the non-interactive or status responses to the `/withdraw` request.
     * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so exchange rate fluctuations might require withdrawal values to slightly vary from the originally provided `amount`. Anchors are instructed to accept a variation of ±10% between the informed `amount` and the actual value sent to the anchor's Stellar account. The withdrawn amount will be adjusted accordingly.
 * **Transaction history**
     * It provides a better experience for users to show deposits or withdrawals they've completed in the past via the `/transactions` endpoint, but it's not strictly necessary.
 
 ### Basic Anchor Implementation
 
-* Provide a full-featured implementation of [`/info`](#info). Leave the `fields` object in the `withdraw` object empty if you accept all your necessary fields in your interactive flow.
+* Provide a full-featured implementation of [`/info`](#info).
 * Decide which endpoints, if any, need to be [authenticated](#authentication), and declare that properly in the `/info` endpoint.
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
-    * We recommend you use the [interactive flow](#3-customer-information-needed-interactive). It's flexible and simple to integrate.
-    * To start an interactive flow, provide the [Customer info needed response](#3-customer-information-needed-interactive).
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
-    * Also include the `id` field in the popup URL you provide to the wallet. This allows you to keep track of the transaction  when the user visits the URL.
-    * Make sure to pass along the `amount` to the popup URL, especially on the `/withdraw` flow.
-    * We recommend you use [SEP-10 authentication](#authentication) in the interactive flow and do not separately prompt for password to achieve a good user experience (although asking for MFA when confirming a transaction or requiring email confirmation is reasonable). Be sure to accept the [`jwt` parameter](#adding-parameters-to-the-url) so the user does not have to re-login. Support the `callback` parameter as well.
-    * Test your interactive flows on mobile. They should be easy to use on all devices: make them responsive, handle auto-fill well, and do smart keyboard management on mobile devices.
-* **Interactive deposit**
-    * Your interactive deposit popup will do everything needed to initiate the deposit without the user needing to interact with the wallet further. It should either directly initiate the deposit, or handle displaying information (such as reference number or bank account number) that the user will need to complete their deposit.
-* **Interactive withdrawal**
-    * Your withdrawal flow will have to pass control back to the user's wallet, so it can initiate the withdrawal with a Stellar payment to your withdrawal address. You'll need to communicate the withdrawal address, amount and status to the wallet using the [`callback` parameter](#adding-parameters-to-the-url), and also by making it available on your `/transaction` endpoint. See [details](#guidance-for-wallets-completing-an-interactive-withdrawal).
-    * If an `amount` parameter is provided to the interactive URL, make sure to use that value to pre-populate the amount on the interactive form, since this greatly improves the user experience.
-    * In order to fulfill a withdrawal, a wallet must make a payment to the Stellar address that the anchor provides. It is the anchor's job to watch for Stellar payments to the given address and make the external transaction as soon as they're detected. It is recommended for anchors to listen to at least `payment` and `path_payment` [operations](https://www.stellar.org/developers/horizon/reference/endpoints/payments-all.html), although supporting the remaining ones is important for covering all use cases. Most Stellar SDKs already support listening to all payment forms via streaming.
-    * Some wallets might exchange currencies only once they're ready to send the withdrawal payment, so there might be slight fluctuations of value between the informed withdrawal `amount` and the actual transferred amount. It is recommended for anchors to accept an amount fluctuation of up to ±10%, and  adjust the amount to be transferred (and fees) to reflect the actual value received.
+    * We recommend you use [SEP-10 authentication](#authentication) for all endpoints.
 * **Providing transaction status**
     * Provide the `/transaction` endpoint. The wallet may rely on it to complete interactive withdrawals.
     * Provide the `/transactions` endpoint. Users like to see transaction histories.
@@ -136,10 +117,9 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 
 A deposit is when a user sends an external token (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by an anchor. In turn, the anchor sends an equal amount of tokens on the Stellar network (minus fees) to the user's Stellar account.
 
-The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information (if desired) that the user must submit interactively via a popup browser window or via [SEP-12](sep-0012.md) to be able to deposit.
+The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to deposit.
 
 If the given account does not exist, or if the account doesn't have a trust line for that specific asset, see the [Special Cases](#special-cases) section below.
-
 
 ### Request
 
@@ -252,7 +232,7 @@ The deposit flow can only be fulfilled if the Stellar `Account` has established 
 
 This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
 
-The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify additional information (if desired) that the user must submit interactively via a popup browser window or via [SEP-12](sep-0012.md) to be able to withdraw.
+The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to withdraw.
 
 ### Request
 
@@ -265,8 +245,8 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
-`type` | string | (optional if interactive) Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values. Optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
-`dest` | string | (optional if interactive) The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address. Optional if the anchor will respond that [interactive customer information is needed](#3-customer-information-needed-interactive).
+`type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values.
+`dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
@@ -343,108 +323,6 @@ Example:
 }
 ```
 
-### 3. Customer information needed (interactive)
-
-Response code: `403 Forbidden`
-
-An anchor that requires the user to fill out information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or when the anchor needs the user to perform a custom step for each transaction like entering an SMS code to confirm a withdrawal or selecting a bank account. A wallet that receives this response should open a popup browser window to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
-
-As the user is interacting with the anchor popup, they will make progress on their deposit or withdrawal and cause updates to the transaction status. The wallet must either listen for a callback or poll the [`/transaction`](#single-historical-transaction) endpoint for updates about the transaction from the anchor. This allows the wallet to show the user status information and confirm if the deposit attempt initiated successfully or failed. For withdrawals, the wallet must get information on where to send the withdrawal payment to the anchor.
-
-The response body must be a JSON object with the following fields:
-
-Name | Type | Description
------|------|------------
-`type` | string | Always set to `interactive_customer_info_needed`.
-`url` | string | URL hosted by the anchor. The wallet should show this URL to the user either as a popup or an iframe.
-`id` | string | (optional) The anchor's internal ID for this deposit / withdrawal request. Can be passed to the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
-
-Example response:
-
-```json
-{
-  "type": "interactive_customer_info_needed",
-  "url" : "https://api.example.com/kycflow?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI",
-  "id": "82fhs729f63dh0v4"
-}
-```
-
-#### Adding parameters to the URL
-
-Before the wallet sends the user to the `url` field received from the anchor, it may add query parameters to the URL.
-
-The possible parameters are summarized in the table below.
-
-Name | Type | Description
------|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`.
-`jwt` | string | (optional) JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow.
-
-**`callback` details**
-
-If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. If `callback=postMessage` is passed, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
-
-In either case, the JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
-
-```javascript
-// Example postMessage callback at the end of an interactive withdraw, indicating that the anchor is waiting for the wallet to send a payment in the amount of 80 of the asset in question. 
-const target = window.opener || window.parent;
-target.postMessage({
- transaction: {
-   id: "anchors_identifier_for_this_transaction",
-   status: "pending_user_transfer_start",
-   withdraw_anchor_account: "ANCHORS_STELLAR_ACCOUNT_ID",
-   withdraw_memo: "MEMO_ANCHOR_EXPECTS_TO_SEE",
-   withdraw_memo_type: "text|hash|id",
-   amount_in: "80"
-   // ... Any other values from the /transaction endpoint may be passed as well
- }
-}, "*");
-```
-
-As an alternative to using the `callback` parameter, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
-
-**`jwt` details**
-
-If the anchor's deposit or withdrawal endpoints require [SEP-10](sep-0010.md) authentication, the wallet should include this extra parameter. It allows the anchor to continue the interactive flow without requiring the user to authenticate again. When the user visits the anchor's interactive flow URL and provides a `jwt`, the anchor must verify the JWT.
-
-* **If the JWT is valid**: The anchor must honor the user's authenticated session. The anchor should respond with a `302 redirect` response that sets a cookie authenticating the user and redirects the user to a different URL that does not contain the `jwt` parameter. This is to avoid the JWT appearing in the user's browser history. After the redirect, the authenticated interactive flow must continue as usual.
-* **If the JWT is missing or invalid**: The anchor may display a login or signup form allowing the user to authenticate manually. On success, the anchor may allow the deposit / withdrawal to proceed normally.
-
-#### Guidance for wallets: completing an interactive withdrawal
-
-In the case of an interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
-
-To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `interactive_customer_info_needed` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
-
-In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
-
-When a successful response comes back (either from polling or via callback), the response will contain the transaction fields described in the [/transactions](#transaction-history) endpoint.
-
-The wallet must use the response fields in the following way to complete the withdrawal:
-
-- `status`: `pending_user_transfer_start` means the user has given all necessary info to the anchor, and the ball is back in  the wallet's court.
-- `withdraw_anchor_account`: send the withdrawal payment to this Stellar account. 
-- `withdraw_memo`: (if specified) use this memo in the payment transaction to the anchor.
-- `withdraw_memo_type`: use this as the memo type.
-- `amount_in`: the amount expected in the Stellar payment.
-
- The next step is for the wallet to display a confirmation screen summarizing the withdrawal to the user, and then send a Stellar payment to `withdraw_anchor_account`. The wallet should show the following info to the user:
- 
-- `to`: show the user what external account they will be withdrawing to.
-- `external_extra_text`: show the bank name or store name that the user will be withdrawing their funds to.
-- `more_info_url`: tell the user they can visit this URL for more info about their transaction as it processes.
-
-The anchor may chose to replace most of the digits in the `to` account number with `*`s to keep it confidential.
-
-#### Guidance for wallets: completing an interactive deposit
-
-When a user initiates a deposit, the wallet must kick off a background process to handle the case where the account [has no trustline](#stellar-account-doesnt-trust-asset).
-
-After that, the wallet displays the anchor's interactive URL in a popup, and everything else the user needs to do to complete that deposit either happens in the popup, or externally (for example by initiating a SEPA transfer). The wallet must track the status of the deposit in the same fashion as described in the withdrawal guidance section, and may show that information to the user.
-
-If the wallet displays information to the user, it can display any of the fields that may be useful to the user, such as `more_info_url`, `status`, and `amount_in`.
-
 ### 4. Customer Information Status
 
 Response code: `403 Forbidden`
@@ -458,7 +336,7 @@ Name | Type | Description
 `more_info_url` | string | (optional) A URL the user can visit if they want more information about their account / status.
 `eta` | int | (optional) Estimated number of seconds until the customer information status will update.
 
-If the anchor decides that more customer information is needed after receiving some information and processing it, it can respond again with a response of type `interactive_customer_info_needed` or `non_interactive_customer_info_needed`. In the case of a `denied` request, an anchor can use the `more_info_url` to explain to the user the issue with their request and give them a way to rectify it manually. A wallet should show the `more_info_url` to the user when explaining that the request was denied.
+If the anchor decides that more customer information is needed after receiving some information and processing it, it can respond again with a response of type `non_interactive_customer_info_needed`. In the case of a `denied` request, an anchor can use the `more_info_url` to explain to the user the issue with their request and give them a way to rectify it manually. A wallet should show the `more_info_url` to the user when explaining that the request was denied.
 
 Note: this status response should never be used in the case that the user's KYC request succeeds. In that case, the anchor should respond with a deposit / withdrawal address as described by those endpoints.
 
@@ -471,6 +349,38 @@ Example:
   "more_info_url": "https://api.example.com/kycstatus?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI"
 }
 ```
+
+### Guidance for wallets: completing a transaction
+
+#### Transaction Polling
+
+Once the deposit or withdraw request has been made and KYC information has been passed to the anchor via [SEP-12](sep-0012.md), the wallet will need to detect that the anchor has completed the flow by sending funds to the user. The wallet needs to poll the [Transaction History](#transaction-history) endpoint response from the anchor and match the transaction objects returned using the `memo` and `memo_type` parameters used in the deposit or withdraw success response.
+
+If transaction response object has a JSON `status` field set to `incomplete`, it means the user still needs to be KYC'ed using [SEP-12](sep-0012.md). In this case, the wallet should collect the fields requested in the `non_interactive_customer_info_needed` response and send them back to the anchor.
+
+The wallet must use the response fields in the following way to complete the withdrawal:
+
+- `status`: `pending_user_transfer_start` means the user has given all necessary info to the anchor, and the ball is back in the wallet's court.
+- `withdraw_anchor_account`: send the withdrawal payment to this Stellar account. 
+- `withdraw_memo`: (if specified) use this memo in the payment transaction to the anchor.
+- `withdraw_memo_type`: use this as the memo type.
+- `amount_in`: the amount expected in the Stellar payment.
+
+ The next step is for the wallet to display a confirmation screen summarizing the withdrawal to the user, and then send a Stellar payment to `withdraw_anchor_account`. The wallet should show the following info to the user:
+ 
+- `to`: show the user what external account they will be withdrawing to.
+- `external_extra_text`: show the bank name or store name that the user will be withdrawing their funds to.
+- `more_info_url`: tell the user they can visit this URL for more info about their transaction as it processes.
+
+The anchor may chose to replace most of the digits in the `to` account number with `*`s to keep it confidential.
+
+#### Completing a deposit
+
+When a user initiates a deposit, the wallet must kick off a background process to handle the case where the account [has no trustline](#stellar-account-doesnt-trust-asset).
+
+After that, the wallet displays everything the user needs to do to complete that deposit in-app or externally (for example by initiating a SEPA transfer). The wallet must track the status of the deposit in the fashion as described in the above section, and may show that information to the user.
+
+If the wallet displays information to the user, it can display any of the fields that may be useful to the user, such as `more_info_url`, `status`, and `amount_in`.
 
 ### 5. Authentication required
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -55,7 +55,7 @@ The JWT should be included in all requests as request header:
 Authorization: Bearer <JWT>
 ```
 
-The SDF highly recommends all endpoints other than `/info` (and optionally `/fee`) require authentication.
+It is highly recommended to require authentication for all endpoints other than `/info` (and optionally `/fee`).
 
 ## Cross-Origin Headers
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -14,7 +14,7 @@ Version 3.1.1
 
 This SEP defines the standard way for anchors and wallets to interact on behalf of users. This improves user experience by allowing wallets and other clients to interact with anchors directly without the user needing to leave the wallet to go to the anchor's site.
 
-Please note that this SEP provides a normalized interface specification that allow wallets and other services to interact with anchors _programmatically_. [SEP-24](sep-0024.md) was created to support use cases where the anchor may want to interact with users _interactively_ using a popup opened within the wallet application.
+Please note that this SEP provides a normalized interface specification that allows wallets and other services to interact with anchors _programmatically_. [SEP-24](sep-0024.md) was created to support use cases where the anchor may want to interact with users _interactively_ using a popup opened within the wallet application.
 
 ## Abstract
 
@@ -108,7 +108,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
-    * We recommend you use [SEP-10 authentication](#authentication) for all endpoints other than `/info`. Anchors may also want to allow clients to access the `/fee` endpoint as well.
+    * We recommend you use [SEP-10 authentication](#authentication) for all endpoints other than `/info`. Anchors may want to allow clients to access the `/fee` endpoint as well.
 * **Providing transaction status**
     * Provide the `/transaction` endpoint. The wallet may rely on it to complete interactive withdrawals.
     * Provide the `/transactions` endpoint. Users like to see transaction histories.
@@ -117,7 +117,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 
 A deposit is when a user sends an external token (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by an anchor. In turn, the anchor sends an equal amount of tokens on the Stellar network (minus fees) to the user's Stellar account.
 
-The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to deposit.
+The `/deposit` endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to deposit.
 
 If the given account does not exist, or if the account doesn't have a trust line for that specific asset, see the [Special Cases](#special-cases) section below.
 
@@ -232,7 +232,7 @@ The deposit flow can only be fulfilled if the Stellar `Account` has established 
 
 This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
 
-The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to withdraw.
+The `/withdraw` endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to withdraw.
 
 ### Request
 
@@ -751,4 +751,3 @@ For example:
 ## Implementations
 
 * iOS and macOS SDK: https://github.com/Soneso/stellar-ios-mac-sdk/blob/master/README.md#6-anchor-client-interoperability
-

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -108,7 +108,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 * Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
-    * We recommend you use [SEP-10 authentication](#authentication) for all endpoints.
+    * We recommend you use [SEP-10 authentication](#authentication) for all endpoints other than `/info`. Anchors may also want to allow clients to access the `/fee` endpoint as well.
 * **Providing transaction status**
     * Provide the `/transaction` endpoint. The wallet may rely on it to complete interactive withdrawals.
     * Provide the `/transactions` endpoint. Users like to see transaction histories.
@@ -323,7 +323,7 @@ Example:
 }
 ```
 
-### 4. Customer Information Status
+### 3. Customer Information Status
 
 Response code: `403 Forbidden`
 


### PR DESCRIPTION
resolves #785 

# Issue Description

SEP-6 was originally created to support both interactive and non-interactive flows for deposits and withdrawals. SEP-24 was then created and offered an interactive-only protocol, and the interactive portions in SEP-6 were deprecated.

At this point, there is no reason to keep the interactive portions in SEP-6 at all. Removing these sections will make the protocol more focused and reduce potential for confusion.

## Notes

No functional changes to the protocol were made, but I did rewrite the `Transaction Polling` section which originally asked clients to use transaction IDs in order to fetch a transaction's current status. The problem with this suggestion was that IDs are not return for non-interactive responses. Hence the only way to match a transaction is to use the memo's specified in the success responses.

This is the first of a series of PR's I'm planning to make on SEP-6. The next one up will make an additive change enabling SEP-6 to take advantages of the SEP-12 upgrade Michael and I worked on for SEP-31.