### PR TITLE
SEP-24: Update request/response encoding policy to match SEP-30 and others

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Interactive Anchor/Wallet Asset Transfer Server
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2020-10-06
-Version 1.1.0
+Updated: 2020-12-15
+Version 1.1.1
 ```
 
 ## Simple Summary
@@ -71,8 +71,11 @@ This protocol involves the transfer of value, and so HTTPS is required for all e
 
 All endpoints accept in requests the following `Content-Type`s:
 
+- `multipart/form-data`
 - `application/x-www-form-urlencoded`
 - `application/json`
+
+`multipart/form-data` is only necessary when including binary data type values from [SEP-9](sep-0009.md). Any of the above encoding schemes may be used when requests do not include binary data.
 
 All endpoints respond with content type:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -67,6 +67,17 @@ In order for browsers-based wallets to validate the CORS headers, as [specified 
 
 This protocol involves the transfer of value, and so HTTPS is required for all endpoints for security.  Wallets and anchors should refuse to interact with any insecure HTTP endpoints.
 
+## Content Type
+
+All endpoints accept in requests the following `Content-Type`s:
+
+- `application/x-www-form-urlencoded`
+- `application/json`
+
+All endpoints respond with content type:
+
+- `application/json`
+
 ## Recommendations
 
 SEP-24 lays out many options for how deposit and withdrawal can work. These are recommendations for getting a wallet or anchor implementation working with minimal effort while providing a great user experience.
@@ -132,7 +143,6 @@ If the given account does not exist, or if the account doesn't have a trust line
 
 ```
 POST TRANSFER_SERVER_SEP0024/transactions/deposit/interactive
-Content-Type: multipart/form-data
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.
@@ -159,7 +169,7 @@ Example:
 
 ```
 POST /transactions/deposit/interactive
-Content-Type: multipart/form-data
+Content-Type: application/x-www-form-urlencoded
 
 asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```
@@ -200,7 +210,6 @@ The withdraw endpoint allows a wallet to get withdrawal information from an anch
 
 ```
 POST TRANSFER_SERVER_SEP0024/transactions/withdraw/interactive
-Content-Type: multipart/form-data
 ```
 
 The fields below should be placed in the request body using the `multipart/form-data` encoding.
@@ -225,7 +234,7 @@ Example:
 
 ```
 POST TRANSFER_SERVER_SEP0024/transactions/withdraw/interactive
-Content-Type: multipart/form-data
+Content-Type: application/x-www-form-urlencoded
 
 asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
 ```


### PR DESCRIPTION
resolves #558 

Updates the SEP-24 encoding policy to match SEP-30 and other more recent SEPs.

This same change in spirit is being made to the following SEPs:
- SEP-12 (#789)
- SEP-31 (#790)

SEP-6 doesn't need to specify an encoding policy because all requests are `GET` requests.

An exception to this emerging standard is SEP-12, which supports sending file data, and `multipart/form-data` is a common encoding used for file uploads. SEP-6 and SEP-31 will be updated to use the same encodings as SEP-24 and SEP-30, while SEP-12 requests will continue using `multipart/form-data`.