### PR TITLE
SEP-12: Added Content-Type policy section

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -64,6 +64,7 @@ All endpoints respond with content type:
 
 - `application/json`
 
+
 ## Customer GET
 
 This endpoint allows clients to:
@@ -216,7 +217,39 @@ PUT [KYC_SERVER || TRANSFER_SERVER]/customer
 
 ### Request
 
-The fields below should be placed in the request body using the `multipart/form-data` encoding.
+```
+Content-Type: multipart/form-data;boundary="boundary"
+
+--boundary
+Content-Disposition: form-data; name="account"
+
+GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6
+--boundary
+Content-Disposition: form-data; name="memo"
+
+21bf91a4-7db1-401d-8108-fab7660a45d6 
+--boundary
+Content-Disposition: form-data; name="memo_type"
+
+text
+--boundary--
+```
+
+```
+Content-Type: application/x-www-form-urlencoded
+
+account=GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6&memo=21bf91a4-7db1-401d-8108-fab7660a45d6&memo_type=text
+```
+
+```
+Content-Type: application/json
+
+{
+   "account":"GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6",
+   "memo":"21bf91a4-7db1-401d-8108-fab7660a45d6",
+   "memo_type":"text"
+}
+```
 
 Name | Type | Description
 -----|------|------------

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -50,6 +50,20 @@ Alternatively, if the client cannot add the authorization header. The JWT should
 ?jwt=<token>
 ```
 
+## Content Type
+
+All endpoints accept in requests the following `Content-Type`s:
+
+- `multipart/form-data`
+- `application/x-www-form-urlencoded`
+- `application/json`
+
+All endpoints respond with content type:
+
+- `application/json`
+
+`multipart/form-data` should be used instead of `application/x-www-form-urlencoded` for requests transmitting binary data type values from [SEP-9](sep-0009.md).
+
 ## Customer GET
 
 This endpoint allows clients to:
@@ -198,7 +212,6 @@ Upload customer information to an anchor in an authenticated and idempotent fash
 
 ```
 PUT [KYC_SERVER || TRANSFER_SERVER]/customer
-Content-Type: multipart/form-data
 ```
 
 ### Request
@@ -256,7 +269,6 @@ Delete all personal information that the anchor has stored about a given custome
 
 ```
 DELETE [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
-Content-Type: multipart/form-data
 ```
 
 Name | Type | Description

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: Anchor/Client customer info transfer
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2020-10-29
-Version 1.1.2
+Updated: 2020-12-15
+Version 1.2.0
 ```
 
 ## Abstract

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -58,11 +58,11 @@ All endpoints accept in requests the following `Content-Type`s:
 - `application/x-www-form-urlencoded`
 - `application/json`
 
+`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). `multipart/form-data` or `application/x-www-form-urlencoded` may be used when no binary fields are included.
+
 All endpoints respond with content type:
 
 - `application/json`
-
-`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). `multipart/form-data` or `application/x-www-form-urlencoded` may be used when no binary fields are included.
 
 ## Customer GET
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -64,7 +64,6 @@ All endpoints respond with content type:
 
 - `application/json`
 
-
 ## Customer GET
 
 This endpoint allows clients to:

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -62,7 +62,7 @@ All endpoints respond with content type:
 
 - `application/json`
 
-`multipart/form-data` should be used instead of `application/x-www-form-urlencoded` for requests transmitting binary data type values from [SEP-9](sep-0009.md).
+`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). `multipart/form-data` or `application/x-www-form-urlencoded` may be used when no binary fields are included.
 
 ## Customer GET
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -58,7 +58,7 @@ All endpoints accept in requests the following `Content-Type`s:
 - `application/x-www-form-urlencoded`
 - `application/json`
 
-`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). `multipart/form-data` or `application/x-www-form-urlencoded` may be used when no binary fields are included.
+`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). Any of the above encoding schemes may be used when requests do not include binary data.
 
 All endpoints respond with content type:
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Direct Payments
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2020-12-15
-Version 1.1.0
+Updated: 2020-05-06
+Version 1.0.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Direct Payments
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2020-05-06
-Version 1.0.0
+Updated: 2020-12-15
+Version 1.1.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
relates to #788 

Adds a `Content-Type` section to outline what encodings are accepted for requests and responses. SEP-12 differs from most standards by supporting `multipart/form-data` since requests could contain file uploads.