### PR TITLE
Add semantic section to CAP Template

### DIFF
--- a/cap-template.md
+++ b/cap-template.md
@@ -80,6 +80,11 @@ on top of a different CAP).
 For large changes, it may be beneficial to link to actual XDR files copied
 in the relevant "contents" folder.
 
+### Semantics
+This section includes subsections, one for each logical change included in the XDR changes,
+that describes how each new or changed type functions and is used, and for new operations
+a step-by-step description of what happens when the operation is executed.
+
 ## Design Rationale
 The rationale fleshes out the specification by describing what motivated the design and why
 particular design decisions were made. It should describe alternate designs that were considered


### PR DESCRIPTION
### What
Add semantic section to CAP template within the specification section.

### Why
I've noticed that in many of the CAPs that are authored by @jonjove the CAP separates the XDR definitions from the semantics of how those new or changed XDR types function. This template was recently updated. It's not clear to me if the semantics section was intentionally left out with the intention to discuss the semantics within the XDR section, or if it was accidental. I suspect it was accidental because otherwise there would be little reason to have the XDR sub-section of specification.