### PR TITLE
CAP-0035: Move XDRs into a single section and move discussion to a semantics section

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -81,10 +81,6 @@ in the event of a fraudulent or mistaken transaction.
 
 ### XDR changes
 
-#### Account
-This proposal requires the addition of `CLAWBACK_ENABLED` to the issuing account 
-AccountFlags so the XDR becomes
- 
 ```c
 enum AccountFlags
 {
@@ -93,20 +89,7 @@ enum AccountFlags
     AUTH_REVOCABLE = 4,                                  
     CLAWBACK_ENABLED = 8                                  
 };
-```
- 
-In order to execute a clawback, the Issuer submits a `CLAWBACK` operation
-from the account containing the asset to be clawed back to the desired 
-destination. This operation does not require the affected account’s signature. 
-The transaction results in a change in balance to the recipient’s account. 
- 
-#### Clawback Operation
-Clawback operation pulls back the specified amount of a specific asset from 
-the designated account, effectively burning it.
 
-The following XDR changes are required:
-
-```c
 struct ClawbackOp 
 {
     union switch (AssetType type)
@@ -119,7 +102,7 @@ struct ClawbackOp
     } asset; // asset code to claw back. asset issuer is implied from source account.  
     MuxedAccount from;
     int64 amount;
-}
+};
  
 enum ClawbackResultCode
 {
@@ -159,7 +142,22 @@ struct Operation
  
     body;
 };
-``` 
+```
+
+### Semantics
+
+#### Account
+This proposal requires the addition of `CLAWBACK_ENABLED` to the issuing account 
+AccountFlags so the XDR becomes
+ 
+In order to execute a clawback, the Issuer submits a `CLAWBACK` operation
+from the account containing the asset to be clawed back to the desired 
+destination. This operation does not require the affected account’s signature. 
+The transaction results in a change in balance to the recipient’s account. 
+ 
+#### Clawback Operation
+Clawback operation pulls back the specified amount of a specific asset from 
+the designated account, effectively burning it.
  
 The account CLAWBACK_ENABLED flag allows the issuer to designate the asset as a
 non-bearer instrument asset. By including the CLAWBACK_ENABLED flag in Asset 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -148,7 +148,7 @@ struct Operation
 
 #### Account
 This proposal requires the addition of `CLAWBACK_ENABLED` to the issuing account 
-AccountFlags so the XDR becomes
+AccountFlags.
  
 In order to execute a clawback, the Issuer submits a `CLAWBACK` operation
 from the account containing the asset to be clawed back to the desired 


### PR DESCRIPTION
### What
Move XDRs into a single section and move discussion to a semantics section.

### Why
To adhere to the CAP template. No functional changes to the CAP.