### PR TITLE
CAP-0035: Address concerns raised by Jon and Nicolas on the mailing list

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -82,14 +82,6 @@ in the event of a fraudulent or mistaken transaction.
 ### XDR changes
 
 ```c
-enum AccountFlags
-{
-    AUTH_IMMUTABLE = 1,                                      
-    AUTH_REQUIRED = 2,                                  
-    AUTH_REVOCABLE = 4,                                  
-    AUTH_CLAWBACKABLE = 8
-};
-
 struct ClawbackOp 
 {
     union switch (AssetType type)
@@ -145,26 +137,22 @@ struct Operation
 ```
 
 ### Semantics
-In order to execute a clawback, an issuer account must be clawback enabled. Once
-enabled, the issuer submits a `ClawbackOp` operation from the account containing
-the asset to be clawed back to the desired destination. This operation does not
-require the affected account’s signature. The transaction results in a change in
-balance to the recipient’s account. 
- 
+Clawback operates similar to auth revocation in that it takes an amount of the
+asset out of active circulation by preventing the account from using it on the
+network. Auth revocation freezes the full balance of an asset in an account, but
+clawback provides fine grain control and allows the issuer to take out of the
+account and destroy a specific amount of the asset. 
+
+In order to execute a clawback, an issuer account must have its `AUTH_REVOCABLE`
+flag set. Once set, the issuer submits a `ClawbackOp` operation from the account
+containing the asset to be clawed back to the desired destination. This
+operation does not require the affected account’s signature. The transaction
+results in a change in balance to the recipient’s account. 
+
 #### Account
-This proposal requires the addition of `AUTH_CLAWBACKABLE` to the issuer account
-`AccountFlags`.
+This proposal uses the existing `AUTH_REVOCABLE` flag in the issuer account
+`AccountFlags`. Existing behavior and meaning of the flag is unchanged.
 
-The flag may be set or unset on any account as long as that account has not set
-the `AUTH_IMMUTABLE` flag.
-
-The flag does not require any other flags to be set on the account and other
-flags may be set without conflict. However, an issuer account will only be able
-to guarantee clawback if the issuer account also has the `AUTH_REQUIRED` and
-`AUTH_REVOCABLE` flags set. If these flags are not set the issuer account will
-only be able to clawback asset amounts that are not bound to selling
-liabilities.
- 
 #### Clawback Operation
 The `ClawbackOp` operation reduces the balance of the asset in the account by
 the specified amount of the specific `asset` from the `from` account,
@@ -189,7 +177,7 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
   `asset`.
-- `CLAWBACK_DISABLED` if the `CLAWBACK_ENABLED` flag is not set on the issuer
+- `CLAWBACK_DISABLED` if the `AUTH_REVOCABLE` flag is not set on the issuer
   account.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.
@@ -197,7 +185,7 @@ Possible return values for the `ClawbackOp` are:
 ## Design Rationale
 
 In the event of regulatory action, erroneous transaction, or loss of custody,
-the issuer may conduct a clawback transaction if the `AUTH_CLAWBACKABLE` flag is 
+the issuer may conduct a clawback transaction if the `AUTH_REVOCABLE` flag is 
 set. In the event of loss of custody, the affected party would need to 
 demonstrate they are the rightful owner of the account (usually through 
 reproofing KYC credentials or otherwise authenticating). On obtaining this 
@@ -208,11 +196,13 @@ in many cases should be reserved for licensed entities (like a transfer agent)
 holding the issuer credentials and aware of responsibilities under the law of 
 the jurisdiction of the affected party and asset. 
  
-The account `AUTH_CLAWBACKABLE` flag allows the issuer to designate the asset as a
-non-bearer instrument asset. By including the `AUTH_CLAWBACKABLE` flag in Asset
-flags, account owners may review the revocability of an asset and have the
-choice to avoid this type of asset if they object to the implied trust in the
-issuer.
+The account `AUTH_REVOCABLE` flag allows the issuer to indicate that it has
+control over the use of the asset on the network. By including the
+`AUTH_REVOCABLE` flag in account flags, account owners may review the
+revocability of an asset issued by the issuer and have the choice to avoid this
+type of asset if they object to the implied trust in the issuer. Clawback is
+another form of an issuer revoking use of an asset with fine control over the
+exact amount that the issuer is taking out of active circulation.
  
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -91,8 +91,8 @@ This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b
  };
  
  /* CreateAccount
-@@ -321,6 +322,30 @@ struct ClaimClaimableBalanceOp
-     ClaimableBalanceID balanceID;
+@@ -376,6 +377,30 @@ case REVOKE_SPONSORSHIP_SIGNER:
+     signer;
  };
  
 +/* Claws back an amount of an asset from an account
@@ -119,9 +119,9 @@ This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b
 +    int64 amount;
 +};
 +
- /* BeginSponsoringFutureReserves
- 
-     Establishes the is-sponsoring-future-reserves-for relationship between
+ /* An operation is the lowest unit of work that a transaction does */
+ struct Operation
+ {
 @@ -424,6 +449,8 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -219,6 +219,10 @@ added in a future proposal.
 
 The change does not have an affect on previous assets, accounts, or transaction 
 structure. It should not cause a breaking change in existing implementations. 
+
+The new operations introduced are all reversable meaning that their use if
+reversed has no impact on existing pre-signed or pre-authorized transactions
+involving the asset and the account that the clawback operates on.
  
 ### Resource Utilization
 TODO

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -101,7 +101,7 @@ enum ClawbackResultCode
     // codes considered as "failure" for the operation
     CLAWBACK_MALFORMED = -1,
     CLAWBACK_NO_TRUST = -2,
-    CLAWBACK_DISABLED = -3,
+    CLAWBACK_NOT_REVOCABLE = -3,
     CLAWBACK_UNDERFUNDED = -4
 };
 
@@ -177,7 +177,7 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
   `asset`.
-- `CLAWBACK_DISABLED` if the `AUTH_REVOCABLE` flag is not set on the issuer
+- `CLAWBACK_NOT_REVOCABLE` if the `AUTH_REVOCABLE` flag is not set on the issuer
   account.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -5,7 +5,6 @@
 ```text
 CAP: 0035
 Title: Asset Clawback
-Author: Dan Doney
 Working Group:
     Owner: Tomer Weller <@tomerweller>
     Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -213,8 +213,9 @@ Claimable balances are already not revokable, so it seems consistent to not add
 functionality that allows them to be clawed back. We could explore additional
 changes to make claimable balances always claimable by their issuer if the
 issuer has the `AUTH_REVOCABLE` flag set. This problem is not solved by this
-proposal, but it leaves space for it to be solved independently.
- 
+proposal, but introduces nothing that prevents that functionality from being
+added in a future proposal.
+
 ## Protocol Upgrade Transition
 
 ### Backwards Incompatibilities

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -204,7 +204,7 @@ balance is less than the amount specified when account for selling liabilities.
 If clawback is required of asset amounts locked up with selling liabilities then
 the issuer may use the `AllowTrustOp` operation to revoke authorization of the
 trustline, which will cancel any existing ledger entries creating selling
-liabilities, such as offers, and issue the `ClawbackOp` in the same operation.
+liabilities, such as offers, and issue the `ClawbackOp` in the same transaction.
 If the issuer wishes to allow the `from` account to continue utilizing the asset
 it can include another `AllowTrustOp` after the `ClawbackOp` to authorize the
 account once again.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -180,6 +180,10 @@ If the issuer wishes to allow the `from` account to continue utilizing the asset
 it can include another `AllowTrustOp` after the `ClawbackOp` to authorize the
 account once again.
 
+Similar to the limitations of the `AllowTrustOp`'s ability to revoke a trustline
+for an asset, the `ClawbackOp` can only affect a trustline held in an account,
+and not an asset held in a `BalanceEntry`.
+
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -72,9 +72,7 @@ Assets that are revocable can be easily distinguished from traditional
 blockchain assets (bearer instruments) so that asset owners are aware of rights.
 The transaction may result in revocation of some or all of the specified assets
 from the designated account based on the amount provided in the `ClawbackOp`
-operation. In a future proposal, we will outline an approach by which the same
-flag can be used to execute a ROLLBACK of a transaction (within a designated
-time window) in the event of a fraudulent or mistaken transaction.
+operation.
 
 ## Specification
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -52,7 +52,6 @@ custodial or omnibus account.
 Ex: https://www.ccn.com/190m-gone-how-canada-biggest-bitcoin-exchange-lost-it/
 
 ### Goals Alignment
-
 This CAP is aligned with the following Stellar Network Goals:
 
 - The Stellar Network should be secure and reliable.
@@ -62,7 +61,6 @@ exchange of assets, throughout the globe, enabling users to make payments betwee
 assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
-
 This proposal introduces a new `ClawbackOp` operation. The `AUTH_REVOCABLE`
 flag on the issuing account must be set to authorize a `ClawbackOp` operation
 submitted by the Issuing account.  The `ClawbackOp` operation results in the
@@ -172,6 +170,7 @@ operation.
 ```
 
 ### Semantics
+
 Clawback operates similar to auth revocation in that it takes an amount of the
 asset out of active circulation by preventing the account from using it on the
 network. Auth revocation freezes the full balance of an asset in an account, but
@@ -188,10 +187,12 @@ the same account or to another account if the intent of the clawback is to move
 the asset to another account.
 
 #### Account
+
 This proposal uses the existing `AUTH_REVOCABLE` flag in the issuer account
 `AccountFlags`. Existing behavior and meaning of the flag is unchanged.
 
 #### Clawback Operation
+
 The `ClawbackOp` operation reduces the balance of the asset in the account by
 the specified amount of the specific `asset` from the `from` account,
 effectively returning it to the issuer account, burning it.
@@ -238,6 +239,7 @@ holding the issuer credentials and aware of responsibilities under the law of
 the jurisdiction of the affected party and asset. 
  
 ### Reusing the AUTH_REVOCABLE flag
+
 The account `AUTH_REVOCABLE` flag allows the issuer to indicate that it has
 control over the use of the asset on the network. By including the
 `AUTH_REVOCABLE` flag in account flags, account owners may review the
@@ -247,11 +249,13 @@ another form of an issuer revoking use of an asset with fine control over the
 exact amount that the issuer is taking out of active circulation.
 
 ### Threshold
+
 The clawback operation requires a medium threshold signature because it is
 changing the balance of an account and is more aligned with impact to a payment
 operation than an allow trust operation.
 
 ### Claimable Balances
+
 Claimable balances are already not revokable, so it seems consistent to not add
 functionality that allows them to be clawed back. We could explore additional
 changes to make claimable balances always claimable by their issuer if the
@@ -271,6 +275,7 @@ reversed has no impact on existing pre-signed or pre-authorized transactions
 involving the asset and the account that the clawback operates on.
  
 ### Resource Utilization
+
 No substantial changes to resource utilization.
 
 ## Test Cases

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -63,18 +63,18 @@ assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
 
-This proposal adds a new flag to the Issuing account and introduces a new `CLAWBACK`
-operation. The `CLAWBACK_ENABLED` flag on the issuing account must be set to 
-authorize a `CLAWBACK` operation submitted by the Issuing account.  The `CLAWBACK` 
-operation results in the removal of the specified assets issued from the 
-designated account. The `CLAWBACK` operation only applies to assets issued by the 
-source account. Assets with clawback enabled can be easily distinguished from 
-traditional blockchain assets (bearer instruments) so that asset owners are aware 
-of rights. The transaction may result in revocation of some or all of the specified 
-assets from the designated account based on the amount provided in the `CLAWBACK` 
-operation. In a future proposal, we will outline an approach by which the same flag 
-can be used to execute a ROLLBACK of a transaction (within a designated time window) 
-in the event of a fraudulent or mistaken transaction.
+This proposal introduces a new `ClawbackOp` operation. The `AUTH_RECOVERABLE`
+flag on the issuing account must be set to authorize a `ClawbackOp` operation
+submitted by the Issuing account.  The `ClawbackOp` operation results in the
+removal of the specified assets issued from the designated account. The
+`ClawbackOp` operation only applies to assets issued by the source account.
+Assets that are revocable can be easily distinguished from traditional
+blockchain assets (bearer instruments) so that asset owners are aware of rights.
+The transaction may result in revocation of some or all of the specified assets
+from the designated account based on the amount provided in the `ClawbackOp`
+operation. In a future proposal, we will outline an approach by which the same
+flag can be used to execute a ROLLBACK of a transaction (within a designated
+time window) in the event of a fraudulent or mistaken transaction.
 
 ## Specification
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -78,59 +78,97 @@ operation.
 
 ### XDR changes
 
-```c
-struct ClawbackOp 
-{
-    union switch (AssetType type)
-    {
-    // ASSET_TYPE_NATIVE is not allowed
-    case ASSET_TYPE_CREDIT_ALPHANUM4:
-        AssetCode4 assetCode4;
-    case ASSET_TYPE_CREDIT_ALPHANUM12:
-        AssetCode12 assetCode12;
-    } asset; // asset code to claw back. asset issuer is implied from source account.  
-    MuxedAccount from;
-    int64 amount;
-};
-
-enum ClawbackResultCode
-{
-    // codes considered as "success" for the operation
-    CLAWBACK_SUCCESS = 0,
+```diff
+--- a/src/xdr/Stellar-transaction.x
++++ b/src/xdr/Stellar-transaction.x
+@@ -46,7 +46,8 @@ enum OperationType
+     CLAIM_CLAIMABLE_BALANCE = 15,
+     BEGIN_SPONSORING_FUTURE_RESERVES = 16,
+     END_SPONSORING_FUTURE_RESERVES = 17,
+-    REVOKE_SPONSORSHIP = 18
++    REVOKE_SPONSORSHIP = 18,
++    CLAWBACK = 19
+ };
  
-    // codes considered as "failure" for the operation
-    CLAWBACK_MALFORMED = -1,
-    CLAWBACK_NO_TRUST = -2,
-    CLAWBACK_NOT_REVOCABLE = -3,
-    CLAWBACK_UNDERFUNDED = -4
-};
-
-enum OperationType
-{
-    CREATE_ACCOUNT = 0,
-    ...
-    REVOKE_SPONSORSHIP = 18,
-    CLAWBACK = 19
-};
+ /* CreateAccount
+@@ -321,6 +322,30 @@ struct ClaimClaimableBalanceOp
+     ClaimableBalanceID balanceID;
+ };
  
-struct Operation
-{
++/* Claws back an amount of an asset from an account
++
++    Threshold: med
++
++    Result: ClawbackResult
++*/
++struct ClawbackOp
++{
++    union switch (AssetType type)
++    {
++    // ASSET_TYPE_NATIVE is not allowed
++    case ASSET_TYPE_CREDIT_ALPHANUM4:
++        AssetCode4 assetCode4;
++
++    case ASSET_TYPE_CREDIT_ALPHANUM12:
++        AssetCode12 assetCode12;
++
++        // add other asset types here in the future
++    }
++    asset;
++    MuxedAccount from;
++    int64 amount;
++};
++
+ /* BeginSponsoringFutureReserves
  
-    MuxedAccount* sourceAccount;
+     Establishes the is-sponsoring-future-reserves-for relationship between
+@@ -424,6 +449,8 @@ struct Operation
+         void;
+     case REVOKE_SPONSORSHIP:
+         RevokeSponsorshipOp revokeSponsorshipOp;
++    case CLAWBACK:
++        ClawbackOp clawbackOp;
+     }
+     body;
+ };
+@@ -1120,6 +1147,28 @@ default:
+     void;
+ };
  
-    union switch (OperationType type)
-    {
-    case CREATE_ACCOUNT:
-        CreateAccountOp createAccountOp;
-    ...
-    case REVOKE_SPONSORSHIP:
-        RevokeSponsorshipOp revokeSponsorshipOp;
-    case CLAWBACK:
-    	ClawbackOp clawbackOp;
-    }
- 
-    body;
-};
++/******* Clawback Result ********/
++
++enum ClawbackResultCode
++{
++    // codes considered as "success" for the operation
++    CLAWBACK_SUCCESS = 0,
++
++    // codes considered as "failure" for the operation
++    CLAWBACK_MALFORMED = -1,
++    CLAWBACK_NO_TRUST = -2,
++    CLAWBACK_NOT_REVOCABLE = -3,
++    CLAWBACK_UNDERFUNDED = -4
++};
++
++union ClawbackResult switch (ClawbackResultCode code)
++{
++case CLAWBACK_SUCCESS:
++    void;
++default:
++    void;
++};
++
+ /* High level Operation Result */
+ enum OperationResultCode
+ {
+@@ -1176,6 +1225,8 @@ case opINNER:
+         EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+     case REVOKE_SPONSORSHIP:
+         RevokeSponsorshipResult revokeSponsorshipResult;
++    case CLAWBACK:
++        ClawbackResult clawbackResult;
+     }
+     tr;
+ default:
 ```
 
 ### Semantics

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -144,10 +144,13 @@ clawback provides fine grain control and allows the issuer to take out of the
 account and destroy a specific amount of the asset. 
 
 In order to execute a clawback, an issuer account must have its `AUTH_REVOCABLE`
-flag set. Once set, the issuer submits a `ClawbackOp` operation from the account
-containing the asset to be clawed back to the desired destination. This
-operation does not require the affected account’s signature. The transaction
-results in a change in balance to the recipient’s account. 
+flag set. Once set, the issuer submits a `ClawbackOp` operation specifying the
+`from` account containing the asset to be clawed back. This operation does not
+require the affected account’s signature. The transaction results in a change in
+balance to the recipient’s account. The amount of the asset clawed back is
+burned and is not sent to any other address. The issuer may reissue the asset to
+the same account or to another account if the intent of the clawback is to move
+the asset to another account.
 
 #### Account
 This proposal uses the existing `AUTH_REVOCABLE` flag in the issuer account

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -196,6 +196,7 @@ in many cases should be reserved for licensed entities (like a transfer agent)
 holding the issuer credentials and aware of responsibilities under the law of 
 the jurisdiction of the affected party and asset. 
  
+### Reusing the AUTH_REVOCABLE flag
 The account `AUTH_REVOCABLE` flag allows the issuer to indicate that it has
 control over the use of the asset on the network. By including the
 `AUTH_REVOCABLE` flag in account flags, account owners may review the

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -8,7 +8,7 @@ Title: Asset Clawback
 Working Group:
     Owner: Tomer Weller <@tomerweller>
     Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>
-    Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Eric Saunders <@ire-and-curses>
+    Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Bartek Nowotarski <@bartekn>
 Status: Draft
 Created: 2020-12-14
 Discussion: https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/ZF6eJcqKAgAJ

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -253,7 +253,7 @@ exact amount that the issuer is taking out of active circulation.
 ### Threshold
 
 The clawback operation requires a medium threshold signature because it is
-changing the balance of an account and is more aligned with impact to a payment
+changing the balance of an account and is more aligned with impact of a payment
 operation than an allow trust operation.
 
 ### Claimable Balances

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -225,7 +225,7 @@ reversed has no impact on existing pre-signed or pre-authorized transactions
 involving the asset and the account that the clawback operates on.
  
 ### Resource Utilization
-TODO
+No substantial changes to resource utilization.
 
 ## Test Cases
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -87,7 +87,7 @@ enum AccountFlags
     AUTH_IMMUTABLE = 1,                                      
     AUTH_REQUIRED = 2,                                  
     AUTH_REVOCABLE = 4,                                  
-    CLAWBACK_ENABLED = 8                                  
+    AUTH_CLAWBACKABLE = 8
 };
 
 struct ClawbackOp 
@@ -103,19 +103,19 @@ struct ClawbackOp
     MuxedAccount from;
     int64 amount;
 };
- 
+
 enum ClawbackResultCode
 {
     // codes considered as "success" for the operation
-    CLAWBACK_SUCCESS = 0, // CLAWBACK successfully completed
+    CLAWBACK_SUCCESS = 0,
  
     // codes considered as "failure" for the operation
-    CLAWBACK_MALFORMED = -1, // asset code is malformed or amount is < 1
-    CLAWBACK_NO_TRUST = -2, // no trust line on source account
-    CLAWBACK_DISABLED = -3, // CLAWBACK_ENABLED flag is off on the issuer account 
-    CLAWBACK_UNDERFUNDED = -4, // trustline balance is less than amount to clawback 
+    CLAWBACK_MALFORMED = -1,
+    CLAWBACK_NO_TRUST = -2,
+    CLAWBACK_DISABLED = -3,
+    CLAWBACK_UNDERFUNDED = -4
 };
- 
+
 enum OperationType
 {
     CREATE_ACCOUNT = 0,
@@ -145,33 +145,55 @@ struct Operation
 ```
 
 ### Semantics
-
-#### Account
-This proposal requires the addition of `CLAWBACK_ENABLED` to the issuing account 
-AccountFlags.
+In order to execute a clawback, an issuer account must be clawback enabled. Once
+enabled, the issuer submits a `ClawbackOp` operation from the account containing
+the asset to be clawed back to the desired destination. This operation does not
+require the affected account’s signature. The transaction results in a change in
+balance to the recipient’s account. 
  
-In order to execute a clawback, the Issuer submits a `CLAWBACK` operation
-from the account containing the asset to be clawed back to the desired 
-destination. This operation does not require the affected account’s signature. 
-The transaction results in a change in balance to the recipient’s account. 
+#### Account
+This proposal requires the addition of `AUTH_CLAWBACKABLE` to the issuer account
+`AccountFlags`.
+
+The flag may be set or unset on any account as long as that account has not set
+the `AUTH_IMMUTABLE` flag.
+
+The flag does not require any other flags to be set on the account and other
+flags may be set without conflict. However, an issuer account will only be able
+to guarantee clawback if the issuer account also has the `AUTH_REQUIRED` and
+`AUTH_REVOCABLE` flags set. If these flags are not set the issuer account will
+only be able to clawback asset amounts that are not bound to selling
+liabilities.
  
 #### Clawback Operation
-Clawback operation pulls back the specified amount of a specific asset from 
-the designated account, effectively burning it.
- 
-The account CLAWBACK_ENABLED flag allows the issuer to designate the asset as a
-non-bearer instrument asset. By including the CLAWBACK_ENABLED flag in Asset 
-flags, account owners may review the revocability of an asset and have the
-choice to avoid this type of asset if they object to the implied trust in the 
-issuer.  
+The `ClawbackOp` operation reduces the balance of the asset in the account by
+the specified amount of the specific `asset` from the `from` account,
+effectively returning it to the issuer account, burning it.
 
-Clawback will cancel as many pending orders as necessary, in order of creation, 
-to ensure that account liabilities are maintained.
+Similar to other operations the clawback operation will fail if the account
+balance is less than the amount specified when account for selling liabilities.
+If clawback is required of asset amounts locked up with selling liabilities then
+the issuer may use the `AllowTrustOp` operation to revoke authorization of the
+trustline, which will cancel any existing ledger entries creating selling
+liabilities, such as offers, and issue the `ClawbackOp` in the same operation.
+If the issuer wishes to allow the `from` account to continue utilizing the asset
+it can include another `AllowTrustOp` after the `ClawbackOp` to authorize the
+account once again.
+
+Possible return values for the `ClawbackOp` are:
+- `CLAWBACK_SUCCESS` if the clawback is successful.
+- `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
+- `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
+  `asset`.
+- `CLAWBACK_DISABLED` if the `CLAWBACK_ENABLED` flag is not set on the issuer
+  account.
+- `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
+  available balance of `asset` after accounting for selling liabilities.
 
 ## Design Rationale
 
 In the event of regulatory action, erroneous transaction, or loss of custody,
-the issuer may conduct a clawback transaction if the `CLAWBACK_ENABLED` flag is 
+the issuer may conduct a clawback transaction if the `AUTH_CLAWBACKABLE` flag is 
 set. In the event of loss of custody, the affected party would need to 
 demonstrate they are the rightful owner of the account (usually through 
 reproofing KYC credentials or otherwise authenticating). On obtaining this 
@@ -181,6 +203,12 @@ Needless to say, executing a reallocation is a significant responsibility and
 in many cases should be reserved for licensed entities (like a transfer agent) 
 holding the issuer credentials and aware of responsibilities under the law of 
 the jurisdiction of the affected party and asset. 
+ 
+The account `AUTH_CLAWBACKABLE` flag allows the issuer to designate the asset as a
+non-bearer instrument asset. By including the `AUTH_CLAWBACKABLE` flag in Asset
+flags, account owners may review the revocability of an asset and have the
+choice to avoid this type of asset if they object to the implied trust in the
+issuer.
  
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -76,6 +76,8 @@ operation.
 
 ### XDR changes
 
+This patch of XDR changes is based on the XDR files in commit f60c329467f5f637b4137ca220fde4e609434f53 of [stellar-core].
+
 ```diff
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
@@ -285,3 +287,5 @@ None yet.
 ## Implementation
 
 None yet.
+
+[stellar-core]: https://github.com/stellar/stellar-core

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -1,4 +1,4 @@
-# CAP-0035:  Asset Clawback
+# CAP-0035: Asset Clawback
 
 ## Preamble
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -203,6 +203,13 @@ revocability of an asset issued by the issuer and have the choice to avoid this
 type of asset if they object to the implied trust in the issuer. Clawback is
 another form of an issuer revoking use of an asset with fine control over the
 exact amount that the issuer is taking out of active circulation.
+
+### Claimable Balances
+Claimable balances are already not revokable, so it seems consistent to not add
+functionality that allows them to be clawed back. We could explore additional
+changes to make claimable balances always claimable by their issuer if the
+issuer has the `AUTH_REVOCABLE` flag set. This problem is not solved by this
+proposal, but it leaves space for it to be solved independently.
  
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -63,7 +63,7 @@ assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
 
-This proposal introduces a new `ClawbackOp` operation. The `AUTH_RECOVERABLE`
+This proposal introduces a new `ClawbackOp` operation. The `AUTH_REVOCABLE`
 flag on the issuing account must be set to authorize a `ClawbackOp` operation
 submitted by the Issuing account.  The `ClawbackOp` operation results in the
 removal of the specified assets issued from the designated account. The

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -76,7 +76,7 @@ operation.
 
 ### XDR changes
 
-This patch of XDR changes is based on the XDR files in commit f60c329467f5f637b4137ca220fde4e609434f53 of [stellar-core].
+This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b4137ca220fde4e609434f53` of [stellar-core].
 
 ```diff
 --- a/src/xdr/Stellar-transaction.x

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -172,6 +172,9 @@ Similar to the limitations of the `AllowTrustOp`'s ability to revoke a trustline
 for an asset, the `ClawbackOp` can only affect a trustline held in an account,
 and not an asset held in a `BalanceEntry`.
 
+The clawback operation requires a medium threshold signature to authorize the
+operation.
+
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
@@ -204,6 +207,11 @@ revocability of an asset issued by the issuer and have the choice to avoid this
 type of asset if they object to the implied trust in the issuer. Clawback is
 another form of an issuer revoking use of an asset with fine control over the
 exact amount that the issuer is taking out of active circulation.
+
+### Threshold
+The clawback operation requires a medium threshold signature because it is
+changing the balance of an account and is more aligned with impact to a payment
+operation than an allow trust operation.
 
 ### Claimable Balances
 Claimable balances are already not revokable, so it seems consistent to not add


### PR DESCRIPTION
### What
Address concerns raised by Jon and Nicolas on the [mailing list](https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/ZF6eJcqKAgAJ?pli=1).

Specifically:
- Remove `AUTH_CLAWBACKWABLE` and use `AUTH_REVOCABLE`.
- Change what happens when the `CallbackOp` is used on an account that has selling liabilities such that it functions like other operations and fails.
- Include an example of how to use `AllowTrustOp` to temporarily revoke authorization of an account to free up selling liabilities.
- Include discussion highlighting how the limitations of clawback match the limitations of revoking authorization, and how they cannot affect claimable balances.
- Include discussion about backwards compatibility.
- Include discussion about thresholds.

### Why
Addressing feedback from the [discussion thread](https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/ZF6eJcqKAgAJ?pli=1) from @jonjove and @MonsieurNicolas and @dandoney. 

It was agreed in the discussion thread that revoking all offers is simpler and acceptable, and this can be achieved with existing logic assuming the issuer account can revoke authorization (has its `AUTH_REVOCABLE` flag set). This simplification also lends to us fitting this functionality into the existing `AUTH_REVOCABLE` feature set. Clawback is really a fine grain version of revocation which has more flexibility than the existing revocation functionality provides.

It seems difficult to disconnect this new flag from `AUTH_IMMUTABLE` because it is reasonable for an asset holder to assume any asset already issued with `AUTH_IMMUTABLE` cannot be clawed back. Even though we could argue clawback has nothing or little to do with authorization, it seems to be tied to it conceptually. For this reason the functionality lends itself to being considered a form of auth revocation.

Claimable balances are already not revokable, so it seems consistent to make them not clawbackable. The changes to the proposal include discussion about this. I've opened a separate proposal, CAP-36 (#797) to discuss an approach we could take similar to this proposal for claimable balances.