### PR TITLE
Clarify SEP-24 account funding policy (special case)

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -173,21 +173,21 @@ Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-a
 ##### Special Cases
 ###### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use `create_account` to create the account with at least enough XLM for the minimum reserve and a trust line (2.01 XLM is recommended). The anchor should take some of the asset that is sent in to pay for the XLM. The anchor should not list this minimal funding as a fee because the user still receives the value of the XLM in their account. The anchor should detect if the account has been created before returning deposit information, and adjust the `min_amount` in the response to be at least the amount needed to create the account.
+If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
-Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the remaining asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the remaining asset tokens to the account in Stellar to complete the deposit.
+Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account on Stellar to complete the deposit.
 
-If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error. The response body should be a JSON object containing an `error` field that explains why the request failed.
+If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the `transactions/deposit/interactive` response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
 ###### Stellar account doesn't trust asset
 
-The deposit flow can only be fulfilled if the Stellar `Account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `Account` has a trust line for the given asset. If it doesn't:
+The deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
 
-1. `Wallet` checks if `Account` has enough XLM to create a trust line. If it does, skip to step `4`.
-2. If `Account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough XLM for a trust line.
-3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `Account`.
-4. `Wallet` detects the arrival of XLM in the `Account`, and establishes a trust line.
-5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
+1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
+2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.
+3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `account`.
+4. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
+5. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
 6. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -177,7 +177,7 @@ If the given Stellar `account` does not exist on receipt of the deposit funds, t
 
 Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account on Stellar to complete the deposit.
 
-If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the `transactions/deposit/interactive` response. The response body should be a JSON object containing an `error` field that explains why the request failed.
+If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
 ###### Stellar account doesn't trust asset
 
@@ -185,10 +185,11 @@ The deposit flow can only be fulfilled if the Stellar `account` has established 
 
 1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
 2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.
-3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `account`.
-4. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
-5. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
-6. `Anchor` proceeds with the deposit flow.
+3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` may charge a service fee to cover the cost of the XLM, but this must be communicated to the user.
+4. `Anchor` then starts listening for trust line creations for that `account`.
+5. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
+6. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
+7. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw
 


### PR DESCRIPTION
resolves #771 

Currently, the anchor is instructed to not list the minimum funding amount (2.01XLM recommended) as a fee because the user still receives that amount in their account. While true, the user cannot transact that minimum funding amount, due to it being the _minimum amount the account needs to exist_.

Its also in the anchors best interest to sponsor account creations, so deducting the minimum funding amount from the deposit given to the anchor likely brings more complexity and UX dissatisfaction than its worth.