### PR TITLE
CAP-0035: Add note about how issuers can prevent creation of claimable balances

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -263,7 +263,10 @@ functionality that allows them to be clawed back. We could explore additional
 changes to make claimable balances always claimable by their issuer if the
 issuer has the `AUTH_REVOCABLE` flag set. This problem is not solved by this
 proposal, but introduces nothing that prevents that functionality from being
-added in a future proposal.
+added in a future proposal. Any issuer issuing assets under strict regulation
+where claimable balances that cannot be clawed back are desireable could use
+`AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, introduced in CAP-18, and SEP-8 to
+approve individual transactions and prevent the creation of a claimable balance.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
### What
Add note about how issuers can prevent creation of claimable balances.

### Why
@MonsieurNicolas identified [on the mailing list](https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/l2OTWiKSAQAJ) that `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` introduced in CAP-18 and SEP-8 could be used by a regulated asset issuer to restrict the creation of claimable balances.