### PR TITLE
SEP-0030: Remove urlencoded form data as an accepted content-type in requests

### DIFF
--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -9,7 +9,7 @@ Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
 Updated: 2020-11-17
-Version: 0.7.0
+Version: 0.8.0
 ```
 
 ## Summary
@@ -156,8 +156,7 @@ prove they meet the high threshold on the account.
 
 ### Content Type
 
-All endpoints accept in requests the following `Content-Type`s:
-- `application/x-www-form-urlencoded`
+All endpoints accept in requests the following `Content-Type`:
 - `application/json`
 
 All endpoints respond with content type:
@@ -225,8 +224,6 @@ Type | Description
 
 ##### Example (With One Identity)
 
-###### JSON
-
 ```json
 {
   "identities": [
@@ -242,15 +239,7 @@ Type | Description
 }
 ```
 
-###### Form
-
-```
-identities.0.role=owner&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001
-```
-
 ##### Example (With Multiple Roles)
-
-###### JSON
 
 ```json
 {
@@ -273,12 +262,6 @@ identities.0.role=owner&identities.0.auth_methods.account=GDUA...&identities.0.a
     },
   ]
 }
-```
-
-###### Form
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 #### Common Response Fields
@@ -349,7 +332,7 @@ declaring should be allowed to gain control of the account.
 
 See [Common Fields].
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
@@ -372,12 +355,6 @@ See [Common Fields].
     },
   ]
 }
-```
-
-###### Example (Form)
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -431,7 +408,7 @@ request does not include it, it is removed.
 
 See [Common Fields].
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
@@ -454,12 +431,6 @@ See [Common Fields].
     },
   ]
 }
-```
-
-###### Example (Form)
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -531,18 +502,12 @@ Name | Type | Description
 -----|------|------------
 `transaction` | string | A XDR base64 encoded Stellar transaction.
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
   "transaction": "AAAAAHAHhQtYBh5F2zA6...",
 }
-```
-
-###### Example (Form)
-
-```
-transaction=AAAAAHAHhQtYBh5F2zA6...
 ```
 
 ##### Response


### PR DESCRIPTION
### What
Remove urlencoded form data as a accepted content-type in requests.

### Why
@JakeUrban pointed out how there is really no consistent standard for encoding complex nested data in urlencoded form, which means that integrations are highly likely to use it, or to be buggy. We started using dual content types in requests in SEP-10 and we applied that broadly here but the difficulty to use is compelling that this isn't going to have a positive return on investment to maintain and isn't a pattern we should propogate to other SEPs either.

Related conversation in https://github.com/stellar/stellar-protocol/pull/790.

This change is breaking but the proposal is in draft and that is acceptable. It is also unlikely that there are implementations using form encoding given the difficult to provide that feature.

The recoverysigner reference implementation can be updated to remove the urlencoded form data decoding, but it doesn't have to be to continue to meet the standard. When we have time we can update it. I have created https://github.com/stellar/stellar-protocol/issues/801 to track that work.