### PR TITLE
SEP-9: Add bank branch field

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC / AML fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2020-04-03
-Version 1.2.0
+Updated: 2020-12-22
+Version 1.2.1
 ```
 
 ## Simple Summary
@@ -48,6 +48,7 @@ Name | Type | Description
 `birth_place` | date | Place of birth (city, state, country; as on passport)
 `birth_country_code` | country code | ISO Code of country of birth
 `bank_account_number` | string | Number identifying bank account
+`bank_agency_number` | string | Number identifying bank agency
 `bank_number` | string | Number identifying bank in national banking system (routing number in US)
 `bank_phone_number` | string | Phone number with country code for bank
 `tax_id` | string | Tax identifier of user in their country (social security number in US)

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -50,7 +50,7 @@ Name | Type | Description
 `bank_account_number` | string | Number identifying bank account
 `bank_number` | string | Number identifying bank in national banking system (routing number in US)
 `bank_phone_number` | string | Phone number with country code for bank
-`bank_branch` | string | Number identifying bank branch
+`bank_branch_number` | string | Number identifying bank branch
 `tax_id` | string | Tax identifier of user in their country (social security number in US)
 `tax_id_name` | string | Name of the tax ID (`SSN` or `ITIN` in the US)
 `occupation` | number | Occupation ISCO code

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -7,7 +7,7 @@ Author: stellar.org
 Status: Active
 Created: 2018-07-27
 Updated: 2020-12-22
-Version 1.2.1
+Version 1.3.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -48,9 +48,9 @@ Name | Type | Description
 `birth_place` | date | Place of birth (city, state, country; as on passport)
 `birth_country_code` | country code | ISO Code of country of birth
 `bank_account_number` | string | Number identifying bank account
-`bank_agency_number` | string | Number identifying bank agency
 `bank_number` | string | Number identifying bank in national banking system (routing number in US)
 `bank_phone_number` | string | Phone number with country code for bank
+`bank_branch` | string | Number identifying bank branch
 `tax_id` | string | Tax identifier of user in their country (social security number in US)
 `tax_id_name` | string | Name of the tax ID (`SSN` or `ITIN` in the US)
 `occupation` | number | Occupation ISCO code


### PR DESCRIPTION
Add `bank_branch` field to Natural Person KYC fields in order to identify customer's bank branch number wich is needed in Brazil, for example.