### PR TITLE
SEP-12 callback endpoint

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -339,7 +339,7 @@ PUT [KYC_SERVER || TRANSFER_SERVER]/customer/callback
 | `account`   | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.                                                                                                                 |
 `memo` | `string` | (optional) The memo used to create the customer record |
 `memo_type` | `string` | (optional) The type of memo used to create the customer record |
-| `url` | `string` | A valid URL. |
+| `url` | `string` | A callback URL that the SEP-12 server will POST to when the state of the account changes. |
 
 ### PUT Responses
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -36,8 +36,8 @@ To support this protocol an anchor acts as a server and implements the specified
 
 * [`GET /customer`](#customer-get): Check the status of a customers info
 * [`PUT /customer`](#customer-put): Idempotent upload of customer info
-* [`DELETE /customer`](#customer-delete): Deletion of customer info
-* [`POST /customer`](#customer-post): Set callbacks for a wallet to receive status updates from the anchor
+* [`DELETE /customer/[account]`](#customer-delete): Deletion of customer info
+* [`POST /customer/callbacks`](#customer-post): Set a callback for a wallet to receive status updates from the anchor
 
 ## Authentication
 
@@ -317,7 +317,7 @@ Success | `200 OK`
 Client not authenticated properly | `401 Unauthorized`
 Anchor has no information on the customer | `404 Not Found`
 
-## Customer POST
+## Customer callback POST
 
 Allow the wallet to provide a callback URL to the anchor.
 
@@ -325,17 +325,19 @@ Whenever the user's
 `status` field changes, the anchor will issue a POST request to the callback
 URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
 
-The anchor will POST updates to the callback URL until the user's status changes to ACCEPTED or REJECTED.
+If a wallet submits a callback URL that has already been set, the anchor shouldn't POST changes more than once. But a wallet might submit more than one unique callback URL.
 
 ### Request
 
 ```
-POST [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
+POST [KYC_SERVER || TRANSFER_SERVER]/customer/callbacks
 ```
 
 | Name                 | Type     | Description             |
 | -------------------- | -------- | ----------------------- |
-| `on_change_callback` | `string` | (optional) A valid URL. |
+| `id`        | `string`      | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.                                                                                                                                     |
+| `account`   | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.                                                                                                                 |
+| `url` | `string` | A valid URL. |
 
 ### POST Responses
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -7,7 +7,7 @@ Author: Interstellar
 Status: Active
 Created: 2018-09-11
 Updated: 2020-12-23
-Version 1.2.0
+Version 1.2.1
 ```
 
 ## Abstract
@@ -16,39 +16,37 @@ This SEP defines a standard way for stellar clients to upload KYC (or other) inf
 
 This SEP was made with these goals in mind:
 
-- interoperability
-- Allow a customer to enter their KYC information to their wallet once and use it across many services without re-entering information manually
-- handle the most common 80% of use cases
-- handle image and binary data
-- support the set of fields defined in [SEP-9](sep-0009.md)
-- support authentication via [SEP-10](sep-0010.md)
-- support the provision of data for [SEP-6](sep-0006.md), [SEP-24](sep-0024.md), [SEP-31](sep-0031.md), and others
-- give customers control over their data by supporting complete data erasure
+* interoperability
+* Allow a customer to enter their KYC information to their wallet once and use it across many services without re-entering information manually
+* handle the most common 80% of use cases
+* handle image and binary data
+* support the set of fields defined in [SEP-9](sep-0009.md)
+* support authentication via [SEP-10](sep-0010.md)
+* support the provision of data for [SEP-6](sep-0006.md), [SEP-24](sep-0024.md), [SEP-31](sep-0031.md), and others
+* give customers control over their data by supporting complete data erasure
 
 To support this protocol an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.
 
 ## Prerequisites
 
-- An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a client app knows where to find the anchor's server. A client app will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
-- Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
+* An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a client app knows where to find the anchor's server. A client app will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
+* Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
 
 ## API Endpoints
 
-- [`GET /customer`](#customer-get): Check the status of a customers info
-- [`PUT /customer`](#customer-put): Idempotent upload of customer info
-- [`DELETE /customer`](#customer-delete): Deletion of customer info
-- [`POST /customer`](#customer-post): Set callbacks for a wallet to receive status updates from the anchor
+* [`GET /customer`](#customer-get): Check the status of a customers info
+* [`PUT /customer`](#customer-put): Idempotent upload of customer info
+* [`DELETE /customer`](#customer-delete): Deletion of customer info
+* [`POST /customer`](#customer-post): Set callbacks for a wallet to receive status updates from the anchor
 
 ## Authentication
 
 Clients should submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow. The JWT should be included in all requests as request header:
-
 ```
 Authorization: Bearer <JWT>
 ```
 
 Alternatively, if the client cannot add the authorization header. The JWT should be passed as a jwt query parameter:
-
 ```
 ?jwt=<token>
 ```
@@ -73,11 +71,11 @@ This endpoint allows clients to:
 
 1. Fetch the fields the server requires in order to register a new customer via a `PUT /customer` request
 
-If the server does not have a customer registered for the parameters sent in the request, it should return the fields required in the response. The same response should be returned when no parameters are sent.
+ If the server does not have a customer registered for the parameters sent in the request, it should return the fields required in the response. The same response should be returned when no parameters are sent.
 
 2. Check the status of a customer that may already be registered
-
-This allows clients to check whether the customers information was accepted, rejected, or still needs more info. If the server still needs more info, or the server needs updated information, it should return the fields required.
+   
+ This allows clients to check whether the customers information was accepted, rejected, or still needs more info. If the server still needs more info, or the server needs updated information, it should return the fields required.
 
 ### Request
 
@@ -87,14 +85,14 @@ GET [KYC_SERVER]/customer?account=<public-key>&memo=<memo>&memo_type=<memo-type>
 GET [KYC_SERVER]/customer?id=<customer-id>
 ```
 
-| Name        | Type          | Description                                                                                                                                                                                                                                                                                           |
-| ----------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `string`      | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.                                                                                                                                     |
-| `account`   | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.                                                                                                                 |
-| `memo`      | string        | (optional) a [properly formatted memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies a customer. This value is generated by the client making the request. This parameter and `memo_type` are identical to the `PUT` request parameters of the same name. |
-| `memo_type` | string        | (optional) type of `memo`. One of `text`, `id` or `hash`. If `hash`, `memo` should be base64-encoded.                                                                                                                                                                                                 |
-| `type`      | string        | (optional) the type of action the customer is being KYCd for. See below.                                                                                                                                                                                                                              |
-| `lang`      | string        | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). Human readable descriptions, choices, and messages should be in this language.                                                                                                       |
+Name | Type | Description
+-----|------|------------
+`id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
+`account` | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.
+`memo` | string | (optional) a [properly formatted memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies a customer. This value is generated by the client making the request. This parameter and `memo_type` are identical to the `PUT` request parameters of the same name.
+`memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`. If `hash`, `memo` should be base64-encoded.
+`type` | string | (optional) the type of action the customer is being KYCd for.  See below.
+`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions, choices, and messages should be in this language.
 
 #### ID vs. Account & Memo
 
@@ -102,16 +100,16 @@ The client can always use the `account`, `memo`, and `memo_type` parameters to u
 
 #### Type specification
 
-Different types of actions may have different kyc requirements. The type parameter is used to signify what type of transaction this customer needs to be KYC'd for. For example, if a customer is being KYC'd as a SEP31 sender, they may only require full name, but a SEP31 receiver needs to be fully KYCd with comprehensive data. It can also be used to specify if this is a business being KYC'd or a person which can require different fields. The value used for `type` is up to the implementor to signify the types of transactions their services support, and is optional.
+Different types of actions may have different kyc requirements.  The type parameter is used to signify what type of transaction this customer needs to be KYC'd for.  For example, if a customer is being KYC'd as a SEP31 sender, they may only require full name, but a SEP31 receiver needs to be fully KYCd with comprehensive data.  It can also be used to specify if this is a business being KYC'd or a person which can require different fields.  The value used for `type` is up to the implementor to signify the types of transactions their services support, and is optional.
 
 ### Response
 
-| Name      | Type   | Description                                                                                            |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------ |
-| `id`      | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request. |
-| `status`  | string | Status of the customers KYC process.                                                                   |
-| `fields`  | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type   |
-| `message` | string | (optional) Human readable reason for rejection                                                         |
+Name | Type | Description
+-----|------|------------
+`id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
+`status` | string | Status of the customers KYC process.
+`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
+`message` | string | (optional) Human readable reason for rejection
 
 ```js
 // The case when a customer has been successfully KYC'd and approved
@@ -122,7 +120,7 @@ Different types of actions may have different kyc requirements. The type paramet
 ```
 
 ```js
-// The case when an anchor requires info about an unknown customer
+// The case when an anchor requires info about an unknown customer 
 {
    "status": "NEEDS_INFO",
    "fields": {
@@ -173,31 +171,30 @@ Different types of actions may have different kyc requirements. The type paramet
 
 #### Status
 
-| Status     | Description                                                                                                                                                                                                                                                                                                      |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ACCEPTED   | KYC has been accepted and the customer can be identified by stellar account and optional memo in future transactions. It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list. |
-| PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed                                                                                                                                                                                                           |
-| NEEDS_INFO | More info needs to be provided to finish KYC for this customer. The `fields` entry is required in this case.                                                                                                                                                                                                     |
-| REJECTED   | This customer's KYC has failed and will never succeed. The `message` must be supplied in this case.                                                                                                                                                                                                              |
+Status | Description
+-------|------------
+ACCEPTED | KYC has been accepted and the customer can be identified by stellar account and optional memo in future transactions.  It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list.
+PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed
+NEEDS_INFO | More info needs to be provided to finish KYC for this customer.  The `fields` entry is required in this case.
+REJECTED | This customer's KYC has failed and will never succeed.  The `message` must be supplied in this case.
 
 #### Fields
 
-The fields entry is required for the `NEEDS_INFO` status. Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
+The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
 
-| Property      | Type    | Description                                                                                    |
-| ------------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `type`        | enum    | The data type of the field value. Can be `string`, `binary`, `number`, or `date`               |
-| `description` | string  | A human-readable description of this field, especially important if this is not a SEP-9 field. |
-| `choices`     | array   | (optional) An array of valid values for this field.                                            |
-| `optional`    | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.      |
+Property | Type | Description
+-----|------|------------
+`type` | enum | The data type of the field value. Can be `string`, `binary`, `number`, or `date`
+`description` | string | A human-readable description of this field, especially important if this is not a SEP-9 field.
+`choices` | array | (optional) An array of valid values for this field.
+`optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
 
 #### Errors
 
 For requests containing an `id` parameter value that does not exist or exists for a customer created by another anchor, return a `404` response.
-
 ```json
 {
-  "error": "customer not found for id: 7e285e7d-d984-412c-97bc-909d0e399fbf"
+   "error": "customer not found for id: 7e285e7d-d984-412c-97bc-909d0e399fbf"
 }
 ```
 
@@ -206,7 +203,7 @@ For example:
 
 ```json
 {
-  "error": "unrecognized 'type' value. see valid values in the /info response"
+   "error": "unrecognized 'type' value. see valid values in the /info response"
 }
 ```
 
@@ -230,7 +227,7 @@ GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6
 --boundary
 Content-Disposition: form-data; name="memo"
 
-21bf91a4-7db1-401d-8108-fab7660a45d6
+21bf91a4-7db1-401d-8108-fab7660a45d6 
 --boundary
 Content-Disposition: form-data; name="memo_type"
 
@@ -254,12 +251,12 @@ Content-Type: application/json
 }
 ```
 
-| Name        | Type          | Description                                                                                                                                                                                                                        |
-| ----------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | string        | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.                                                                                                            |
-| `account`   | `G...` string | (optional) The Stellar account ID to upload KYC data for. If specified, `id` should not be specified.                                                                                                                              |
-| `memo`      | string        | (optional) Uniquely identifies individual customers in schemes where multiple customers share one Stellar address (ex. [SEP-31](sep-0031.md)). If included, the KYC data will only apply to all requests that include this `memo`. |
-| `memo_type` | string        | (optional) type of `memo`. One of `text`, `id` or `hash`                                                                                                                                                                           |
+Name | Type | Description
+-----|------|------------
+`id` | string | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.
+`account` | `G...` string | (optional) The Stellar account ID to upload KYC data for. If specified, `id` should not be specified.
+`memo` | string | (optional) Uniquely identifies individual customers in schemes where multiple customers share one Stellar address (ex. [SEP-31](sep-0031.md)). If included, the KYC data will only apply to all requests that include this `memo`.
+`memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
 
 The wallet should also transmit one or more of the fields listed in [SEP-9](./sep-0009.md), depending on what the anchor has indicated it needs.
 
@@ -269,23 +266,22 @@ When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` ty
 
 If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and a response body containing the customer ID.
 
-| Name | Type     | Description                                       |
-| ---- | -------- | ------------------------------------------------- |
-| `id` | `string` | An identifier for the updated or created customer |
+Name | Type | Description
+-----|------|------------
+`id` | `string` | An identifier for the updated or created customer
 
 ```json
 {
-  "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
+   "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
 }
 ```
 
 This ID can be used in future requests to retrieve the status of the customer or update the customer's information. It may also be used in other SEPs to identify the customer.
 
 Anchors should return `404 Not Found` for requests including an `id` value that does not exist in the database. Anchors should also return `404` when the `id` specified in the request was initially used to create a customer for a different stellar account.
-
 ```json
 {
-  "error": "customer with `id` not found"
+   "error":  "customer with `id` not found"
 }
 ```
 
@@ -294,7 +290,7 @@ For example:
 
 ```json
 {
-  "error": "'photo_id_front' cannot be decoded. Must be jpg or png."
+   "error": "'photo_id_front' cannot be decoded. Must be jpg or png."
 }
 ```
 
@@ -308,18 +304,18 @@ Delete all personal information that the anchor has stored about a given custome
 DELETE [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
 ```
 
-| Name        | Type     | Description                                                    |
-| ----------- | -------- | -------------------------------------------------------------- |
-| `memo`      | `string` | (optional) The memo used to create the customer record         |
-| `memo_type` | `string` | (optional) The type of memo used to create the customer record |
+Name | Type | Description
+-----|------|------------
+`memo` | `string` | (optional) The memo used to create the customer record
+`memo_type` | `string` | (optional) The type of memo used to create the customer record
 
 ### DELETE Responses
 
-| Situation                                 | Response           |
-| ----------------------------------------- | ------------------ |
-| Success                                   | `200 OK`           |
-| Client not authenticated properly         | `401 Unauthorized` |
-| Anchor has no information on the customer | `404 Not Found`    |
+Situation | Response
+----------|---------
+Success | `200 OK`
+Client not authenticated properly | `401 Unauthorized`
+Anchor has no information on the customer | `404 Not Found`
 
 ## Customer POST
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -323,7 +323,7 @@ Allow the wallet to provide a callback URL to the anchor. The provided callback 
 
 Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
 
-It's the wallet's responsibility to send a working callback URL to the anchor. If callback POST fails due to a problem on the callback URL's side, the anchor should not retry it.
+It's the wallet's responsibility to send a working callback URL to the anchor.
 
 Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -7,7 +7,7 @@ Author: Interstellar
 Status: Active
 Created: 2018-09-11
 Updated: 2020-12-23
-Version 1.2.1
+Version 1.3.0
 ```
 
 ## Abstract

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -319,16 +319,13 @@ Anchor has no information on the customer | `404 Not Found`
 
 ## Customer callback PUT
 
-Allow the wallet to provide a callback URL to the anchor. The provided callback 
-URL will replace (and supercede) any previously-set callback URL for this account.
+Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
-Whenever the user's
-`status` field changes, the anchor will issue a POST request to the callback
-URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
+Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
 
-Anchors will submit POST requests until the user's status changes to `ACCEPTED`
-or `REJECTED`. If a wallet needs to watch a user's KYC status after that,
-it will need to set a callback again.
+It's the wallet's responsibility to send a working callback URL to the anchor. If callback POST fails due to a problem on the callback URL's side, the anchor should not retry it.
+
+Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
 
 ### Request
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -37,7 +37,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /customer`](#customer-get): Check the status of a customers info
 * [`PUT /customer`](#customer-put): Idempotent upload of customer info
 * [`DELETE /customer/[account]`](#customer-delete): Deletion of customer info
-* [`POST /customer/callbacks`](#customer-post): Set a callback for a wallet to receive status updates from the anchor
+* [`PUT /customer/callback`](#customer-callback-put): Set a callback for a wallet to receive status updates from the anchor
 
 ## Authentication
 
@@ -317,29 +317,34 @@ Success | `200 OK`
 Client not authenticated properly | `401 Unauthorized`
 Anchor has no information on the customer | `404 Not Found`
 
-## Customer callback POST
+## Customer callback PUT
 
-Allow the wallet to provide a callback URL to the anchor.
+Allow the wallet to provide a callback URL to the anchor. The provided callback 
+URL will replace (and supercede) any previously-set callback URL for this account.
 
 Whenever the user's
 `status` field changes, the anchor will issue a POST request to the callback
 URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
 
-If a wallet submits a callback URL that has already been set, the anchor shouldn't POST changes more than once. But a wallet might submit more than one unique callback URL.
+Anchors will submit POST requests until the user's status changes to `ACCEPTED`
+or `REJECTED`. If a wallet needs to watch a user's KYC status after that,
+it will need to set a callback again.
 
 ### Request
 
 ```
-POST [KYC_SERVER || TRANSFER_SERVER]/customer/callbacks
+PUT [KYC_SERVER || TRANSFER_SERVER]/customer/callback
 ```
 
 | Name                 | Type     | Description             |
 | -------------------- | -------- | ----------------------- |
 | `id`        | `string`      | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.                                                                                                                                     |
 | `account`   | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.                                                                                                                 |
+`memo` | `string` | (optional) The memo used to create the customer record |
+`memo_type` | `string` | (optional) The type of memo used to create the customer record |
 | `url` | `string` | A valid URL. |
 
-### POST Responses
+### PUT Responses
 
 | Situation                                 | Response           |
 | ----------------------------------------- | ------------------ |

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,7 +6,7 @@ Title: Anchor/Client customer info transfer
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2020-12-15
+Updated: 2020-12-23
 Version 1.2.0
 ```
 
@@ -16,36 +16,39 @@ This SEP defines a standard way for stellar clients to upload KYC (or other) inf
 
 This SEP was made with these goals in mind:
 
-* interoperability
-* Allow a customer to enter their KYC information to their wallet once and use it across many services without re-entering information manually
-* handle the most common 80% of use cases
-* handle image and binary data
-* support the set of fields defined in [SEP-9](sep-0009.md)
-* support authentication via [SEP-10](sep-0010.md)
-* support the provision of data for [SEP-6](sep-0006.md), [SEP-24](sep-0024.md), [SEP-31](sep-0031.md), and others
-* give customers control over their data by supporting complete data erasure
+- interoperability
+- Allow a customer to enter their KYC information to their wallet once and use it across many services without re-entering information manually
+- handle the most common 80% of use cases
+- handle image and binary data
+- support the set of fields defined in [SEP-9](sep-0009.md)
+- support authentication via [SEP-10](sep-0010.md)
+- support the provision of data for [SEP-6](sep-0006.md), [SEP-24](sep-0024.md), [SEP-31](sep-0031.md), and others
+- give customers control over their data by supporting complete data erasure
 
 To support this protocol an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.
 
 ## Prerequisites
 
-* An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a client app knows where to find the anchor's server. A client app will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
-* Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
+- An anchor must define the location of their `KYC_SERVER` or `TRANSFER_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a client app knows where to find the anchor's server. A client app will send KYC requests to the `KYC_SERVER` if it is specified, otherwise to the `TRANSFER_SERVER`.
+- Anchors and clients must support [SEP-10](sep-0010.md) web authentication and use it for all SEP-12 endpoints.
 
 ## API Endpoints
 
-* [`GET /customer`](#customer-get): Check the status of a customers info
-* [`PUT /customer`](#customer-put): Idempotent upload of customer info
-* [`DELETE /customer`](#customer-delete): Deletion of customer info
+- [`GET /customer`](#customer-get): Check the status of a customers info
+- [`PUT /customer`](#customer-put): Idempotent upload of customer info
+- [`DELETE /customer`](#customer-delete): Deletion of customer info
+- [`POST /customer`](#customer-post): Set callbacks for a wallet to receive status updates from the anchor
 
 ## Authentication
 
 Clients should submit the JWT previously obtained from the anchor via the [SEP-10](sep-0010.md) authentication flow. The JWT should be included in all requests as request header:
+
 ```
 Authorization: Bearer <JWT>
 ```
 
 Alternatively, if the client cannot add the authorization header. The JWT should be passed as a jwt query parameter:
+
 ```
 ?jwt=<token>
 ```
@@ -70,11 +73,11 @@ This endpoint allows clients to:
 
 1. Fetch the fields the server requires in order to register a new customer via a `PUT /customer` request
 
- If the server does not have a customer registered for the parameters sent in the request, it should return the fields required in the response. The same response should be returned when no parameters are sent.
+If the server does not have a customer registered for the parameters sent in the request, it should return the fields required in the response. The same response should be returned when no parameters are sent.
 
 2. Check the status of a customer that may already be registered
-   
- This allows clients to check whether the customers information was accepted, rejected, or still needs more info. If the server still needs more info, or the server needs updated information, it should return the fields required.
+
+This allows clients to check whether the customers information was accepted, rejected, or still needs more info. If the server still needs more info, or the server needs updated information, it should return the fields required.
 
 ### Request
 
@@ -84,14 +87,14 @@ GET [KYC_SERVER]/customer?account=<public-key>&memo=<memo>&memo_type=<memo-type>
 GET [KYC_SERVER]/customer?id=<customer-id>
 ```
 
-Name | Type | Description
------|------|------------
-`id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
-`account` | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.
-`memo` | string | (optional) a [properly formatted memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies a customer. This value is generated by the client making the request. This parameter and `memo_type` are identical to the `PUT` request parameters of the same name.
-`memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`. If `hash`, `memo` should be base64-encoded.
-`type` | string | (optional) the type of action the customer is being KYCd for.  See below.
-`lang` | string | (optional) Defaults to `en`.  Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Human readable descriptions, choices, and messages should be in this language.
+| Name        | Type          | Description                                                                                                                                                                                                                                                                                           |
+| ----------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | `string`      | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.                                                                                                                                     |
+| `account`   | `G...` string | (optional) The Stellar account ID used to identify this customer. If many customers share the same Stellar account, the `memo` and `memo_type` parameters should be included as well.                                                                                                                 |
+| `memo`      | string        | (optional) a [properly formatted memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies a customer. This value is generated by the client making the request. This parameter and `memo_type` are identical to the `PUT` request parameters of the same name. |
+| `memo_type` | string        | (optional) type of `memo`. One of `text`, `id` or `hash`. If `hash`, `memo` should be base64-encoded.                                                                                                                                                                                                 |
+| `type`      | string        | (optional) the type of action the customer is being KYCd for. See below.                                                                                                                                                                                                                              |
+| `lang`      | string        | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). Human readable descriptions, choices, and messages should be in this language.                                                                                                       |
 
 #### ID vs. Account & Memo
 
@@ -99,16 +102,16 @@ The client can always use the `account`, `memo`, and `memo_type` parameters to u
 
 #### Type specification
 
-Different types of actions may have different kyc requirements.  The type parameter is used to signify what type of transaction this customer needs to be KYC'd for.  For example, if a customer is being KYC'd as a SEP31 sender, they may only require full name, but a SEP31 receiver needs to be fully KYCd with comprehensive data.  It can also be used to specify if this is a business being KYC'd or a person which can require different fields.  The value used for `type` is up to the implementor to signify the types of transactions their services support, and is optional.
+Different types of actions may have different kyc requirements. The type parameter is used to signify what type of transaction this customer needs to be KYC'd for. For example, if a customer is being KYC'd as a SEP31 sender, they may only require full name, but a SEP31 receiver needs to be fully KYCd with comprehensive data. It can also be used to specify if this is a business being KYC'd or a person which can require different fields. The value used for `type` is up to the implementor to signify the types of transactions their services support, and is optional.
 
 ### Response
 
-Name | Type | Description
------|------|------------
-`id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
-`status` | string | Status of the customers KYC process.
-`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
-`message` | string | (optional) Human readable reason for rejection
+| Name      | Type   | Description                                                                                            |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| `id`      | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request. |
+| `status`  | string | Status of the customers KYC process.                                                                   |
+| `fields`  | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type   |
+| `message` | string | (optional) Human readable reason for rejection                                                         |
 
 ```js
 // The case when a customer has been successfully KYC'd and approved
@@ -119,7 +122,7 @@ Name | Type | Description
 ```
 
 ```js
-// The case when an anchor requires info about an unknown customer 
+// The case when an anchor requires info about an unknown customer
 {
    "status": "NEEDS_INFO",
    "fields": {
@@ -170,30 +173,31 @@ Name | Type | Description
 
 #### Status
 
-Status | Description
--------|------------
-ACCEPTED | KYC has been accepted and the customer can be identified by stellar account and optional memo in future transactions.  It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list.
-PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed
-NEEDS_INFO | More info needs to be provided to finish KYC for this customer.  The `fields` entry is required in this case.
-REJECTED | This customer's KYC has failed and will never succeed.  The `message` must be supplied in this case.
+| Status     | Description                                                                                                                                                                                                                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ACCEPTED   | KYC has been accepted and the customer can be identified by stellar account and optional memo in future transactions. It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list. |
+| PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed                                                                                                                                                                                                           |
+| NEEDS_INFO | More info needs to be provided to finish KYC for this customer. The `fields` entry is required in this case.                                                                                                                                                                                                     |
+| REJECTED   | This customer's KYC has failed and will never succeed. The `message` must be supplied in this case.                                                                                                                                                                                                              |
 
 #### Fields
 
-The fields entry is required for the `NEEDS_INFO` status.  Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
+The fields entry is required for the `NEEDS_INFO` status. Fields should be specified as an object with keys representing field names required, preferably from SEP-9.
 
-Property | Type | Description
------|------|------------
-`type` | enum | The data type of the field value. Can be `string`, `binary`, `number`, or `date`
-`description` | string | A human-readable description of this field, especially important if this is not a SEP-9 field.
-`choices` | array | (optional) An array of valid values for this field.
-`optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
+| Property      | Type    | Description                                                                                    |
+| ------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `type`        | enum    | The data type of the field value. Can be `string`, `binary`, `number`, or `date`               |
+| `description` | string  | A human-readable description of this field, especially important if this is not a SEP-9 field. |
+| `choices`     | array   | (optional) An array of valid values for this field.                                            |
+| `optional`    | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.      |
 
 #### Errors
 
 For requests containing an `id` parameter value that does not exist or exists for a customer created by another anchor, return a `404` response.
+
 ```json
 {
-   "error": "customer not found for id: 7e285e7d-d984-412c-97bc-909d0e399fbf"
+  "error": "customer not found for id: 7e285e7d-d984-412c-97bc-909d0e399fbf"
 }
 ```
 
@@ -202,7 +206,7 @@ For example:
 
 ```json
 {
-   "error": "unrecognized 'type' value. see valid values in the /info response"
+  "error": "unrecognized 'type' value. see valid values in the /info response"
 }
 ```
 
@@ -226,7 +230,7 @@ GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6
 --boundary
 Content-Disposition: form-data; name="memo"
 
-21bf91a4-7db1-401d-8108-fab7660a45d6 
+21bf91a4-7db1-401d-8108-fab7660a45d6
 --boundary
 Content-Disposition: form-data; name="memo_type"
 
@@ -250,12 +254,12 @@ Content-Type: application/json
 }
 ```
 
-Name | Type | Description
------|------|------------
-`id` | string | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.
-`account` | `G...` string | (optional) The Stellar account ID to upload KYC data for. If specified, `id` should not be specified.
-`memo` | string | (optional) Uniquely identifies individual customers in schemes where multiple customers share one Stellar address (ex. [SEP-31](sep-0031.md)). If included, the KYC data will only apply to all requests that include this `memo`.
-`memo_type` | string | (optional) type of `memo`. One of `text`, `id` or `hash`
+| Name        | Type          | Description                                                                                                                                                                                                                        |
+| ----------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | string        | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.                                                                                                            |
+| `account`   | `G...` string | (optional) The Stellar account ID to upload KYC data for. If specified, `id` should not be specified.                                                                                                                              |
+| `memo`      | string        | (optional) Uniquely identifies individual customers in schemes where multiple customers share one Stellar address (ex. [SEP-31](sep-0031.md)). If included, the KYC data will only apply to all requests that include this `memo`. |
+| `memo_type` | string        | (optional) type of `memo`. One of `text`, `id` or `hash`                                                                                                                                                                           |
 
 The wallet should also transmit one or more of the fields listed in [SEP-9](./sep-0009.md), depending on what the anchor has indicated it needs.
 
@@ -265,22 +269,23 @@ When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` ty
 
 If the anchor received and stored the data successfully, it should respond with a `202 Accepted` HTTP status code and a response body containing the customer ID.
 
-Name | Type | Description
------|------|------------
-`id` | `string` | An identifier for the updated or created customer
+| Name | Type     | Description                                       |
+| ---- | -------- | ------------------------------------------------- |
+| `id` | `string` | An identifier for the updated or created customer |
 
 ```json
 {
-   "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
+  "id": "391fb415-c223-4608-b2f5-dd1e91e3a986"
 }
 ```
 
 This ID can be used in future requests to retrieve the status of the customer or update the customer's information. It may also be used in other SEPs to identify the customer.
 
 Anchors should return `404 Not Found` for requests including an `id` value that does not exist in the database. Anchors should also return `404` when the `id` specified in the request was initially used to create a customer for a different stellar account.
+
 ```json
 {
-   "error":  "customer with `id` not found"
+  "error": "customer with `id` not found"
 }
 ```
 
@@ -289,7 +294,7 @@ For example:
 
 ```json
 {
-   "error": "'photo_id_front' cannot be decoded. Must be jpg or png."
+  "error": "'photo_id_front' cannot be decoded. Must be jpg or png."
 }
 ```
 
@@ -303,15 +308,43 @@ Delete all personal information that the anchor has stored about a given custome
 DELETE [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
 ```
 
-Name | Type | Description
------|------|------------
-`memo` | `string` | (optional) The memo used to create the customer record
-`memo_type` | `string` | (optional) The type of memo used to create the customer record
+| Name        | Type     | Description                                                    |
+| ----------- | -------- | -------------------------------------------------------------- |
+| `memo`      | `string` | (optional) The memo used to create the customer record         |
+| `memo_type` | `string` | (optional) The type of memo used to create the customer record |
 
 ### DELETE Responses
 
-Situation | Response
-----------|---------
-Success | `200 OK`
-Client not authenticated properly | `401 Unauthorized`
-Anchor has no information on the customer | `404 Not Found`
+| Situation                                 | Response           |
+| ----------------------------------------- | ------------------ |
+| Success                                   | `200 OK`           |
+| Client not authenticated properly         | `401 Unauthorized` |
+| Anchor has no information on the customer | `404 Not Found`    |
+
+## Customer POST
+
+Allow the wallet to provide a callback URL to the anchor.
+
+Whenever the user's
+`status` field changes, the anchor will issue a POST request to the callback
+URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
+
+The anchor will POST updates to the callback URL until the user's status changes to ACCEPTED or REJECTED.
+
+### Request
+
+```
+POST [KYC_SERVER || TRANSFER_SERVER]/customer/[account]
+```
+
+| Name                 | Type     | Description             |
+| -------------------- | -------- | ----------------------- |
+| `on_change_callback` | `string` | (optional) A valid URL. |
+
+### POST Responses
+
+| Situation                                 | Response           |
+| ----------------------------------------- | ------------------ |
+| Success                                   | `200 OK`           |
+| Client not authenticated properly         | `401 Unauthorized` |
+| Anchor has no information on the customer | `404 Not Found`    |


### PR DESCRIPTION
Wallets need a way to check a user's KYC status even if the user isn't available to sign a SEP-10 request. This change adds a POST /customer endpoint that allows wallets to provide a callback URL. Anchors will POST whenever the status changes (in the same format as responses to GET /customer) until the user is accepted or rejected.