### PR TITLE
SEP-6: Add sep12_type to GET /deposit and /withdraw responses

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -492,16 +492,14 @@ The response should be a JSON object like:
         "bank_account": {
           "fields": {
             "dest": { 
-              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
-              "optional": true
+              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used"
             }
           }
         },
         "cash": {
           "fields": {
             "dest": { 
-              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
-              "optional": true
+              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used"
             }
           }
         }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -491,7 +491,7 @@ The response should be a JSON object like:
       "types": {
         "bank_account": {
           "fields": {
-            "email_address": { 
+            "dest": { 
               "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
               "optional": true
             }
@@ -499,7 +499,7 @@ The response should be a JSON object like:
         },
         "cash": {
           "fields": {
-            "email_address": { 
+            "dest": { 
               "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
               "optional": true
             }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -320,7 +320,16 @@ Example:
 ```json
 {
   "type": "non_interactive_customer_info_needed",
-  "fields" : ["family_name", "given_name", "address", "tax_id"],
+  "fields" : [
+    "family_name",
+    "given_name",
+    "address",
+    "mobile_number",
+    "tax_id",
+    "bank_account_number",
+    "bank_number",
+    "bank_branch_number"
+  ],
   "sep12_type": "default_deposit"
 }
 ```

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -311,15 +311,17 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Always set to `non_interactive_customer_info_needed`.
 `fields` | list of strings | A list of field names that need to be transmitted via SEP-12 for the deposit to proceed.
+`sep12_type` | string | (optional) The SEP-12 `type` value associated with `fields`. Wallets may use this value in [SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) requests for more information on the returned list.
 
-The field names specified in `fields` must be drawn from the list defined in [SEP-9](sep-0009.md).
+The field names specified in `fields` must be drawn from the list defined in [SEP-9](sep-0009.md) and associated with a [SEP-12](sep-0012.md) customer `type`.
 
 Example:
 
 ```json
 {
   "type": "non_interactive_customer_info_needed",
-  "fields" : ["family_name", "given_name", "address", "tax_id"]
+  "fields" : ["family_name", "given_name", "address", "tax_id"],
+  "sep12_type": "default"
 }
 ```
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -321,7 +321,7 @@ Example:
 {
   "type": "non_interactive_customer_info_needed",
   "fields" : ["family_name", "given_name", "address", "tax_id"],
-  "sep12_type": "default_deposit_cash"
+  "sep12_type": "default_deposit"
 }
 ```
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -321,7 +321,7 @@ Example:
 {
   "type": "non_interactive_customer_info_needed",
   "fields" : ["family_name", "given_name", "address", "tax_id"],
-  "sep12_type": "default"
+  "sep12_type": "default_deposit_cash"
 }
 ```
 
@@ -436,7 +436,15 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
-      "max_amount": 1000,
+      "max_amount": 10000,
+      "sep12_types": {
+        "default_deposit": {
+          "description": "used for deposits of less than $1,000"
+        },
+        "large_deposit": {
+          "descrition": "used for deposits of $1,000 or more"
+        },
+      },
       "fields": {
         "email_address" : {
           "description": "your email address for transaction status updates",
@@ -465,7 +473,21 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 0,
       "min_amount": 0.1,
-      "max_amount": 1000,
+      "max_amount": 10000,
+      "sep12_types": {
+        "default_withdraw_cash": {
+          "description": "used for cash deposits of less than $1,000"
+        },
+        "default_withdraw_bank_transfer": {
+          "description": "used for bank transfer deposits of less than $1,000"
+        },
+        "large_withdraw_cash": {
+          "description": "used for cash deposits of $1,000 or more"
+        },
+        "large_withdraw_bank_transfer": {
+          "description": "used for bank transfer deposits of $1,000 or more"
+        }
+      },
       "types": {
         "bank_account": {
           "fields": {
@@ -513,6 +535,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for deposit. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `sep12_types`: Optional object describing the possible `sep12_type` values returned from `/deposit` or `withdraw`.
 * `fields` object as explained below.
 
 #### For each withdrawal asset, response contains:
@@ -523,6 +546,7 @@ The JSON object contains an entry for each asset that the anchor supports for SE
 * `max_amount`: Optional maximum amount. No limit if not specified.
 * `fee_fixed`: Optional fixed (flat) fee for withdraw. In units of the deposited asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for withdraw. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
+* `sep12_types`: Optional object describing the possible `sep12_type` values returned from `/deposit` or `withdraw`.
 * a `types` field with each type of withdrawal supported for that asset as a key. Each type can specify a `fields` object as below explaining what fields are needed and what they do.
 
 The `fields` object allows an anchor to describe fields that are passed into `/deposit` and `/withdraw`. It can explain standard fields like `dest` and `dest_extra` for withdrawal, and it can also specify extra fields that should be passed into `/deposit` or `/withdraw` such as an email address or bank name. If a field is part of the KYC/AML flow handled by SEP-12 or the field is handled by your interactive deposit/withdrawal flow, there's no need to list it in `/info`. Only fields that are passed to `/deposit` or `/withdraw` need appear here.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -491,15 +491,15 @@ The response should be a JSON object like:
       "types": {
         "bank_account": {
           "fields": {
-              "dest": {"description": "your bank account number" },
-              "dest_extra": { "description": "your routing number" },
-              "bank_branch": { "description": "address of your bank branch" },
-              "phone_number": { "description": "your phone number in case there's an issue" }
+            "email_address": { 
+              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
+              "optional": true
+            }
           }
         },
         "cash": {
           "fields": {
-            "dest": { 
+            "email_address": { 
               "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used",
               "optional": true
             }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -330,7 +330,7 @@ Example:
     "bank_number",
     "bank_branch_number"
   ],
-  "sep12_type": "default_deposit"
+  "sep12_type": "default_withdraw_bank_transfer"
 }
 ```
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -492,7 +492,7 @@ The response should be a JSON object like:
         "bank_account": {
           "fields": {
             "dest": { 
-              "description": "your email address. Your cashout PIN will be sent here. If not provided, your account's default email will be used"
+              "description": "your bank account number"
             }
           }
         },


### PR DESCRIPTION
This is the first of several PRs I'll be making to update SEP-6 to use SEP-12 expanded capabilities (it's new GET endpoint in particular).

Changes:
- Adds a `sep12_type` attribute to the `non_interactive_customer_info_needed` response
    - This allows wallets to fetch more detailed information on the fields requested by the server. For example, Wallets can determine which fields are required vs. optional, which fields have a fixed set of accepted values, etc. 
- The possible values for `sep12_type` are outlined in SEP-6's `/info` endpoint, similar to SEP-31's `/info`.