### PR TITLE
SEP-6: Added 'sep12_status_url' to 'customer_info_needed' response

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -327,7 +327,7 @@ Example:
 
 Response code: `403 Forbidden`
 
-An anchor should use this response if customer information was submitted for the `account`, but the information is either still being processed or was not accepted.
+An anchor should use this response if customer information was submitted for the `account`, but the information is either still being processed or was not accepted. SEP-12's [GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) can also be used to check on the user's KYC status.
 
 Name | Type | Description
 -----|------|------------
@@ -335,6 +335,7 @@ Name | Type | Description
 `status` | string | Status of customer information processing. One of: `pending`, `denied`.
 `more_info_url` | string | (optional) A URL the user can visit if they want more information about their account / status.
 `eta` | int | (optional) Estimated number of seconds until the customer information status will update.
+`sep12_status_url` | string | (optional) A [SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) URL that returns the status of the user. This response may have a human-readable message that the Wallet can display instead of opening `more_info_url`.
 
 If the anchor decides that more customer information is needed after receiving some information and processing it, it can respond again with a response of type `non_interactive_customer_info_needed`. In the case of a `denied` request, an anchor can use the `more_info_url` to explain to the user the issue with their request and give them a way to rectify it manually. A wallet should show the `more_info_url` to the user when explaining that the request was denied.
 


### PR DESCRIPTION
This is the second of several PR's I'll be making to update SEP-6 to use SEP-12's new capabilities. First issue: #808

Changes:
- Adds a `sep12_status_url` attribute to SEP-6's `customer_info_status` response. 
    - This response and SEP-12's `GET /customer` response overlap significantly