### PR TITLE
SEP-8: reformat

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -39,7 +39,7 @@ Implementing a regulated asset requires these parts:
 4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by the issuer.
-    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. It is important to understand that an approval service could respond with a different transaction.
+    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. **It is important to understand that an approval service could respond with a different transaction.**
     3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).
     4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
     5. *Rejected?* Wallet should display the associated error message to the user.

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -228,7 +228,7 @@ Name | Type | Description
 ### Best practices
 
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
-- Wallet should inspect revised transactions and alert the user if any of the original operations is changed.
+- Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
 - Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to Boris’ account.

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -118,7 +118,7 @@ Parameters:
 Name | Type | Description
 -----|------|------------
 `status` | string | `"success"`
-`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as an additional signature from the issuer.
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as one or multiple additional signatures from the issuer.
 `message` | string | (optional) A human readable string containing information to pass on to the user.
 
 ###### Example

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -109,7 +109,7 @@ All responses will contain a top level `status` parameter that indicates the typ
 
 ##### Success
 
-This response means that the transaction was found compliant and signed without a revise.
+This response means that the transaction was found compliant and signed without being revised.
 
 A `success` response will have a `200` HTTP status code and `success` as the `status` value.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,51 +3,61 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com
+Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2020-12-09
-Version 1.0.0
+Updated: 2021-01-07
+Version 1.0.1
 ```
 
 ## Simple Summary
 
-Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
+Regulated Assets are assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
 
-**Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
+## Target Audience
+
+Asset issuers, issuance platforms, wallet developers, and exchanges
 
 ## Motivation
 
-Stellar aims to be an ideal platform for issuing securities. As such, it must provide tools to comply with various regulatory requirements. Regulation often requires asset issuers to monitor and approve every transaction involving the issued asset and to enforce an assortment of constraints. This SEP provides support for these requirements.
+Stellar is an ideal platform for issuing securities. Regulation sometimes requires asset issuers to monitor and approve each transaction involving issued assets and to enforce constraints. This is possible on the Stellar network today, however there exists no standard interface between wallets and issuers to negotiate approval.
 
 ## Overview
 
-Implementing a Regulated Asset consists of these parts:
-- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- **Approval Server**: HTTP protocol for transaction signing.
-- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/>
-**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented.
+Implementing a regulated asset requires these parts:
+- Issuer account with appropriate [authorization flags] set.
+- [SEP-1 stellar.toml] used for discovering [Approval Server].
+- [Approval Server] that validates client transactions according to the service's approval criteria. Validated transactions are signed by the asset's issuing account.
 
 ## Regulated Assets Approval Flow
 
-1. User creates and signs a transaction.
+1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
+	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
+	1. Wallet can find the approval server via [SEP-1 stellar.toml] set up by the issuer.
+4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
-    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
-    3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
+    1. *Success?* Transaction has been approved and signed by the issuer.
+    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. It is important to understand that an approval service could respond with a different transaction.
+    3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).
     4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
-    5. *Rejected?* Wallet should display given error message to the user.
+    5. *Rejected?* Wallet should display the associated error message to the user.
 
-## Stellar.toml
-Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+## Authorization Flags
+
+Regulated asset issuers must have both `Authorization Required` and `Authorization Revocable` flags set on their account. This allows the issuer to grant and revoke authorization to transact the asset at will.
+
+## SEP-1 stellar.toml
+
+Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the `[[CURRENCIES]]` section as different assets can have different requirements.
 
 ### Fields:
 
+These fields are listed in the `[[CURRENCIES]]` section:
+
 - `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
-- `approval_server` is the url of an approval service that signs validated transactions.
+- `approval_server` is the URL of an approval service that signs validated transactions.
 - `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
 
 ### Example
@@ -62,90 +72,166 @@ approval_criteria="The goat approval server will ensure that transactions are co
 ```
 
 ## Approval Server
-The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
 
-### Possible results
-- Success: Transaction was found compliant and signed by service.
-- Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
-- Pending: The issuer will asynchronously validate the transaction and respond later.
-- Action Required: The user must complete an action in order to have the transaction approved.
-- Rejected: Transaction was rejected.
+Approval server is a single endpoint that receives a signed transaction, checks for compliance, and signs it on success.
 
-### Request
+The specification of an approval server is defined as follows:
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed if possible.
+### Content Type
 
-### Responses
+Approval server accepts requests in the `Content-Type`:
 
-HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
+- `application/x-www-form-urlencoded`
 
+Approval server responds with the `Content-Type`:
 
-#### Success Response
+- `application/json`
 
-A Successful response will have a `200` HTTP status code and `success` as the `status` value. This response means that the transaction was found compliant and signed.
+### POST Endpoint
 
-Parameters:
+#### Request
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"success"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction will have both the original signature(s) from the request, as well as an additional issuer signature.
-message|string|A human readable string containing information to pass on to the user (optional).
+This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 
-#### Revised Response
+Name | Type | Description
+-----|------|------------
+`tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
-A Revised response will have a `200` HTTP status code and `revised` as the `status` value. It means that the transaction was revised to be made compliant. The user should examine and resign the transaction.
+###### Example (Form)
 
-Parameters:
+```
+tx=AAAAAHAHhQtYBh5F2zA6...
+```
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"revised"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
-message|string|A human readable string explaining the modifications made to the transaction to make it compliant.
+#### Responses
 
-#### Pending Response
+All responses will contain a top level `status` parameter that indicates the type of the result.
 
-A Pending response will have a `200` HTTP status code and `pending` as the `status` value. It means that the issuer needs to asynchronously validate the transaction. The user should resubmit the transaction after a given timeout.
+##### Success
+
+This response means that the transaction was found compliant and signed without a revise.
+
+A `success` response will have a `200` HTTP status code and `success` as the `status` value.
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"pending"`
-timeout|integer|Number of milliseconds to wait before submitting the same transaction again.
-message|string|A human readable string containing information to pass on to the user (optional).
+Name | Type | Description
+-----|------|------------
+`status` | string | `"success"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as an additional signature from the issuer.
+`message` | string | (optional) A human readable string containing information to pass on to the user.
 
-#### Action Required Response
+###### Example
 
-An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+```json
+{
+  "status": "success",
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
+
+##### Revised
+
+This response means that the transaction was revised to be made compliant.
+
+A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
+
+It is important for the user to examine the revised transaction before re-signing it. More specifically, the user should make sure that the revised transaction does not contain any additional operations whose source account matches the source account of the original operation(s).
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"action_required"`
-message|string|A human readable string containing information regarding the action required.
-action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"revised"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
+`message` | string | A human readable string explaining the modifications made to the transaction to make it compliant.
 
-#### Rejected Response
+###### Example
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and could not be revised to be made compliant.
+```json
+{
+  "status": "revised",
+  "tx": "AAAAAHAHhQtYBh5F2zA6...",
+  "message": "Authorization and deauthorization operations were added."
+}
+```
+
+##### Pending
+
+This response means that the issuer could not determine whether to approve the transaction at the time of receiving it. Wallet can re-submit the same transaction at a later point in time.
+
+A `pending` response will have a `200` HTTP status code and `pending` as the `status` value.
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"rejected"`
-error|string|A human readable string explaining why the transaction is not compliant and could not be made compliant.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"pending"`
+`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again.
+`message` | string | (optional) A human readable string containing information to pass on to the user.
+
+###### Example
+
+```json
+{
+  "status": "pending",
+  "message": "Futher verifications are required due to..."
+}
+```
+
+##### Action Required
+
+This reponse means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+
+An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"action_required"`
+`message` | string | A human readable string containing information regarding the action required.
+`action_url` | string | A URL that allows the user to complete the actions required to have the transaction approved.
+
+###### Example
+
+```json
+{
+  "status": "action_required",
+  "message": "Please sign the terms of service via the provided URL.",
+  "action_url": "https://..."
+}
+```
+
+##### Rejected
+
+This response means that the transaction is not compliant and could not be revised to be made compliant.
+
+A `rejected` response will have a `400` HTTP status code and `rejected` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"rejected"`
+`error` | string | A human readable string explaining why the transaction is not compliant and could not be made compliant.
+
+###### Example
+
+```json
+{
+  "status": "rejected",
+  "message": "The destination account is blocked."
+}
+```
 
 ### Best practices
 
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
+- Wallet should inspect revised transactions and alert the user if any of the original operations is changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
-- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
-- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
+- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to Boris’ account.
 
 ## Account Setup
 
@@ -158,10 +244,14 @@ In the future, this requirement can be replaced by introducing protocol level [C
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
-Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
 ### Why doesn’t the approval service submit transactions to the network?
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
+- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
+- Scaling concerns as having the approval server submit transactions would require more infrastructure.
 
+[SEP-1 stellar.toml]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[authorization flags]: #authorization-flags
+[Approval Server]: #approval-server

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -237,8 +237,6 @@ Name | Type | Description
 
 Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
 
-In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
-
 ## Discussion
 
 ### Should my asset be a regulated asset?

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -231,7 +231,7 @@ Name | Type | Description
 - Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
-- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to Boris’ account.
+- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to the issuer's account.
 
 ## Account Setup
 


### PR DESCRIPTION
**What**

This PR beautifies and re-formats SEP-8 without changing the functionality. It also makes things clear by adding a section "authorization flags" in order to explain how to identify a regulated asset in the first place. Finally, account setup is removed from `Overview` because it's not necessary. However, this PR does not remove the `Account Setup` section as its goal is to improves readability.

**Why**

A portion of the content and format in SEP-8 is outdated as it was created more than 2 years ago.