### PR TITLE
SEP-12: Allow GET /customer in PROCESSING to have 'message'

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -160,6 +160,14 @@ Name | Type | Description
 ```
 
 ```js
+{
+    "id": "46116754-695e-43f6-84c4-8c05e50a7b12",
+    "status": "PROCESSING",
+    "message": "Photo ID requires manual review. This process typically takes 1-2 business days."
+}
+```
+
+```js
 // The case when a customer has been rejected and cannot be KYC'd
 {
    "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -107,8 +107,8 @@ Name | Type | Description
 -----|------|------------
 `id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
 `status` | string | Status of the customers KYC process.
-`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
-`message` | string | (optional) Human readable reason for rejection
+`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type.
+`message` | string | (optional) Human readable message describing the current state of customer's KYC process.
 
 ```js
 // The case when a customer has been successfully KYC'd and approved

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -160,6 +160,7 @@ Name | Type | Description
 ```
 
 ```js
+// The case when the Anchor is processing KYC information  
 {
     "id": "46116754-695e-43f6-84c4-8c05e50a7b12",
     "status": "PROCESSING",


### PR DESCRIPTION
The `GET /customer` endpoint has an optional `message` response attribute that is currently implied to only be used for rejection responses. However, SEP-6/SEP-31 Wallets may want to display a human readable message to their users while KYC information is being processed instead of opening a `more_info_url` from the anchor.