### PR TITLE
SEP-8: add application/json as request content type

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-07
-Version 1.0.1
+Updated: 2021-01-08
+Version 1.1.1
 ```
 
 ## Simple Summary
@@ -79,9 +79,10 @@ The specification of an approval server is defined as follows:
 
 ### Content Type
 
-Approval server accepts requests in the `Content-Type`:
+Approval server accepts requests in the following `Content-Type`s:
 
 - `application/x-www-form-urlencoded`
+- `application/json`
 
 Approval server responds with the `Content-Type`:
 
@@ -96,6 +97,14 @@ This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 Name | Type | Description
 -----|------|------------
 `tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+
+###### Example (JSON)
+
+```json
+{
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
 
 ###### Example (Form)
 


### PR DESCRIPTION
**What**

Support JSON encoded request.

**Why**

We accept the `application/json` content type in some other SEPs, e.g. SEP-10 and SEP-30. The viewpoint from some people outside SDF that led to this pattern on SEP-10 was that it makes it easier to integrate with the APIs in some cases.

**Note**

This PR would have a version conflict with https://github.com/stellar/stellar-protocol/pull/817. One that gets merged first will have version 1.1.1; one that gets merged later will have version 1.2.1.