### PR TITLE
SEP-8: replace account setup with transaction composition

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -260,7 +260,7 @@ Name | Type | Description
 
 ### Best practices
 
-- Issuers using the `revised` status to make a transaction complaint is encouraged as it can take the burdens away from the wallets.
+- Issuers are encouraged to use the `revised` status to make a transaction complaint when possible, since Wallets may not know how to form a transaction that is compliant with the server's criteria.
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
 - Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-07
-Version 1.0.1
+Updated: 2021-01-08
+Version 1.1.1
 ```
 
 ## Simple Summary
@@ -69,6 +69,30 @@ issuer="GD5T6IPRNCKFOHQWT264YPKOZAWUMMZOLZBJ6BNQMUGPWGRLBK3U7ZNP"
 regulated=true
 approval_server="https://goat.io/tx_approve"
 approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
+```
+
+## Transaction Composition
+
+A transaction that an approval server will approve consists of operations that authorize the clients' accounts, transact the regulated asset, and deauthorize the clients' accounts. If a transaction is built this way, there will be no point where the clients' accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity. A transaction as described above can be built by wallets preemptively or by approval servers in order to make it compliant when the [revised](#revised) status is applicable.
+
+Depending on whether issuers want to allow the clients' accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+
+An example of the transaction where the issuer allow the client's account to maintain offers:
+
+```
+Operation 1: AllowTrust op where issuer fully authorizes account A, asset X
+Operation 2: Account A manages offer to buy or sell X
+Operation 3: AllowTrust op where issuer sets account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+```
+
+An example of the transaction where the issuer do not allow the clients' accounts to maintain offers:
+
+```
+Operation 1: AllowTrust op where issuer fully authorizes account A, asset X
+Operation 2: AllowTrust op where issuer fully authorizes account B, asset X
+Operation 3: Payment from A to B
+Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X
+Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X
 ```
 
 ## Approval Server
@@ -232,10 +256,6 @@ Name | Type | Description
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
 - Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to the issuer's account.
-
-## Account Setup
-
-Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
 
 ## Discussion
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-08
-Version 1.1.1
+Updated: 2021-01-11
+Version 1.2.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -251,6 +251,7 @@ Name | Type | Description
 
 ### Best practices
 
+- Issuers using the `revised` status to make a transaction complaint is encouraged as it can take the burdens away from the wallets.
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
 - Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.


### PR DESCRIPTION
**What**

This PR replaces Account Setup with Transaction Composition.

**Why**

SEP-8 was introduced before CAP-18 was introduced. The Account Setup section in the current SEP-8 has a few drawbacks as mentioned in CAP-18.
```
1. The owner of an account cannot unilaterally utilize assets unrelated to the issuer without the signature of that issuer
2. If multiple issuers want to become signers on a single account, then many signatures are potentially required for simple operations
3. Issuers cannot easily rotate keys, because their keys are on every account holding their asset
```

We are seeing a few active developments on regulated assets in the ecosystem, and we want to make sure the associated SEP is up-to-date and is easy to use without introducing breaking changes.

**Note**

This PR would have a version conflict with https://github.com/stellar/stellar-protocol/pull/816. One that gets merged first will have version `1.1.1`; one that gets merged later will have version `1.2.1`.