### PR TITLE
SEP-8: add meaning to zero timeout in the case of pending

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-07
-Version 1.0.1
+Updated: 2021-01-08
+Version 1.0.2
 ```
 
 ## Simple Summary
@@ -167,7 +167,7 @@ Parameters:
 Name | Type | Description
 -----|------|------------
 `status` | string | `"pending"`
-`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again.
+`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again. Use `0` if the wait time cannot be determined.
 `message` | string | (optional) A human readable string containing information to pass on to the user.
 
 ###### Example


### PR DESCRIPTION
**What**

Make `0` timeout mean that the issuer could not determine the timeout needed. 

**Why**

Issuers sometimes need to take extra steps before approving a transaction. Those steps may require manual actions.

In order to avoid breaking changes, we can use `0` to indicate the case where issuers couldn't determine the timeout at the time of returning the response. If we don't add this note, it can be misleading as `0` time might as well mean that the wallet/user can re-submit the transaction immediately.