### PR TITLE
CAP-0035: snapshot state in trustline and add claimable balances

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -63,7 +63,7 @@ assets in a manner that is fast, cheap, and highly usable.
 ## Abstract
 This proposal introduces new operations `ClawbackOp` and
 `ClawbackClaimableBalanceOp`, a new account flag
-`AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `CLAWBACK_ENABLED_FLAG,
+`AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `CLAWBACK_ENABLED_FLAG`,
 and a new claimable balance flag `CLAWBACK_ENABLED_FLAG`.
 
 The `AUTH_CLAWBACK_ENABLED_FLAG` flag on the issuing account must be set when a

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,7 +94,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..630b7b44 100644
+index 8d746391..bdfa4026 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,11 +99,14 @@ enum AccountFlags
@@ -142,7 +142,7 @@ index 8d746391..630b7b44 100644
 +    CLAWBACK_ENABLED_FLAG = 0x1
 +};
 +
-+const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1
++const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
 +
 +struct ClaimableBalanceEntryExtensionV1
 +{

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -326,9 +326,9 @@ clawback predicate of any claimable balance it creates.
 #### Account
 
 This proposal introduces a new flag to accounts,
-`AUTH_CLAWBACK_ENABLED_FLAG`. When the flag is set, trustlines created
-inherit the flag and the balances within those trustlines may be clawed back
-by the issuer.
+`AUTH_CLAWBACK_ENABLED_FLAG`. When the flag is set, trustlines created to the
+account inherit the flag and the balances within those trustlines may be
+clawed back by the issuer.
 
 An account may set or unset the flag using the existing `SetOptionsOp`
 operation, unless the `AUTH_IMMUTABLE_FLAG` flag is set, in the same way that

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -7,7 +7,7 @@ CAP: 0035
 Title: Asset Clawback
 Working Group:
     Owner: Tomer Weller <@tomerweller>
-    Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>
+    Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Siddarth Suresh <@sisuresh>
     Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Bartek Nowotarski <@bartekn>
 Status: Draft
 Created: 2020-12-14
@@ -76,9 +76,38 @@ operation.
 
 ### XDR changes
 
-This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b4137ca220fde4e609434f53` of [stellar-core].
+This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90b2780584c6390207bf09291212d606896ce9f8`) of [stellar-core].
 
 ```diff
+diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
+index 8d746391..40531108 100644
+--- a/src/xdr/Stellar-ledger-entries.x
++++ b/src/xdr/Stellar-ledger-entries.x
+@@ -99,7 +99,9 @@ enum AccountFlags
+     // otherwise, authorization cannot be revoked
+     AUTH_REVOCABLE_FLAG = 0x2,
+     // Once set, causes all AUTH_* flags to be read-only
+-    AUTH_IMMUTABLE_FLAG = 0x4
++    AUTH_IMMUTABLE_FLAG = 0x4,
++    // Trustlines are created with clawback enabled set to "true"
++    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
+ };
+ 
+ // mask for all valid flags
+@@ -187,7 +189,10 @@ enum TrustLineFlags
+     AUTHORIZED_FLAG = 1,
+     // issuer has authorized account to maintain and reduce liabilities for its
+     // credit
+-    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2
++    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
++    // issuer has specified that it may clawback its credit, and that claimable
++    // balances created with its credit must be claimable by the issuer
++    CLAWBACK_ENABLED = 3
+ };
+ 
+ // mask for all trustline flags
+diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
+index 7f08d757..f6546c74 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,8 @@ enum OperationType
@@ -131,7 +160,17 @@ This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b
      }
      body;
  };
-@@ -1120,6 +1147,28 @@ default:
+@@ -1025,7 +1052,8 @@ enum CreateClaimableBalanceResultCode
+     CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
+     CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
+     CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
+-    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
++    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5,
++    CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED = -6
+ };
+ 
+ union CreateClaimableBalanceResult switch (
+@@ -1120,6 +1148,28 @@ default:
      void;
  };
  
@@ -145,7 +184,7 @@ This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b
 +    // codes considered as "failure" for the operation
 +    CLAWBACK_MALFORMED = -1,
 +    CLAWBACK_NO_TRUST = -2,
-+    CLAWBACK_NOT_REVOCABLE = -3,
++    CLAWBACK_NOT_CLAWBACK_ENABLED = -3,
 +    CLAWBACK_UNDERFUNDED = -4
 +};
 +
@@ -160,7 +199,7 @@ This patch of XDR changes is based on the XDR files in commit `f60c329467f5f637b
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1225,8 @@ case opINNER:
+@@ -1176,6 +1226,8 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -179,25 +218,53 @@ network. Auth revocation freezes the full balance of an asset in an account, but
 clawback provides fine grain control and allows the issuer to take out of the
 account and destroy a specific amount of the asset. 
 
-In order to execute a clawback, an issuer account must have its `AUTH_REVOCABLE`
-flag set. Once set, the issuer submits a `ClawbackOp` operation specifying the
-`from` account containing the asset to be clawed back. This operation does not
-require the affected account’s signature. The transaction results in a change in
-balance to the recipient’s account. The amount of the asset clawed back is
-burned and is not sent to any other address. The issuer may reissue the asset to
-the same account or to another account if the intent of the clawback is to move
-the asset to another account.
+In order to execute a clawback of an amount in an account, an issuer account
+must have its `AUTH_CLAWBACK_ENABLED_FLAG` flag set when the account holding
+the asset created its trustline. The issuer submits a `ClawbackOp` operation
+specifying the `from` account containing the asset to be clawed back. This
+operation does not require the affected account’s signature. The transaction
+results in a change in balance to the recipient’s account. The amount of the
+asset clawed back is burned and is not sent to any other address. The issuer
+may reissue the asset to the same account or to another account if the intent
+of the clawback is to move the asset to another account.
+
+In order to execute a clawback of a claimable balance, the claimable balance
+must have been created with the issuer account included as a claimant with an
+unconditional predicate. An account that creates a trustline for the asset
+while the issuer account has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set is
+required to include the issuer as a claimant with an unconditional predicate
+of any claimable balance it creates.
 
 #### Account
 
-This proposal uses the existing `AUTH_REVOCABLE` flag in the issuer account
-`AccountFlags`. Existing behavior and meaning of the flag is unchanged.
+This proposal introduces a new flag to accounts,
+`AUTH_CLAWBACK_ENABLED_FLAG`. When the flag is set, trustlines created
+inherit the flag and the balances within those trustlines may be clawed back
+by the issuer.
+
+An account may set or unset the flag using the existing `SetOptionsOp`
+operation, unless the `AUTH_IMMUTABLE_FLAG` flag is set, in the same way that
+existing `AUTH_*` flags may be set or unset unless the immutable flag is set.
+
+#### Trustline
+
+This proposal introduces a new flag to trustlines, `CLAWBACK_ENABLED_FLAG`,
+that is set at the time the trustline is created if the issuer account of the
+asset of the trustline has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set.
+
+No functionality to change the flag is supplied.
+
+If the new flag is set it indicates that the balance held by the trustline
+can be clawed back by the issuer using the `ClawbackOp`, and that any
+claimable balance created by the account must have the issuer account
+included as an claimaint with an unconditional predicate.
 
 #### Clawback Operation
 
-The `ClawbackOp` operation reduces the balance of the asset in the account by
-the specified amount of the specific `asset` from the `from` account,
-effectively returning it to the issuer account, burning it.
+This proposal introduces the `ClawbackOp` operation. The `ClawbackOp`
+operation reduces the balance of the asset in the account by the specified
+amount of the specific `asset` from the `from` account, effectively returning
+it to the issuer account, burning it.
 
 Similar to other operations the clawback operation will fail if the account
 balance is less than the amount specified when account for selling liabilities.
@@ -226,6 +293,16 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.
 
+#### Create Claimable Balance Operation
+
+This proposal introduces a new failure case in the execution of the
+`CreateClaimableBalanceOp`. If the source account of the operation has a
+trustline to the asset with the `CLAWBACK_ENABLED_FLAG` flag set, the
+operation will fail with `CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED` if one
+of the `claimants` `destination` is not the issuer account of the asset, or
+if the issuer account is a claimant and the `predicate` is not
+`CLAIM_PREDICATE_UNCONDITIONAL`.
+
 ## Design Rationale
 
 In the event of regulatory action, erroneous transaction, or loss of custody,
@@ -240,15 +317,16 @@ in many cases should be reserved for licensed entities (like a transfer agent)
 holding the issuer credentials and aware of responsibilities under the law of 
 the jurisdiction of the affected party and asset. 
  
-### Reusing the AUTH_REVOCABLE flag
+### Flags and Trustlines
 
-The account `AUTH_REVOCABLE` flag allows the issuer to indicate that it has
-control over the use of the asset on the network. By including the
-`AUTH_REVOCABLE` flag in account flags, account owners may review the
-revocability of an asset issued by the issuer and have the choice to avoid this
-type of asset if they object to the implied trust in the issuer. Clawback is
-another form of an issuer revoking use of an asset with fine control over the
-exact amount that the issuer is taking out of active circulation.
+The account `AUTH_CLAWBACK_ENABLED_FLAG` flag allows the issuer to indicate
+that it has control over the use of the asset on the network. By including
+the flag in account flags, account owners may review the revocability of an
+asset issued by the issuer and have the choice to avoid this type of asset if
+they object to the implied trust in the issuer. By setting the
+`CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners have confidence
+that the clawback feature may not be enabled if it was not enabled when they
+created their trustline.
 
 ### Threshold
 
@@ -258,15 +336,10 @@ operation than an allow trust operation.
 
 ### Claimable Balances
 
-Claimable balances are already not revokable, so it seems consistent to not add
-functionality that allows them to be clawed back. We could explore additional
-changes to make claimable balances always claimable by their issuer if the
-issuer has the `AUTH_REVOCABLE` flag set. This problem is not solved by this
-proposal, but introduces nothing that prevents that functionality from being
-added in a future proposal. Any issuer issuing assets under strict regulation
-where claimable balances that cannot be clawed back are desireable could use
-`AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, introduced in CAP-18, and SEP-8 to
-approve individual transactions and prevent the creation of a claimable balance.
+Claimable balances are immutable and so any functionality to clawback a
+claimable balance is all or nothing. The clawback feature of claimable
+balances is proposed with the addition of a claimant to make the clawback
+capability explicit.
 
 ## Protocol Upgrade Transition
 
@@ -275,7 +348,12 @@ approve individual transactions and prevent the creation of a claimable balance.
 The change does not have an affect on previous assets, accounts, or transaction 
 structure. It should not cause a breaking change in existing implementations. 
 
-The new operations introduced are all reversable meaning that their use if
+Pre-authorized, pre-signed, or pre-planned transactions that create accounts,
+and create claimable balances, using assets that become clawback enabled
+could fail if those transactions did not include the issuer account as a
+claimant.
+
+The new operations introduced are all reversible meaning that their use if
 reversed has no impact on existing pre-signed or pre-authorized transactions
 involving the asset and the account that the clawback operates on.
  

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -61,7 +61,7 @@ exchange of assets, throughout the globe, enabling users to make payments betwee
 assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
-This proposal introduces new `ClawbackOp` and `ClawbackClaimableBalancesOp`
+This proposal introduces new `ClawbackOp` and `ClawbackClaimableBalanceOp`
 operations.
 
 The `AUTH_CLAWBACK_ENABLED_FLAG` flag on the issuing account must be set when a

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -307,7 +307,7 @@ must have its `AUTH_CLAWBACK_ENABLED_FLAG` flag set when the account holding
 the asset created its trustline. The issuer submits a `ClawbackOp` operation
 specifying the `from` account containing the asset to be clawed back. This
 operation does not require the affected account’s signature. The transaction
-results in a change in balance to the recipient’s accoun. The amount of the
+results in a change in balance to the recipient’s account. The amount of the
 asset clawed back is burned and is not sent to any other address. The issuer
 may reissue the asset to the same account or to another account if the intent
 of the clawback is to move the asset to another account.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -92,7 +92,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..28fd2d3c 100644
+index 8d746391..630b7b44 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,11 +99,14 @@ enum AccountFlags
@@ -129,25 +129,43 @@ index 8d746391..28fd2d3c 100644
  
  struct TrustLineEntry
  {
-@@ -291,7 +298,8 @@ enum ClaimPredicateType
-     CLAIM_PREDICATE_OR = 2,
-     CLAIM_PREDICATE_NOT = 3,
-     CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
--    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
-+    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5,
-+    CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK = 6
+@@ -337,6 +344,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
+     Hash v0;
  };
  
- union ClaimPredicate switch (ClaimPredicateType type)
-@@ -309,6 +317,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
- case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
-     int64 relBefore; // Seconds since closeTime of the ledger in which the
-                      // ClaimableBalanceEntry was created
-+case CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK:
-+    void;
++enum ClaimableBalanceFlags
++{
++    // If set, the issuer account of the asset held by the claimable balance may
++    // clawback the claimable balance
++    CLAWBACK_ENABLED_FLAG = 0x1
++};
++
++const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1
++
++struct ClaimableBalanceEntryExtensionV1
++{
++    uint32 flags; // see ClaimableBalanceFlags
++
++    union switch (int v)
++    {
++    case 0:
++        void;
++    }
++    ext;
++};
++
+ struct ClaimableBalanceEntry
+ {
+     // Unique identifier for this ClaimableBalanceEntry
+@@ -356,6 +384,8 @@ struct ClaimableBalanceEntry
+     {
+     case 0:
+         void;
++    case 1:
++        ClaimableBalanceEntryExtensionV1 v1;
+     }
+     ext;
  };
- 
- enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
 index 7f08d757..6c05c041 100644
 --- a/src/xdr/Stellar-transaction.x
@@ -317,11 +335,8 @@ may reissue the asset to the same account or to another account if the intent
 of the clawback is to move the asset to another account.
 
 In order to execute a clawback of a claimable balance, the claimable balance
-must have been created with the issuer account included as a claimant with an
-unconditional clawback predicate. An account that creates a trustline for the
-asset while the issuer account has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set
-is required to include the issuer as a claimant with an unconditional
-clawback predicate of any claimable balance it creates.
+must have been created by an account that has clawback enabled on its
+trustline.
 
 #### Account
 
@@ -342,8 +357,19 @@ asset of the trustline has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set.
 
 If the new flag is set it indicates that the balance held by the trustline
 can be clawed back by the issuer using the `ClawbackOp`, and that any
-claimable balance created by the account must have the issuer account
-included as an claimaint with an unconditional predicate.
+claimable balance created by the account will also be clawback enabled.
+
+### Claimable Balance
+
+This proposal introduces the first flag to claimable balances,
+`CLAWBACK_ENABLED_FLAG`, that is set at the time the claimable balance is
+created if the account creating the claimable balance has
+`CLAWBACK_ENABLED_FLAG` set on the trustline of the asset of the claimable
+balance.
+
+If the new flag is set it indicates that the balance held by the claimable
+balance can be clawed back by the issuer using the
+`ClawbackClaimableBalanceOp`.
 
 #### Allow Trust Operation
 
@@ -374,10 +400,6 @@ If the issuer wishes to allow the `from` account to continue utilizing the asset
 it can include another `AllowTrustOp` after the `ClawbackOp` to authorize the
 account once again.
 
-Similar to the limitations of the `AllowTrustOp`'s ability to revoke a trustline
-for an asset, the `ClawbackOp` can only affect a trustline held in an account,
-and not an asset held in a `BalanceEntry`.
-
 The clawback operation requires a medium threshold signature to authorize the
 operation.
 
@@ -391,16 +413,6 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.
 
-#### Create Claimable Balance Operation
-
-This proposal introduces a new failure case in the execution of the
-`CreateClaimableBalanceOp`. If the source account of the operation has a
-trustline to the asset with the `CLAWBACK_ENABLED_FLAG` flag set, the
-operation will fail with `CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED` if one
-of the `claimants` `destination` is not the issuer account of the asset, or
-if the issuer account is a claimant and the `predicate` is not
-`CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK`.
-
 #### Clawback Claimable Balance Operation
 
 This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
@@ -408,9 +420,7 @@ This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
 effectively returning the asset to the issuer account, burning it.
 
 The operation will only succeed if the claimable balance has in its
-`claimants` a claimant with:
-- its `destination` set to the issuer account.
-- and, its `predicate` set to include `UNCONDITIONAL_CLAWBACK`.
+`CLAWBACK_ENABLED_FLAG` set.
 
 The operation source account must be the issuer account of the asset held in
 the claimable balance.
@@ -424,8 +434,8 @@ Possible return values for the `ClawbackClaimableBalanceOp` are:
   malformed.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
   the issuer of the asset.
-- `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the claimants do not
-  include the source account with the `UNCONDITIONAL_CLAWBACK` predicate.
+- `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
+  `CLAWBACK_ENABLED_FLAG` is not set.
 
 ## Design Rationale
 
@@ -441,34 +451,46 @@ in many cases should be reserved for licensed entities (like a transfer agent)
 holding the issuer credentials and aware of responsibilities under the law of 
 the jurisdiction of the affected party and asset. 
  
-### Flags and Trustlines
+### Flags
 
 The account `AUTH_CLAWBACK_ENABLED_FLAG` flag allows the issuer to indicate
 that it has control over the use of the asset on the network. By including
 the flag in account flags, account owners may review the revocability of an
 asset issued by the issuer and have the choice to avoid this type of asset if
-they object to the implied trust in the issuer. By setting the
-`CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners have confidence
-that the clawback feature may not be enabled if it was not enabled when they
-created their trustline.
+they object to the implied trust in the issuer.
+
+By setting the `CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners
+have confidence that the clawback feature may not be enabled if it was not
+enabled when they created their trustline.
+
+By setting the `CLAWBACK_ENABLED_FLAG` flag on the claimable balance based on
+the state of the trustline of the account creating the claimable balance,
+account owners have confidence that the clawback feature may not be enabled
+for claimable balances they create if it was not enabled when they created
+their trustline.
 
 ### Threshold
 
 The clawback operations require a medium threshold signature because they are
-changing the balance of accounts changing the states of claimable balances
-and is more aligned with impact of a payment operation than an allow trust
-operation.
+changing the balance of accounts and changing the states of claimable
+balances and is more aligned with impact of a payment operation than an allow
+trust operation.
 
 ### Claimable Balances
 
 Claimable balances are immutable and so any functionality to clawback a
 claimable balance is all or nothing. The clawback feature of claimable
-balances is proposed with the addition of a claimant to make the clawback
-capability explicit. A separate operation is specified to ensure that
-clawback is transparent and highly visible in comparison to routine claiming
-of a claimable balance and to allow issuers that use claimable balances
-routinely to distinguish between claimable balances they can routinely claim
-and claimable balances they may clawback.
+balances is proposed with a flag so that it is explicit when a claimable
+balance can be clawed back. The flag state is inherited from the trustline of
+the account creating the claimable balance to ensure that the balance
+controlled by the account holder does not change clawback enabled status when
+moving between account and claimable balances.
+
+A separate operation is specified to ensure that clawback is transparent and
+highly visible in comparison to routine claiming of a claimable balance and
+to allow issuers that use claimable balances routinely to distinguish between
+claimable balances they can routinely claim and claimable balances they may
+clawback.
 
 ### Allow Trust Operation
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -436,7 +436,7 @@ Possible return values for the `ClawbackClaimableBalanceOp` are:
 ## Design Rationale
 
 In the event of regulatory action, erroneous transaction, or loss of custody,
-the issuer may conduct a clawback transaction if the `AUTH_REVOCABLE` flag is 
+the issuer may conduct a clawback transaction if the appropriate flags are 
 set. In the event of loss of custody, the affected party would need to 
 demonstrate they are the rightful owner of the account (usually through 
 reproofing KYC credentials or otherwise authenticating). On obtaining this 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -353,7 +353,7 @@ If the new flag is set it indicates that the balance held by the trustline
 can be clawed back by the issuer using the `ClawbackOp`, and that any
 claimable balance created by the account will also be clawback enabled.
 
-### Claimable Balance
+#### Claimable Balance
 
 This proposal introduces the first flag to claimable balances,
 `CLAWBACK_ENABLED_FLAG`, that is set at the time the claimable balance is

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -144,7 +144,7 @@ index 8d746391..3f887e79 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..8a55d046 100644
+index 7f08d757..6c05c041 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -158,6 +158,15 @@ index 7f08d757..8a55d046 100644
  };
  
  /* CreateAccount
+@@ -249,7 +251,7 @@ struct AllowTrustOp
+     }
+     asset;
+ 
+-    // 0, or any bitwise combination of TrustLineFlags
++    // 0, or any bitwise combination of the AUTHORIZED_* flags of TrustLineFlags
+     uint32 authorize;
+ };
+ 
 @@ -376,6 +378,41 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
@@ -211,17 +220,7 @@ index 7f08d757..8a55d046 100644
      }
      body;
  };
-@@ -915,7 +956,8 @@ enum AllowTrustResultCode
-                                     // source account does not require trust
-     ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
-     ALLOW_TRUST_CANT_REVOKE = -4,     // source account can't revoke trust,
--    ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
-+    ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
-+    ALLOW_TRUST_CANT_CHANGE_FLAG_CLAWBACK_ENABLED = -6 // changing the clawback enabled flag not allowed
- };
- 
- union AllowTrustResult switch (AllowTrustResultCode code)
-@@ -1025,7 +1067,8 @@ enum CreateClaimableBalanceResultCode
+@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
      CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
      CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
      CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
@@ -231,7 +230,7 @@ index 7f08d757..8a55d046 100644
  };
  
  union CreateClaimableBalanceResult switch (
-@@ -1120,6 +1163,49 @@ default:
+@@ -1120,6 +1162,49 @@ default:
      void;
  };
  
@@ -281,7 +280,7 @@ index 7f08d757..8a55d046 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1262,10 @@ case opINNER:
+@@ -1176,6 +1261,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -343,11 +342,15 @@ included as an claimaint with an unconditional predicate.
 
 #### Allow Trust Operation
 
-This proposal introduces a new failure case in the execution of the
-`AllowTrustOp` to ensure the new trustline flag is immutable. If the flag in
-an `AllowTrustOp` would, when applied, change the
-`AUTH_CLAWBACK_ENABLED_FLAG` of the trustline, the operation fails with new
-result code `ALLOW_TRUST_CANT_CHANGE_FLAG_CLAWBACK_ENABLED`.
+This proposal introduces no changes to the `AllowTrustOp` operation XDR, but
+the operation will not accept the `CLAWBACK_ENABLED_FLAG` as a valid flag
+that it will operate. The definition of what flags the operations supports
+will be limited to `AUTHORIZED_*` flags. When applying new flags to accounts
+the operation will not change the `CLAWBACK_ENABLED_FLAG`.
+
+If an `AllowTrustOp` operation is submitted with the `CLAWBACK_ENABLED_FLAG`
+set the operation will fail with the existing result code
+`ALLOW_TRUST_MALFORMED`.
 
 #### Clawback Operation
 
@@ -461,6 +464,13 @@ clawback is transparent and highly visible in comparison to routine claiming
 of a claimable balance and to allow issuers that use claimable balances
 routinely to distinguish between claimable balances they can routinely claim
 and claimable balances they may clawback.
+
+### Allow Trust Operation
+
+The `AllowTrustOp` is disallowed from operating on the new
+`CLAWBACK_ENABLED_FLAG` trustline flag because the flag is immutable.
+Additionally the `AllowTrustOp` operation is semantically intended to change
+authorization and clawback is outside it's scope.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -92,7 +92,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..537ccd44 100644
+index 8d746391..28fd2d3c 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,11 +99,14 @@ enum AccountFlags
@@ -119,7 +119,7 @@ index 8d746391..537ccd44 100644
 +    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
 +    // issuer has specified that it may clawback its credit, and that claimable
 +    // balances created with its credit must be claimable by the issuer
-+    CLAWBACK_ENABLED = 4
++    CLAWBACK_ENABLED_FLAG = 4
  };
  
  // mask for all trustline flags

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -369,12 +369,12 @@ balance can be clawed back by the issuer using the
 
 This proposal introduces no changes to the `AllowTrustOp` operation XDR, but
 the operation will not accept the `CLAWBACK_ENABLED_FLAG` as a valid flag
-that it will operate. The definition of what flags the operations supports
+that it will operate. The definition of what flags the operation supports
 will be limited to `AUTHORIZED_*` flags. When applying new flags to accounts
 the operation will not change the `CLAWBACK_ENABLED_FLAG`.
 
 If an `AllowTrustOp` operation is submitted with the `CLAWBACK_ENABLED_FLAG`
-set the operation will fail with the existing result code
+set, the operation will fail with the existing result code
 `ALLOW_TRUST_MALFORMED`.
 
 #### Clawback Operation

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -114,7 +114,7 @@ index 8d746391..e105fbc1 100644
 +    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
 +    // issuer has specified that it may clawback its credit, and that claimable
 +    // balances created with its credit must be claimable by the issuer
-+    CLAWBACK_ENABLED = 3
++    CLAWBACK_ENABLED = 4
  };
  
  // mask for all trustline flags

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,16 +94,18 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..bdfa4026 100644
+index 8d746391..5901e27e 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -99,11 +99,14 @@ enum AccountFlags
+@@ -99,11 +99,16 @@ enum AccountFlags
      // otherwise, authorization cannot be revoked
      AUTH_REVOCABLE_FLAG = 0x2,
      // Once set, causes all AUTH_* flags to be read-only
 -    AUTH_IMMUTABLE_FLAG = 0x4
 +    AUTH_IMMUTABLE_FLAG = 0x4,
-+    // Trustlines are created with clawback enabled set to "true"
++    // Trustlines are created with clawback enabled set to "true",
++    // and claimable balances created from those trustlines are created
++    // with clawback enabled set to "true"
 +    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
  };
  
@@ -113,14 +115,14 @@ index 8d746391..bdfa4026 100644
  
  // maximum number of signers
  const MAX_SIGNERS = 20;
-@@ -187,12 +190,16 @@ enum TrustLineFlags
+@@ -187,12 +192,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
 -    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2
 +    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
 +    // issuer has specified that it may clawback its credit, and that claimable
-+    // balances created with its credit must be claimable by the issuer
++    // balances created with its credit may also be clawed back
 +    CLAWBACK_ENABLED_FLAG = 4
  };
  
@@ -131,7 +133,7 @@ index 8d746391..bdfa4026 100644
  
  struct TrustLineEntry
  {
-@@ -337,6 +344,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
+@@ -337,6 +346,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
      Hash v0;
  };
  
@@ -159,7 +161,7 @@ index 8d746391..bdfa4026 100644
  struct ClaimableBalanceEntry
  {
      // Unique identifier for this ClaimableBalanceEntry
-@@ -356,6 +384,8 @@ struct ClaimableBalanceEntry
+@@ -356,6 +386,8 @@ struct ClaimableBalanceEntry
      {
      case 0:
          void;

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -474,9 +474,18 @@ and create claimable balances, using assets that become clawback enabled
 could fail if those transactions did not include the issuer account as a
 claimant.
 
-The new operations introduced are all reversible meaning that their use if
+The `ClawbackOp` operation introduced is reversible meaning that their use if
 reversed has no impact on existing pre-signed or pre-authorized transactions
 involving the asset and the account that the clawback operates on.
+
+The `ClawbackClaimableBalanceOp` operation is not reversible meaning that
+after their use there is no way to recreate the destroyed claimable balance
+with the same identifier. Pre-signed or pre-authorized transactions that
+claim the claimable balance will have encoded its identifier. Authors of
+contracts or systems utilizing pre-signed or pre-authorized transactions can
+identify that assets may be clawed back by inspecting the flags of the
+account that will create the claimable balance and the the flags of the
+issuer to understand if the issuer could enable clawback on new accounts.
  
 ### Resource Utilization
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -171,7 +171,7 @@ index 8d746391..5901e27e 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..f0348594 100644
+index 7f08d757..20e58cab 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -247,7 +247,7 @@ index 7f08d757..f0348594 100644
      }
      body;
  };
-@@ -1120,6 +1161,49 @@ default:
+@@ -1120,6 +1161,50 @@ default:
      void;
  };
  
@@ -260,9 +260,10 @@ index 7f08d757..f0348594 100644
 +
 +    // codes considered as "failure" for the operation
 +    CLAWBACK_MALFORMED = -1,
-+    CLAWBACK_NO_TRUST = -2,
++    CLAWBACK_NOT_ISSUER = -2,
 +    CLAWBACK_NOT_CLAWBACK_ENABLED = -3,
-+    CLAWBACK_UNDERFUNDED = -4
++    CLAWBACK_NO_TRUST = -4,
++    CLAWBACK_UNDERFUNDED = -5
 +};
 +
 +union ClawbackResult switch (ClawbackResultCode code)
@@ -297,7 +298,7 @@ index 7f08d757..f0348594 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1260,10 @@ case opINNER:
+@@ -1176,6 +1261,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -400,9 +401,11 @@ operation.
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
-- `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
+- `CLAWBACK_NOT_ISSUER` if the source account is the not the issuer of the
   `asset`.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
+- `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
+  `asset`.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.
 
@@ -426,7 +429,7 @@ Possible return values for the `ClawbackClaimableBalanceOp` are:
 - `CLAWBACK_CLAIMABLE_BALANCE_MALFORMED` if the `claimableBalanceId` value is
   malformed.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
-  the issuer of the asset.
+  the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
   `CLAWBACK_ENABLED_FLAG` is not set.
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -92,10 +92,10 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..3f887e79 100644
+index 8d746391..537ccd44 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -99,7 +99,9 @@ enum AccountFlags
+@@ -99,11 +99,14 @@ enum AccountFlags
      // otherwise, authorization cannot be revoked
      AUTH_REVOCABLE_FLAG = 0x2,
      // Once set, causes all AUTH_* flags to be read-only
@@ -106,7 +106,12 @@ index 8d746391..3f887e79 100644
  };
  
  // mask for all valid flags
-@@ -187,12 +189,16 @@ enum TrustLineFlags
+ const MASK_ACCOUNT_FLAGS = 0x7;
++const MASK_ACCOUNT_FLAGS_V16 = 0xF;
+ 
+ // maximum number of signers
+ const MAX_SIGNERS = 20;
+@@ -187,12 +190,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
@@ -124,7 +129,7 @@ index 8d746391..3f887e79 100644
  
  struct TrustLineEntry
  {
-@@ -291,7 +297,8 @@ enum ClaimPredicateType
+@@ -291,7 +298,8 @@ enum ClaimPredicateType
      CLAIM_PREDICATE_OR = 2,
      CLAIM_PREDICATE_NOT = 3,
      CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
@@ -134,7 +139,7 @@ index 8d746391..3f887e79 100644
  };
  
  union ClaimPredicate switch (ClaimPredicateType type)
-@@ -309,6 +316,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+@@ -309,6 +317,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
  case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
      int64 relBefore; // Seconds since closeTime of the ledger in which the
                       // ClaimableBalanceEntry was created

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -336,14 +336,18 @@ This proposal introduces a new flag to trustlines, `CLAWBACK_ENABLED_FLAG`,
 that is set at the time the trustline is created if the issuer account of the
 asset of the trustline has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set.
 
-No functionality to change the flag is supplied. `AllowTrustOp` errors with
-`` if applying the operation would change the state of the
-`CLAWBACK_ENABLED_FLAG`.
-
 If the new flag is set it indicates that the balance held by the trustline
 can be clawed back by the issuer using the `ClawbackOp`, and that any
 claimable balance created by the account must have the issuer account
 included as an claimaint with an unconditional predicate.
+
+#### Allow Trust Operation
+
+This proposal introduces a new failure case in the execution of the
+`AllowTrustOp` to ensure the new trustline flag is immutable. If the flag in
+an `AllowTrustOp` would, when applied, change the
+`AUTH_CLAWBACK_ENABLED_FLAG` of the trustline, the operation fails with new
+result code `ALLOW_TRUST_CANT_CHANGE_FLAG_CLAWBACK_ENABLED`.
 
 #### Clawback Operation
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -409,7 +409,7 @@ This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
 `ClawbackClaimableBalanceOp` operation destroys a claimable balance,
 effectively returning the asset to the issuer account, burning it.
 
-The operation will only succeed if the claimable balance has in its
+The operation will only succeed if the claimable balance has its
 `CLAWBACK_ENABLED_FLAG` set.
 
 The operation source account must be the issuer account of the asset held in

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -61,8 +61,10 @@ exchange of assets, throughout the globe, enabling users to make payments betwee
 assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
-This proposal introduces new `ClawbackOp` and `ClawbackClaimableBalanceOp`
-operations.
+This proposal introduces new operations `ClawbackOp` and
+`ClawbackClaimableBalanceOp`, a new account flag
+`AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `CLAWBACK_ENABLED_FLAG,
+and a new claimable balance flag `CLAWBACK_ENABLED_FLAG`.
 
 The `AUTH_CLAWBACK_ENABLED_FLAG` flag on the issuing account must be set when a
 trustline is created to authorize a `ClawbackOp` operation submitted by the

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -402,8 +402,7 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
   `asset`.
-- `CLAWBACK_NOT_REVOCABLE` if the `AUTH_REVOCABLE` flag is not set on the issuer
-  account.
+- `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
   available balance of `asset` after accounting for selling liabilities.
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -144,7 +144,7 @@ index 8d746391..3f887e79 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..64961b76 100644
+index 7f08d757..8a55d046 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -211,7 +211,17 @@ index 7f08d757..64961b76 100644
      }
      body;
  };
-@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
+@@ -915,7 +956,8 @@ enum AllowTrustResultCode
+                                     // source account does not require trust
+     ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
+     ALLOW_TRUST_CANT_REVOKE = -4,     // source account can't revoke trust,
+-    ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
++    ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
++    ALLOW_TRUST_CANT_CHANGE_FLAG_CLAWBACK_ENABLED = -6 // changing the clawback enabled flag not allowed
+ };
+ 
+ union AllowTrustResult switch (AllowTrustResultCode code)
+@@ -1025,7 +1067,8 @@ enum CreateClaimableBalanceResultCode
      CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
      CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
      CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
@@ -221,7 +231,7 @@ index 7f08d757..64961b76 100644
  };
  
  union CreateClaimableBalanceResult switch (
-@@ -1120,6 +1162,49 @@ default:
+@@ -1120,6 +1163,49 @@ default:
      void;
  };
  
@@ -271,7 +281,7 @@ index 7f08d757..64961b76 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1261,10 @@ case opINNER:
+@@ -1176,6 +1262,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -326,7 +336,9 @@ This proposal introduces a new flag to trustlines, `CLAWBACK_ENABLED_FLAG`,
 that is set at the time the trustline is created if the issuer account of the
 asset of the trustline has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set.
 
-No functionality to change the flag is supplied.
+No functionality to change the flag is supplied. `AllowTrustOp` errors with
+`` if applying the operation would change the state of the
+`CLAWBACK_ENABLED_FLAG`.
 
 If the new flag is set it indicates that the balance held by the trustline
 can be clawed back by the issuer using the `ClawbackOp`, and that any

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -80,7 +80,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..40531108 100644
+index 8d746391..e105fbc1 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,7 +99,9 @@ enum AccountFlags
@@ -106,21 +106,41 @@ index 8d746391..40531108 100644
  };
  
  // mask for all trustline flags
+@@ -291,7 +296,8 @@ enum ClaimPredicateType
+     CLAIM_PREDICATE_OR = 2,
+     CLAIM_PREDICATE_NOT = 3,
+     CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
+-    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
++    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5,
++    CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK = 6
+ };
+ 
+ union ClaimPredicate switch (ClaimPredicateType type)
+@@ -309,6 +315,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+ case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
+     int64 relBefore; // Seconds since closeTime of the ledger in which the
+                      // ClaimableBalanceEntry was created
++case CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK:
++    void;
+ };
+ 
+ enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..f6546c74 100644
+index 7f08d757..84ec559b 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -46,7 +46,8 @@ enum OperationType
+@@ -46,7 +46,9 @@ enum OperationType
      CLAIM_CLAIMABLE_BALANCE = 15,
      BEGIN_SPONSORING_FUTURE_RESERVES = 16,
      END_SPONSORING_FUTURE_RESERVES = 17,
 -    REVOKE_SPONSORSHIP = 18
 +    REVOKE_SPONSORSHIP = 18,
-+    CLAWBACK = 19
++    CLAWBACK = 19,
++    CLAWBACK_CLAIMABLE_BALANCE = 20
  };
  
  /* CreateAccount
-@@ -376,6 +377,30 @@ case REVOKE_SPONSORSHIP_SIGNER:
+@@ -376,6 +378,41 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
  
@@ -148,19 +168,32 @@ index 7f08d757..f6546c74 100644
 +    int64 amount;
 +};
 +
++/* Claws back a claimable balance
++
++    Threshold: med
++
++    Result: ClawbackClaimableBalanceResult
++*/
++struct ClawbackClaimableBalanceOp
++{
++    ClaimableBalanceID balanceID;
++};
++
  /* An operation is the lowest unit of work that a transaction does */
  struct Operation
  {
-@@ -424,6 +449,8 @@ struct Operation
+@@ -424,6 +461,10 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipOp revokeSponsorshipOp;
 +    case CLAWBACK:
 +        ClawbackOp clawbackOp;
++    case CLAWBACK_CLAIMABLE_BALANCE:
++        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
      }
      body;
  };
-@@ -1025,7 +1052,8 @@ enum CreateClaimableBalanceResultCode
+@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
      CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
      CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
      CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
@@ -170,7 +203,7 @@ index 7f08d757..f6546c74 100644
  };
  
  union CreateClaimableBalanceResult switch (
-@@ -1120,6 +1148,28 @@ default:
+@@ -1120,6 +1162,48 @@ default:
      void;
  };
  
@@ -196,15 +229,228 @@ index 7f08d757..f6546c74 100644
 +    void;
 +};
 +
++/******* ClawbackClaimableBalance Result ********/
++
++enum ClawbackClaimableBalanceResultCode
++{
++    // codes considered as "success" for the operation
++    CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
++
++    // codes considered as "failure" for the operation
++    CLAWBACK_CLAIMABLE_BALANCE_MALFORMED = -1,
++    CLAWBACK_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
++};
++
++union ClawbackClaimableBalanceResult switch (ClawbackClaimableBalanceResultCode code)
++{
++case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
++    void;
++default:
++    void;
++};
++
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1226,8 @@ case opINNER:
+@@ -1176,6 +1260,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
 +    case CLAWBACK:
 +        ClawbackResult clawbackResult;
++    case CLAWBACK_CLAIMABLE_BALANCE:
++        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
+     }
+     tr;
+ default:
+
+~/devel/stellar--stellar-core v15.1.0-cap-35 M 2 
+ΙΧΘΥΣ 
+
+~/devel/stellar--stellar-core v15.1.0-cap-35 M 2 
+ΙΧΘΥΣ g --no-pager diff
+diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
+index 8d746391..e105fbc1 100644
+--- a/src/xdr/Stellar-ledger-entries.x
++++ b/src/xdr/Stellar-ledger-entries.x
+@@ -99,7 +99,9 @@ enum AccountFlags
+     // otherwise, authorization cannot be revoked
+     AUTH_REVOCABLE_FLAG = 0x2,
+     // Once set, causes all AUTH_* flags to be read-only
+-    AUTH_IMMUTABLE_FLAG = 0x4
++    AUTH_IMMUTABLE_FLAG = 0x4,
++    // Trustlines are created with clawback enabled set to "true"
++    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
+ };
+ 
+ // mask for all valid flags
+@@ -187,7 +189,10 @@ enum TrustLineFlags
+     AUTHORIZED_FLAG = 1,
+     // issuer has authorized account to maintain and reduce liabilities for its
+     // credit
+-    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2
++    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
++    // issuer has specified that it may clawback its credit, and that claimable
++    // balances created with its credit must be claimable by the issuer
++    CLAWBACK_ENABLED = 3
+ };
+ 
+ // mask for all trustline flags
+@@ -291,7 +296,8 @@ enum ClaimPredicateType
+     CLAIM_PREDICATE_OR = 2,
+     CLAIM_PREDICATE_NOT = 3,
+     CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
+-    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
++    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5,
++    CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK = 6
+ };
+ 
+ union ClaimPredicate switch (ClaimPredicateType type)
+@@ -309,6 +315,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+ case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
+     int64 relBefore; // Seconds since closeTime of the ledger in which the
+                      // ClaimableBalanceEntry was created
++case CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK:
++    void;
+ };
+ 
+ enum ClaimantType
+diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
+index 7f08d757..64961b76 100644
+--- a/src/xdr/Stellar-transaction.x
++++ b/src/xdr/Stellar-transaction.x
+@@ -46,7 +46,9 @@ enum OperationType
+     CLAIM_CLAIMABLE_BALANCE = 15,
+     BEGIN_SPONSORING_FUTURE_RESERVES = 16,
+     END_SPONSORING_FUTURE_RESERVES = 17,
+-    REVOKE_SPONSORSHIP = 18
++    REVOKE_SPONSORSHIP = 18,
++    CLAWBACK = 19,
++    CLAWBACK_CLAIMABLE_BALANCE = 20
+ };
+ 
+ /* CreateAccount
+@@ -376,6 +378,41 @@ case REVOKE_SPONSORSHIP_SIGNER:
+     signer;
+ };
+ 
++/* Claws back an amount of an asset from an account
++
++    Threshold: med
++
++    Result: ClawbackResult
++*/
++struct ClawbackOp
++{
++    union switch (AssetType type)
++    {
++    // ASSET_TYPE_NATIVE is not allowed
++    case ASSET_TYPE_CREDIT_ALPHANUM4:
++        AssetCode4 assetCode4;
++
++    case ASSET_TYPE_CREDIT_ALPHANUM12:
++        AssetCode12 assetCode12;
++
++        // add other asset types here in the future
++    }
++    asset;
++    MuxedAccount from;
++    int64 amount;
++};
++
++/* Claws back a claimable balance
++
++    Threshold: med
++
++    Result: ClawbackClaimableBalanceResult
++*/
++struct ClawbackClaimableBalanceOp
++{
++    ClaimableBalanceID balanceID;
++};
++
+ /* An operation is the lowest unit of work that a transaction does */
+ struct Operation
+ {
+@@ -424,6 +461,10 @@ struct Operation
+         void;
+     case REVOKE_SPONSORSHIP:
+         RevokeSponsorshipOp revokeSponsorshipOp;
++    case CLAWBACK:
++        ClawbackOp clawbackOp;
++    case CLAWBACK_CLAIMABLE_BALANCE:
++        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
+     }
+     body;
+ };
+@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
+     CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
+     CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
+     CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
+-    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
++    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5,
++    CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED = -6
+ };
+ 
+ union CreateClaimableBalanceResult switch (
+@@ -1120,6 +1162,49 @@ default:
+     void;
+ };
+ 
++/******* Clawback Result ********/
++
++enum ClawbackResultCode
++{
++    // codes considered as "success" for the operation
++    CLAWBACK_SUCCESS = 0,
++
++    // codes considered as "failure" for the operation
++    CLAWBACK_MALFORMED = -1,
++    CLAWBACK_NO_TRUST = -2,
++    CLAWBACK_NOT_CLAWBACK_ENABLED = -3,
++    CLAWBACK_UNDERFUNDED = -4
++};
++
++union ClawbackResult switch (ClawbackResultCode code)
++{
++case CLAWBACK_SUCCESS:
++    void;
++default:
++    void;
++};
++
++/******* ClawbackClaimableBalance Result ********/
++
++enum ClawbackClaimableBalanceResultCode
++{
++    // codes considered as "success" for the operation
++    CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
++
++    // codes considered as "failure" for the operation
++    CLAWBACK_CLAIMABLE_BALANCE_MALFORMED = -1,
++    CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
++    CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
++};
++
++union ClawbackClaimableBalanceResult switch (ClawbackClaimableBalanceResultCode code)
++{
++case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
++    void;
++default:
++    void;
++};
++
+ /* High level Operation Result */
+ enum OperationResultCode
+ {
+@@ -1176,6 +1261,10 @@ case opINNER:
+         EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
+     case REVOKE_SPONSORSHIP:
+         RevokeSponsorshipResult revokeSponsorshipResult;
++    case CLAWBACK:
++        ClawbackResult clawbackResult;
++    case CLAWBACK_CLAIMABLE_BALANCE:
++        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
      }
      tr;
  default:
@@ -223,17 +469,17 @@ must have its `AUTH_CLAWBACK_ENABLED_FLAG` flag set when the account holding
 the asset created its trustline. The issuer submits a `ClawbackOp` operation
 specifying the `from` account containing the asset to be clawed back. This
 operation does not require the affected account’s signature. The transaction
-results in a change in balance to the recipient’s account. The amount of the
+results in a change in balance to the recipient’s accoun. The amount of the
 asset clawed back is burned and is not sent to any other address. The issuer
 may reissue the asset to the same account or to another account if the intent
 of the clawback is to move the asset to another account.
 
 In order to execute a clawback of a claimable balance, the claimable balance
 must have been created with the issuer account included as a claimant with an
-unconditional predicate. An account that creates a trustline for the asset
-while the issuer account has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set is
-required to include the issuer as a claimant with an unconditional predicate
-of any claimable balance it creates.
+unconditional clawback predicate. An account that creates a trustline for the
+asset while the issuer account has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set
+is required to include the issuer as a claimant with an unconditional
+clawback predicate of any claimable balance it creates.
 
 #### Account
 
@@ -301,7 +547,33 @@ trustline to the asset with the `CLAWBACK_ENABLED_FLAG` flag set, the
 operation will fail with `CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED` if one
 of the `claimants` `destination` is not the issuer account of the asset, or
 if the issuer account is a claimant and the `predicate` is not
-`CLAIM_PREDICATE_UNCONDITIONAL`.
+`CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK`.
+
+#### Clawback Claimable Balance Operation
+
+This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
+`ClawbackClaimableBalanceOp` operation destroys a claimable balance,
+effectively returning the asset to the issuer account, burning it.
+
+The operation will only succeed if the claimable balance has in its
+`claimants` a claimant with:
+- its `destination` set to the issuer account.
+- and, its `predicate` set to include `UNCONDITIONAL_CLAWBACK`.
+
+The operation source account must be the issuer account of the asset held in
+the claimable balance.
+
+The operation requires a medium threshold signature to authorize the
+operation.
+
+Possible return values for the `ClawbackClaimableBalanceOp` are:
+- `CLAWBACK_CLAIMABLE_BALANCE_SUCCESS` if the clawback is successful.
+- `CLAWBACK_CLAIMABLE_BALANCE_MALFORMED` if the `claimableBalanceId` value is
+  malformed.
+- `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
+  the issuer of the asset.
+- `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the claimants do not
+  include the source account with the `UNCONDITIONAL_CLAWBACK` predicate.
 
 ## Design Rationale
 
@@ -330,16 +602,21 @@ created their trustline.
 
 ### Threshold
 
-The clawback operation requires a medium threshold signature because it is
-changing the balance of an account and is more aligned with impact of a payment
-operation than an allow trust operation.
+The clawback operations require a medium threshold signature because they are
+changing the balance of accounts changing the states of claimable balances
+and is more aligned with impact of a payment operation than an allow trust
+operation.
 
 ### Claimable Balances
 
 Claimable balances are immutable and so any functionality to clawback a
 claimable balance is all or nothing. The clawback feature of claimable
 balances is proposed with the addition of a claimant to make the clawback
-capability explicit.
+capability explicit. A separate operation is specified to ensure that
+clawback is transparent and highly visible in comparison to routine claiming
+of a claimable balance and to allow issuers that use claimable balances
+routinely to distinguish between claimable balances they can routinely claim
+and claimable balances they may clawback.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -383,14 +383,14 @@ amount of the specific `asset` from the `from` account, effectively returning
 it to the issuer account, burning it.
 
 Similar to other operations the clawback operation will fail if the account
-balance is less than the amount specified when account for selling liabilities.
-If clawback is required of asset amounts locked up with selling liabilities then
-the issuer may use the `AllowTrustOp` operation to revoke authorization of the
-trustline, which will cancel any existing ledger entries creating selling
-liabilities, such as offers, and issue the `ClawbackOp` in the same transaction.
-If the issuer wishes to allow the `from` account to continue utilizing the asset
-it can include another `AllowTrustOp` after the `ClawbackOp` to authorize the
-account once again.
+balance is less than the amount specified when accounting for selling
+liabilities. If clawback is required of asset amounts locked up with selling
+liabilities then the issuer may use the `AllowTrustOp` operation to revoke
+authorization of the trustline, which will cancel any existing ledger entries
+creating selling liabilities, such as offers, and issue the `ClawbackOp` in
+the same transaction. If the issuer wishes to allow the `from` account to
+continue utilizing the asset it can include another `AllowTrustOp` after the
+`ClawbackOp` to authorize the account once again.
 
 The clawback operation requires a medium threshold signature to authorize the
 operation.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -92,7 +92,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..e105fbc1 100644
+index 8d746391..3f887e79 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,7 +99,9 @@ enum AccountFlags
@@ -106,7 +106,7 @@ index 8d746391..e105fbc1 100644
  };
  
  // mask for all valid flags
-@@ -187,7 +189,10 @@ enum TrustLineFlags
+@@ -187,12 +189,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
@@ -118,7 +118,13 @@ index 8d746391..e105fbc1 100644
  };
  
  // mask for all trustline flags
-@@ -291,7 +296,8 @@ enum ClaimPredicateType
+ const MASK_TRUSTLINE_FLAGS = 1;
+ const MASK_TRUSTLINE_FLAGS_V13 = 3;
++const MASK_TRUSTLINE_FLAGS_V16 = 7;
+ 
+ struct TrustLineEntry
+ {
+@@ -291,7 +297,8 @@ enum ClaimPredicateType
      CLAIM_PREDICATE_OR = 2,
      CLAIM_PREDICATE_NOT = 3,
      CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
@@ -128,197 +134,7 @@ index 8d746391..e105fbc1 100644
  };
  
  union ClaimPredicate switch (ClaimPredicateType type)
-@@ -309,6 +315,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
- case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
-     int64 relBefore; // Seconds since closeTime of the ledger in which the
-                      // ClaimableBalanceEntry was created
-+case CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK:
-+    void;
- };
- 
- enum ClaimantType
-diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..84ec559b 100644
---- a/src/xdr/Stellar-transaction.x
-+++ b/src/xdr/Stellar-transaction.x
-@@ -46,7 +46,9 @@ enum OperationType
-     CLAIM_CLAIMABLE_BALANCE = 15,
-     BEGIN_SPONSORING_FUTURE_RESERVES = 16,
-     END_SPONSORING_FUTURE_RESERVES = 17,
--    REVOKE_SPONSORSHIP = 18
-+    REVOKE_SPONSORSHIP = 18,
-+    CLAWBACK = 19,
-+    CLAWBACK_CLAIMABLE_BALANCE = 20
- };
- 
- /* CreateAccount
-@@ -376,6 +378,41 @@ case REVOKE_SPONSORSHIP_SIGNER:
-     signer;
- };
- 
-+/* Claws back an amount of an asset from an account
-+
-+    Threshold: med
-+
-+    Result: ClawbackResult
-+*/
-+struct ClawbackOp
-+{
-+    union switch (AssetType type)
-+    {
-+    // ASSET_TYPE_NATIVE is not allowed
-+    case ASSET_TYPE_CREDIT_ALPHANUM4:
-+        AssetCode4 assetCode4;
-+
-+    case ASSET_TYPE_CREDIT_ALPHANUM12:
-+        AssetCode12 assetCode12;
-+
-+        // add other asset types here in the future
-+    }
-+    asset;
-+    MuxedAccount from;
-+    int64 amount;
-+};
-+
-+/* Claws back a claimable balance
-+
-+    Threshold: med
-+
-+    Result: ClawbackClaimableBalanceResult
-+*/
-+struct ClawbackClaimableBalanceOp
-+{
-+    ClaimableBalanceID balanceID;
-+};
-+
- /* An operation is the lowest unit of work that a transaction does */
- struct Operation
- {
-@@ -424,6 +461,10 @@ struct Operation
-         void;
-     case REVOKE_SPONSORSHIP:
-         RevokeSponsorshipOp revokeSponsorshipOp;
-+    case CLAWBACK:
-+        ClawbackOp clawbackOp;
-+    case CLAWBACK_CLAIMABLE_BALANCE:
-+        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-     }
-     body;
- };
-@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
-     CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
-     CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
-     CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
--    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
-+    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5,
-+    CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED = -6
- };
- 
- union CreateClaimableBalanceResult switch (
-@@ -1120,6 +1162,48 @@ default:
-     void;
- };
- 
-+/******* Clawback Result ********/
-+
-+enum ClawbackResultCode
-+{
-+    // codes considered as "success" for the operation
-+    CLAWBACK_SUCCESS = 0,
-+
-+    // codes considered as "failure" for the operation
-+    CLAWBACK_MALFORMED = -1,
-+    CLAWBACK_NO_TRUST = -2,
-+    CLAWBACK_NOT_CLAWBACK_ENABLED = -3,
-+    CLAWBACK_UNDERFUNDED = -4
-+};
-+
-+union ClawbackResult switch (ClawbackResultCode code)
-+{
-+case CLAWBACK_SUCCESS:
-+    void;
-+default:
-+    void;
-+};
-+
-+/******* ClawbackClaimableBalance Result ********/
-+
-+enum ClawbackClaimableBalanceResultCode
-+{
-+    // codes considered as "success" for the operation
-+    CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
-+
-+    // codes considered as "failure" for the operation
-+    CLAWBACK_CLAIMABLE_BALANCE_MALFORMED = -1,
-+    CLAWBACK_CLAIMABLE_BALANCE_CANNOT_CLAIM = -2,
-+};
-+
-+union ClawbackClaimableBalanceResult switch (ClawbackClaimableBalanceResultCode code)
-+{
-+case CLAWBACK_CLAIMABLE_BALANCE_SUCCESS:
-+    void;
-+default:
-+    void;
-+};
-+
- /* High level Operation Result */
- enum OperationResultCode
- {
-@@ -1176,6 +1260,10 @@ case opINNER:
-         EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
-     case REVOKE_SPONSORSHIP:
-         RevokeSponsorshipResult revokeSponsorshipResult;
-+    case CLAWBACK:
-+        ClawbackResult clawbackResult;
-+    case CLAWBACK_CLAIMABLE_BALANCE:
-+        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-     }
-     tr;
- default:
-
-~/devel/stellar--stellar-core v15.1.0-cap-35 M 2 
-ΙΧΘΥΣ 
-
-~/devel/stellar--stellar-core v15.1.0-cap-35 M 2 
-ΙΧΘΥΣ g --no-pager diff
-diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..e105fbc1 100644
---- a/src/xdr/Stellar-ledger-entries.x
-+++ b/src/xdr/Stellar-ledger-entries.x
-@@ -99,7 +99,9 @@ enum AccountFlags
-     // otherwise, authorization cannot be revoked
-     AUTH_REVOCABLE_FLAG = 0x2,
-     // Once set, causes all AUTH_* flags to be read-only
--    AUTH_IMMUTABLE_FLAG = 0x4
-+    AUTH_IMMUTABLE_FLAG = 0x4,
-+    // Trustlines are created with clawback enabled set to "true"
-+    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
- };
- 
- // mask for all valid flags
-@@ -187,7 +189,10 @@ enum TrustLineFlags
-     AUTHORIZED_FLAG = 1,
-     // issuer has authorized account to maintain and reduce liabilities for its
-     // credit
--    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2
-+    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
-+    // issuer has specified that it may clawback its credit, and that claimable
-+    // balances created with its credit must be claimable by the issuer
-+    CLAWBACK_ENABLED = 3
- };
- 
- // mask for all trustline flags
-@@ -291,7 +296,8 @@ enum ClaimPredicateType
-     CLAIM_PREDICATE_OR = 2,
-     CLAIM_PREDICATE_NOT = 3,
-     CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME = 4,
--    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5
-+    CLAIM_PREDICATE_BEFORE_RELATIVE_TIME = 5,
-+    CLAIM_PREDICATE_UNCONDITIONAL_CLAWBACK = 6
- };
- 
- union ClaimPredicate switch (ClaimPredicateType type)
-@@ -309,6 +315,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
+@@ -309,6 +316,8 @@ case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
  case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
      int64 relBefore; // Seconds since closeTime of the ledger in which the
                       // ClaimableBalanceEntry was created

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -167,7 +167,7 @@ index 8d746391..630b7b44 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..6c05c041 100644
+index 7f08d757..f0348594 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -243,17 +243,7 @@ index 7f08d757..6c05c041 100644
      }
      body;
  };
-@@ -1025,7 +1066,8 @@ enum CreateClaimableBalanceResultCode
-     CREATE_CLAIMABLE_BALANCE_LOW_RESERVE = -2,
-     CREATE_CLAIMABLE_BALANCE_NO_TRUST = -3,
-     CREATE_CLAIMABLE_BALANCE_NOT_AUTHORIZED = -4,
--    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5
-+    CREATE_CLAIMABLE_BALANCE_UNDERFUNDED = -5,
-+    CREATE_CLAIMABLE_BALANCE_CLAWBACK_REQUIRED = -6
- };
- 
- union CreateClaimableBalanceResult switch (
-@@ -1120,6 +1162,49 @@ default:
+@@ -1120,6 +1161,49 @@ default:
      void;
  };
  
@@ -303,7 +293,7 @@ index 7f08d757..6c05c041 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1261,10 @@ case opINNER:
+@@ -1176,6 +1260,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -61,15 +61,27 @@ exchange of assets, throughout the globe, enabling users to make payments betwee
 assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
-This proposal introduces a new `ClawbackOp` operation. The `AUTH_REVOCABLE`
-flag on the issuing account must be set to authorize a `ClawbackOp` operation
-submitted by the Issuing account.  The `ClawbackOp` operation results in the
-removal of the specified assets issued from the designated account. The
-`ClawbackOp` operation only applies to assets issued by the source account.
-Assets that are revocable can be easily distinguished from traditional
-blockchain assets (bearer instruments) so that asset owners are aware of rights.
-The transaction may result in revocation of some or all of the specified assets
-from the designated account based on the amount provided in the `ClawbackOp`
+This proposal introduces new `ClawbackOp` and `ClawbackClaimableBalancesOp`
+operations.
+
+The `AUTH_CLAWBACK_ENABLED_FLAG` flag on the issuing account must be set when a
+trustline is created to authorize a `ClawbackOp` operation submitted by the
+issuer account.
+
+A claimable balance inherits its clawback enabled status from the account
+creating it and a `ClawbackClaimableBalanceOp` operation is only valid for
+claimable balances created from accounts that have clawback enabled.
+
+The `ClawbackOp` and `ClawbackClaimableBalanceOp` operations result in the
+removal of the specified assets issued from the network.
+
+The `ClawbackOp` and `ClawbackClaimableBalanceOp` operations only apply to
+assets issued by the source account. Assets that can be clawed back are easily
+distinguished from traditional blockchain assets (bearer instruments) so that
+asset owners are aware of rights.
+
+The `ClawbackOp` may result in revocation of some or all of the specified
+assets from the designated account based on the amount provided in the
 operation.
 
 ## Specification


### PR DESCRIPTION
### What
Store a snapshot of the state of whether a trustline is clawbackable in the trustline itself, rather than storing it only in the account. Also, add a new operation for clawing back claimable balances.

These changes are based on the proposal by @sisuresh [here](https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/UFJsWcdqCQAJ), but the inclusion of a separate operation is an idea @jonjove shared with me.

### Why
These changes incorporate the latest ideas from the mailing list. There are two commits, the first commit keeps to what was on the mailing list and the second commit extends with the additional clawback operation for claimable balances that keep the operations used for clawing back explicit.