### PR TITLE
SEP-12: Added Binary Data Types section under Content Type section

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -58,11 +58,17 @@ All endpoints accept in requests the following `Content-Type`s:
 - `application/x-www-form-urlencoded`
 - `application/json`
 
-`multipart/form-data` should be used for requests including binary data type values from [SEP-9](sep-0009.md). Any of the above encoding schemes may be used when requests do not include binary data.
-
 All endpoints respond with content type:
 
 - `application/json`
+
+### Binary Data Types
+
+`multipart/form-data` or `application/json` should be used for requests including binary data type values from [SEP-9](sep-0009.md). 
+
+If `application/json` is used, values for the binary data type attributes must be objects containing `data` and `content_type` keys, where the `data` is base64-encoded. See the [PUT /customer](#customer-put) section for request examples. 
+
+Any of the above encoding schemes may be used when requests do not include binary data.
 
 ## Customer GET
 
@@ -226,6 +232,12 @@ PUT [KYC_SERVER || TRANSFER_SERVER]/customer
 ### Request
 
 ```
+Content-Type: application/x-www-form-urlencoded
+
+account=GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6&memo=21bf91a4-7db1-401d-8108-fab7660a45d6&memo_type=text
+```
+
+```
 Content-Type: multipart/form-data;boundary="boundary"
 
 --boundary
@@ -240,13 +252,17 @@ Content-Disposition: form-data; name="memo"
 Content-Disposition: form-data; name="memo_type"
 
 text
+--boundary
+Content-Disposition: form-data; name="photo_id_front"; filename="id_front.png"
+Content-Type: image/png
+
+...contents of id_front.png...
+--boundary
+Content-Disposition: form-data; name="photo_id_back"; filename="id_back.png"
+Content-Type: image/png
+
+...contents of id_back.png...
 --boundary--
-```
-
-```
-Content-Type: application/x-www-form-urlencoded
-
-account=GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6&memo=21bf91a4-7db1-401d-8108-fab7660a45d6&memo_type=text
 ```
 
 ```
@@ -255,7 +271,16 @@ Content-Type: application/json
 {
    "account":"GBORFR3GDNVZ5PLUTBDQHKGWVD26CQUHORO2T3SDQ2JPLGLUJCCA5GK6",
    "memo":"21bf91a4-7db1-401d-8108-fab7660a45d6",
-   "memo_type":"text"
+   "memo_type":"text",
+   "photo_id_front": {
+      "data": "VGhpcyB0ZXh0IHJlcHJlc2VudHMgYmluYXJ5IGltYWdlIGRhdGE=",
+      "content_type": "image/png"
+   },
+   "photo_id_back": {
+      "data": "VGhpcyB0ZXh0IHJlcHJlc2VudHMgYmluYXJ5IGltYWdlIGRhdGE=",
+      "content_type": "image/png"
+   },
+   ""
 }
 ```
 
@@ -268,7 +293,7 @@ Name | Type | Description
 
 The wallet should also transmit one or more of the fields listed in [SEP-9](./sep-0009.md), depending on what the anchor has indicated it needs.
 
-When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
+When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields** when using `multipart/form-data`. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
 
 ### Response
 


### PR DESCRIPTION
originally discussed in [#783](https://github.com/stellar/stellar-protocol/pull/783#discussion_r556693629), `application/json` can be used to send binary data if that data is base64-encoded. 

Once the referenced PR is merged, a `Nested Data Types` subsection should be added to point out that `application/json` data should be used when SEP-9 attributes cannot be encoded in a standardized manner (i.e. sub-objects, arrays).

Once this PR is merged, I will create issues for SEP-6, 8, 24, and 31 containing the same information.