### PR TITLE
CAP-0029: Remove typo

### DIFF
--- a/core/cap-0029.md
+++ b/core/cap-0029.md
@@ -16,7 +16,7 @@ This CAP addresses the following authorization semantics requirements:
 - An issuer should always be able to revoke a trustline for an asset that is set as revocable.
 
 ## Motivation
-Trustline authorization is an important feature of the Stellar protocol. It allows issuers to handle various regulatory requirements. However, it's current behavior is not sensible with regards to to configuration changes and revocable assets:
+Trustline authorization is an important feature of the Stellar protocol. It allows issuers to handle various regulatory requirements. However, it's current behavior is not sensible with regards to configuration changes and revocable assets:
 - The authorize (`ALLOW_TRUST, Authorize=true`) operation fails if the issuer does not have any flags set, even when the trustline is unauthorized. This complicates asset configuration changes.
 - The revoke (`ALLOW_TRUST, Authorize=false`) operation fails if the issuer does not have the `AUTH_REQUIRED` flag set. This defeats the purpose of having revocable assets that default to authorized trustlines ("Blacklist authorization"). 
 


### PR DESCRIPTION
### What
Remove an extra word that looks like a typo.

### Why
Just noticed while reading. It's not a big deal, just thought I'd fix it.