### PR TITLE
CAP-0035: Replace Bartek with Eric in the Consulted role of the working group

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -8,7 +8,7 @@ Title: Asset Clawback
 Working Group:
     Owner: Tomer Weller <@tomerweller>
     Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Siddarth Suresh <@sisuresh>
-    Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Bartek Nowotarski <@bartekn>
+    Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Eric Saunders <@ire-and-curses>
 Status: Draft
 Created: 2020-12-14
 Discussion: https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/ZF6eJcqKAgAJ


### PR DESCRIPTION
### What
Replace Bartek (@bartekn) with Eric (@ire-and-curses) in the Consulted role of the working group.

### Why
I added Bartek while Eric was unavailable, but now Eric is heavily involved and reviewing this from a Horizon and SDK perspective, and this change reflects reality.