### PR TITLE
CAP-0029: Define the working group

### DIFF
--- a/core/cap-0029.md
+++ b/core/cap-0029.md
@@ -3,7 +3,10 @@
 ```
 CAP: 0029
 Title: AllowTrust when not AUTH_REQUIRED
-Author: Tomer Weller
+Working Group:
+    Owner: Tomer Weller <@tomerweller>
+    Authors: Tomer Weller <@tomerweller>
+    Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Eric Saunders <@ire-and-curses>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2019-12-13
 Discussion: https://groups.google.com/d/msg/stellar-dev/igkJhpPUm-g/7k_3v6SKBQAJ


### PR DESCRIPTION
### What
Define the working group for CAP-29.

### Why
It is currently undefined and implicit. It's worth making it explicit.

### Notes
@tomerweller I made some assumptions about who should be consulted and included two people who work on Core and two people who work on the layers above Core. Let me know if you'd prefer different people named.