### PR TITLE
SEP-0008: support CORS header

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-11
-Version 1.3.1
+Updated: 2021-01-15
+Version 1.4.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -101,6 +101,14 @@ Approval server is a single endpoint that receives a signed transaction, checks 
 
 The specification of an approval server is defined as follows:
 
+### Cross-Origin Headers
+
+Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for the endpoint on the approval server, including error responses.
+
+```
+Access-Control-Allow-Origin: *
+```
+
 ### Content Type
 
 Approval server accepts requests in the following `Content-Type`s:

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -103,7 +103,7 @@ The specification of an approval server is defined as follows:
 
 ### Cross-Origin Headers
 
-Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for the endpoint on the approval server, including error responses.
+Cross-origin requests to the endpoints in this specification must be supported by the server so that web clients from other sites can use the endpoint(s). Valid CORS headers and requests that allow any domain origin to access the endpoints in this specification are necessary. The following HTTP header and support of preflight OPTIONS requests are the smallest change necessary. More complex headers configurations can be used.
 
 ```
 Access-Control-Allow-Origin: *


### PR DESCRIPTION
**What**

Add support for CORS header.

**Why**

CORS requests should be supported by the endpoint so that web apps on other domains can hit them cross-domain.

Closes #823 

cc @shredding @dmgmyza