### PR TITLE
CAP-0035: changes from the Open Protocol Meeting held on 2020-01-14

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,7 +94,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..5901e27e 100644
+index 8d746391..11ad933b 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -99,11 +99,16 @@ enum AccountFlags
@@ -148,14 +148,14 @@ index 8d746391..5901e27e 100644
 +
 +struct ClaimableBalanceEntryExtensionV1
 +{
-+    uint32 flags; // see ClaimableBalanceFlags
-+
 +    union switch (int v)
 +    {
 +    case 0:
 +        void;
 +    }
 +    ext;
++
++    uint32 flags; // see ClaimableBalanceFlags
 +};
 +
  struct ClaimableBalanceEntry

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,10 +94,28 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..11ad933b 100644
+index 8d746391..a272f744 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -99,11 +99,16 @@ enum AccountFlags
+@@ -21,6 +21,17 @@ typedef opaque AssetCode4[4];
+ // 5-12 alphanumeric characters right-padded with 0 bytes
+ typedef opaque AssetCode12[12];
+ 
++union AssetCode switch (AssetType type)
++{
++case ASSET_TYPE_CREDIT_ALPHANUM4:
++    AssetCode4 assetCode4;
++
++case ASSET_TYPE_CREDIT_ALPHANUM12:
++    AssetCode12 assetCode12;
++
++    // add other asset types here in the future
++};
++
+ enum AssetType
+ {
+     ASSET_TYPE_NATIVE = 0,
+@@ -99,11 +110,16 @@ enum AccountFlags
      // otherwise, authorization cannot be revoked
      AUTH_REVOCABLE_FLAG = 0x2,
      // Once set, causes all AUTH_* flags to be read-only
@@ -115,7 +133,7 @@ index 8d746391..11ad933b 100644
  
  // maximum number of signers
  const MAX_SIGNERS = 20;
-@@ -187,12 +192,16 @@ enum TrustLineFlags
+@@ -187,12 +203,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
@@ -133,7 +151,7 @@ index 8d746391..11ad933b 100644
  
  struct TrustLineEntry
  {
-@@ -337,6 +346,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
+@@ -337,6 +357,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
      Hash v0;
  };
  
@@ -161,7 +179,7 @@ index 8d746391..11ad933b 100644
  struct ClaimableBalanceEntry
  {
      // Unique identifier for this ClaimableBalanceEntry
-@@ -356,6 +386,8 @@ struct ClaimableBalanceEntry
+@@ -356,6 +397,8 @@ struct ClaimableBalanceEntry
      {
      case 0:
          void;
@@ -171,7 +189,7 @@ index 8d746391..11ad933b 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..20e58cab 100644
+index 7f08d757..b7e76a1d 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -185,16 +203,30 @@ index 7f08d757..20e58cab 100644
  };
  
  /* CreateAccount
-@@ -249,7 +251,7 @@ struct AllowTrustOp
-     }
-     asset;
+@@ -236,20 +238,9 @@ struct ChangeTrustOp
+ struct AllowTrustOp
+ {
+     AccountID trustor;
+-    union switch (AssetType type)
+-    {
+-    // ASSET_TYPE_NATIVE is not allowed
+-    case ASSET_TYPE_CREDIT_ALPHANUM4:
+-        AssetCode4 assetCode4;
+-
+-    case ASSET_TYPE_CREDIT_ALPHANUM12:
+-        AssetCode12 assetCode12;
+-
+-        // add other asset types here in the future
+-    }
+-    asset;
++    AssetCode asset;
  
 -    // 0, or any bitwise combination of TrustLineFlags
 +    // 0, or any bitwise combination of the AUTHORIZED_* flags of TrustLineFlags
      uint32 authorize;
  };
  
-@@ -376,6 +378,41 @@ case REVOKE_SPONSORSHIP_SIGNER:
+@@ -376,6 +367,30 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
  
@@ -206,18 +238,7 @@ index 7f08d757..20e58cab 100644
 +*/
 +struct ClawbackOp
 +{
-+    union switch (AssetType type)
-+    {
-+    // ASSET_TYPE_NATIVE is not allowed
-+    case ASSET_TYPE_CREDIT_ALPHANUM4:
-+        AssetCode4 assetCode4;
-+
-+    case ASSET_TYPE_CREDIT_ALPHANUM12:
-+        AssetCode12 assetCode12;
-+
-+        // add other asset types here in the future
-+    }
-+    asset;
++    AssetCode asset;
 +    MuxedAccount from;
 +    int64 amount;
 +};
@@ -236,7 +257,7 @@ index 7f08d757..20e58cab 100644
  /* An operation is the lowest unit of work that a transaction does */
  struct Operation
  {
-@@ -424,6 +461,10 @@ struct Operation
+@@ -424,6 +439,10 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipOp revokeSponsorshipOp;
@@ -247,7 +268,7 @@ index 7f08d757..20e58cab 100644
      }
      body;
  };
-@@ -1120,6 +1161,50 @@ default:
+@@ -1120,6 +1139,50 @@ default:
      void;
  };
  
@@ -298,7 +319,7 @@ index 7f08d757..20e58cab 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1261,10 @@ case opINNER:
+@@ -1176,6 +1239,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -350,6 +350,9 @@ asset clawed back is burned and is not sent to any other address. The issuer
 may reissue the asset to the same account or to another account if the intent
 of the clawback is to move the asset to another account.
 
+If an issuer wishes to set `AUTH_CLAWBACK_ENABLED_FLAG`, it must also have
+`AUTH_REVOCABLE_FLAG` set.
+
 In order to execute a clawback of a claimable balance, the claimable balance
 must have been created by an account that has clawback enabled on its
 trustline.
@@ -398,6 +401,19 @@ the operation will not change the `CLAWBACK_ENABLED_FLAG`.
 If an `AllowTrustOp` operation is submitted with the `CLAWBACK_ENABLED_FLAG`
 set, the operation will fail with the existing result code
 `ALLOW_TRUST_MALFORMED`.
+
+#### Set Options Operation
+
+This proposal introduces no changes to the `SetOptionsOp` operation XDR, but
+the operation will require the `AUTH_REVOCABLE_FLAG` flag to be set whenever
+the `AUTH_CLAWBACK_ENABLED_FLAG` flag is set.
+
+This introduces a failing result in these cases:
+
+1. Setting only `AUTH_CLAWBACK_ENABLED_FLAG` without `AUTH_REVOCABLE_FLAG`
+   already set will result in `SET_OPTIONS_BAD_FLAGS`.
+2. Clearing `AUTH_REVOCABLE_FLAG` while `AUTH_CLAWBACK_ENABLED_FLAG` is set
+   will result in `SET_OPTIONS_BAD_FLAGS`.
 
 #### Clawback Operation
 
@@ -475,6 +491,12 @@ that it has control over the use of the asset on the network. By including
 the flag in account flags, account owners may review the revocability of an
 asset issued by the issuer and have the choice to avoid this type of asset if
 they object to the implied trust in the issuer.
+
+The account `AUTH_REVOCABLE_FLAG` flag must also be set because for clawback
+to succeed in all cases that an account holds an asset, the issuer must be
+able to revoke authorization to release any offers creating selling
+liabilities with the asset. If an issuer enables clawback but not
+`AUTH_REVOCABLE_FLAG` it will likely be oversight.
 
 By setting the `CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners
 have confidence that the clawback feature may not be enabled if it was not


### PR DESCRIPTION
### What
Changes:
- Move extensions at top of new ledger entry structs to top rather than bottom.
- Define shared non-native asset code type to use in AllowTrustOp and new ops.
- Require that both are set auth revocable and auth clawback.

### Why
These change were decided in the [Open Protocol Meeting held on 2020-01-14].

Moving the extensions to the top of new ledger entry structs gives greater freedom to how extensions are applied in the future.

Defining a shared asset code definition simplifies the existing `AllowTrustOp` and the new `ClawbackOp`.

Requiring that `AUTH_REVOCABLE_FLAG` is set whenever `AUTH_CLAWBACK_ENABLED_FLAG` is set makes it harder for issuers to configure issuer accounts in such a way that they would be unable to clawback assets held by the selling liabilities of offers.

See the design rationale within for further discussion.

[Open Protocol Meeting held on 2020-01-14]: https://www.youtube.com/watch?v=TMV3V2LLYME