### PR TITLE
CAP-0035: remove _MALFORMED and add _DOES_NOT_EXIST

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -437,7 +437,7 @@ operation.
 
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
-- `CLAWBACK_MALFORMED` if `amount` is < 1.
+- `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NOT_ISSUER` if the source account is the not the issuer of the
   `asset`.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -422,9 +422,9 @@ which will be returned if `AUTH_REVOCABLE_FLAG` flag is not set whenever the
 This introduces a failing result in these cases:
 
 1. Setting only `AUTH_CLAWBACK_ENABLED_FLAG` without `AUTH_REVOCABLE_FLAG`
-   already set will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
+already set will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
 2. Clearing `AUTH_REVOCABLE_FLAG` while `AUTH_CLAWBACK_ENABLED_FLAG` is set
-   will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
+will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
 
 #### Clawback Operation
 
@@ -450,12 +450,12 @@ Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NOT_ISSUER` if the source account is the not the issuer of the
-  `asset`.
+`asset`.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
-  `asset`.
+`asset`.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
-  available balance of `asset` after accounting for selling liabilities.
+available balance of `asset` after accounting for selling liabilities.
 
 #### Clawback Claimable Balance Operation
 
@@ -479,12 +479,12 @@ same way it is freed when any sponsored ledger entry is removed.
 
 Possible return values for the `ClawbackClaimableBalanceOp` are:
 - `CLAWBACK_CLAIMABLE_BALANCE_SUCCESS` if the clawback is successful.
-- `CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST` if the claimable balance does not
-exist.
+- `CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST` if the claimable balance does
+not exist.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
-  the issuer of the `asset`.
+the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
-  `CLAWBACK_ENABLED_FLAG` is not set.
+`CLAWBACK_ENABLED_FLAG` is not set.
 
 ## Design Rationale
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -71,8 +71,9 @@ trustline is created to authorize a `ClawbackOp` operation submitted by the
 issuer account.
 
 A claimable balance inherits its clawback enabled status from the account
-creating the asset and a `ClawbackClaimableBalanceOp` operation is only valid for
-claimable balances created for assets whose issuers have clawback enabled.
+creating the claimable balance and a `ClawbackClaimableBalanceOp` operation
+is only valid for claimable balances created by accounts whose trustline for
+the asset has clawback enabled.
 
 The `ClawbackOp` and `ClawbackClaimableBalanceOp` operations result in the
 removal of the specified assets issued from the network.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -71,8 +71,8 @@ trustline is created to authorize a `ClawbackOp` operation submitted by the
 issuer account.
 
 A claimable balance inherits its clawback enabled status from the account
-creating it and a `ClawbackClaimableBalanceOp` operation is only valid for
-claimable balances created from accounts that have clawback enabled.
+creating the asset and a `ClawbackClaimableBalanceOp` operation is only valid for
+claimable balances created for assets whose issuers have clawback enabled.
 
 The `ClawbackOp` and `ClawbackClaimableBalanceOp` operations result in the
 removal of the specified assets issued from the network.
@@ -303,7 +303,7 @@ index 7f08d757..b7e76a1d 100644
 +    CLAWBACK_CLAIMABLE_BALANCE_SUCCESS = 0,
 +
 +    // codes considered as "failure" for the operation
-+    CLAWBACK_CLAIMABLE_BALANCE_MALFORMED = -1,
++    CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST = -1,
 +    CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER = -2,
 +    CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED = -3
 +};
@@ -437,7 +437,7 @@ operation.
 
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
-- `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
+- `CLAWBACK_MALFORMED` if `amount` is < 1.
 - `CLAWBACK_NOT_ISSUER` if the source account is the not the issuer of the
   `asset`.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
@@ -463,8 +463,8 @@ operation.
 
 Possible return values for the `ClawbackClaimableBalanceOp` are:
 - `CLAWBACK_CLAIMABLE_BALANCE_SUCCESS` if the clawback is successful.
-- `CLAWBACK_CLAIMABLE_BALANCE_MALFORMED` if the `claimableBalanceId` value is
-  malformed.
+- `CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST` if the claimable balance does not
+exist.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
   the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the


### PR DESCRIPTION
This commit adds some non-controversial changes to CAP-35:
* Renamed `CLAWBACK_CLAIMABLE_BALANCE_MALFORMED` to `CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST` to be consistent with `ClaimClaimableBalanceResultCode`.
* Changed `CLAWBACK_MALFORMED` description. `AssetCode` union cannot be malformed (invalid value will be catched by XDR decoder).
* Updated description of claimable balance clawback flag inheritance for clarity.

Some questions:
* I'm not sure if the proposal really solves the theft/fraud issues for liquid assets. Stolen funds can be easily exchanged to non-_clawbackable_ assets.
* Do we really need `amount` in `ClawbackOp`? Alternatively, we can clawback entire amount and send smaller amount back in the same transaction. It can simplify the implementation.
* Maybe we should explain what happens to sponsored claimable balances when clawed-back?