### PR TITLE
CAP-0035: mention sponsored reserve behavior

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -461,6 +461,11 @@ the claimable balance.
 The operation requires a medium threshold signature to authorize the
 operation.
 
+The operation introduces no new or unique behavior to how sponsored reserves
+function. When the operation applies removing the claimable balance ledger
+entry the reserve held in sponsorship will be freed for the sponsor, in the
+same way it is freed when any sponsored ledger entry is removed.
+
 Possible return values for the `ClawbackClaimableBalanceOp` are:
 - `CLAWBACK_CLAIMABLE_BALANCE_SUCCESS` if the clawback is successful.
 - `CLAWBACK_CLAIMABLE_BALANCE_MALFORMED` if the `claimableBalanceId` value is

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -462,8 +462,8 @@ The operation requires a medium threshold signature to authorize the
 operation.
 
 The operation introduces no new or unique behavior to how sponsored reserves
-function. When the operation applies removing the claimable balance ledger
-entry the reserve held in sponsorship will be freed for the sponsor, in the
+function. When the operation applies, removing the claimable balance ledger
+entry, the reserve held in sponsorship will be freed for the sponsor, in the
 same way it is freed when any sponsored ledger entry is removed.
 
 Possible return values for the `ClawbackClaimableBalanceOp` are:


### PR DESCRIPTION
### What
Mention what happens to sponsored reserves when a claimable balance is clawed back.

### Why
@bartekn asked what happens on the mailing list, and whilst there is nothing unique being introduced regarding this feature we can add a statement making it clear that is the case.