### PR TITLE
CAP-0035 - XDR fixes

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,12 +94,12 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..a272f744 100644
+index 8d746391..47446464 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -21,6 +21,17 @@ typedef opaque AssetCode4[4];
- // 5-12 alphanumeric characters right-padded with 0 bytes
- typedef opaque AssetCode12[12];
+@@ -28,6 +28,17 @@ enum AssetType
+     ASSET_TYPE_CREDIT_ALPHANUM12 = 2
+ };
  
 +union AssetCode switch (AssetType type)
 +{
@@ -112,10 +112,10 @@ index 8d746391..a272f744 100644
 +    // add other asset types here in the future
 +};
 +
- enum AssetType
+ union Asset switch (AssetType type)
  {
-     ASSET_TYPE_NATIVE = 0,
-@@ -99,11 +110,16 @@ enum AccountFlags
+ case ASSET_TYPE_NATIVE: // Not credit
+@@ -99,11 +110,15 @@ enum AccountFlags
      // otherwise, authorization cannot be revoked
      AUTH_REVOCABLE_FLAG = 0x2,
      // Once set, causes all AUTH_* flags to be read-only
@@ -128,12 +128,12 @@ index 8d746391..a272f744 100644
  };
  
  // mask for all valid flags
- const MASK_ACCOUNT_FLAGS = 0x7;
-+const MASK_ACCOUNT_FLAGS_V16 = 0xF;
+-const MASK_ACCOUNT_FLAGS = 0x7;
++const MASK_ACCOUNT_FLAGS = 0xF;
  
  // maximum number of signers
  const MAX_SIGNERS = 20;
-@@ -187,12 +203,16 @@ enum TrustLineFlags
+@@ -187,12 +202,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
@@ -151,7 +151,7 @@ index 8d746391..a272f744 100644
  
  struct TrustLineEntry
  {
-@@ -337,6 +357,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
+@@ -337,6 +356,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
      Hash v0;
  };
  
@@ -159,7 +159,7 @@ index 8d746391..a272f744 100644
 +{
 +    // If set, the issuer account of the asset held by the claimable balance may
 +    // clawback the claimable balance
-+    CLAWBACK_ENABLED_FLAG = 0x1
++    CB_CLAWBACK_ENABLED_FLAG = 0x1
 +};
 +
 +const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
@@ -179,7 +179,7 @@ index 8d746391..a272f744 100644
  struct ClaimableBalanceEntry
  {
      // Unique identifier for this ClaimableBalanceEntry
-@@ -356,6 +397,8 @@ struct ClaimableBalanceEntry
+@@ -356,6 +396,8 @@ struct ClaimableBalanceEntry
      {
      case 0:
          void;
@@ -330,6 +330,7 @@ index 7f08d757..b7e76a1d 100644
      }
      tr;
  default:
+
 ```
 
 ### Semantics

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -94,7 +94,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..47446464 100644
+index 8d746391..ab914436 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -28,6 +28,17 @@ enum AssetType
@@ -141,7 +141,7 @@ index 8d746391..47446464 100644
 +    AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG = 2,
 +    // issuer has specified that it may clawback its credit, and that claimable
 +    // balances created with its credit may also be clawed back
-+    CLAWBACK_ENABLED_FLAG = 4
++    TRUSTLINE_CLAWBACK_ENABLED_FLAG = 4
  };
  
  // mask for all trustline flags
@@ -159,7 +159,7 @@ index 8d746391..47446464 100644
 +{
 +    // If set, the issuer account of the asset held by the claimable balance may
 +    // clawback the claimable balance
-+    CB_CLAWBACK_ENABLED_FLAG = 0x1
++    CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG = 0x1
 +};
 +
 +const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
@@ -189,7 +189,7 @@ index 8d746391..47446464 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..b7e76a1d 100644
+index 7f08d757..7476f1b6 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,9 @@ enum OperationType
@@ -268,7 +268,17 @@ index 7f08d757..b7e76a1d 100644
      }
      body;
  };
-@@ -1120,6 +1139,50 @@ default:
+@@ -868,7 +887,8 @@ enum SetOptionsResultCode
+     SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
+     SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
+     SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+-    SET_OPTIONS_INVALID_HOME_DOMAIN = -9     // malformed home domain
++    SET_OPTIONS_INVALID_HOME_DOMAIN = -9,     // malformed home domain
++    SET_OPTIONS_AUTH_REVOCABLE_REQUIRED = -10 // auth revocable is required for clawback
+ };
+ 
+ union SetOptionsResult switch (SetOptionsResultCode code)
+@@ -1120,6 +1140,50 @@ default:
      void;
  };
  
@@ -319,7 +329,7 @@ index 7f08d757..b7e76a1d 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1239,10 @@ case opINNER:
+@@ -1176,6 +1240,10 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -330,7 +340,6 @@ index 7f08d757..b7e76a1d 100644
      }
      tr;
  default:
-
 ```
 
 ### Semantics
@@ -405,16 +414,16 @@ set, the operation will fail with the existing result code
 
 #### Set Options Operation
 
-This proposal introduces no changes to the `SetOptionsOp` operation XDR, but
-the operation will require the `AUTH_REVOCABLE_FLAG` flag to be set whenever
-the `AUTH_CLAWBACK_ENABLED_FLAG` flag is set.
+This proposal introduces a new result code to the `SetOptionsOp` operation XDR,
+which will be returned if `AUTH_REVOCABLE_FLAG` flag is not set whenever the 
+`AUTH_CLAWBACK_ENABLED_FLAG` flag is set.
 
 This introduces a failing result in these cases:
 
 1. Setting only `AUTH_CLAWBACK_ENABLED_FLAG` without `AUTH_REVOCABLE_FLAG`
-   already set will result in `SET_OPTIONS_BAD_FLAGS`.
+   already set will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
 2. Clearing `AUTH_REVOCABLE_FLAG` while `AUTH_CLAWBACK_ENABLED_FLAG` is set
-   will result in `SET_OPTIONS_BAD_FLAGS`.
+   will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
 
 #### Clawback Operation
 


### PR DESCRIPTION
This PR includes three changes -

1. Moved `AssetCode` below `AssetType` so we can compile.
2. XDR uses C-style enums, so the `CLAWBACK_ENABLED_FLAG` in trustline flags conflicts with the claimable balance flags. I changed the claimable balance flag to `CB_CLAWBACK_ENABLED_FLAG`.
3.  Removed `MASK_ACCOUNT_FLAGS_V16`. `MASK_ACCOUNT_FLAGS` is only used in the invariants, which is not part of the protocol. We can just change the value instead of introducing a new mask.

One other thing I noticed in the CAP is that the new `AUTH_CLAWBACK_ENABLED_FLAG`/`AUTH_REVOCABLE_FLAG` check in `SetOptionsOp` uses the `SET_OPTIONS_BAD_FLAGS` result code, which is currently used during validation. The new check will be done at apply time (since we need to load the account to learn which flags are currently set). Should we use a new result code instead for clarity? I can address this here if we agree. 