### PR TITLE
Close stale issues and pull requests automatically after 35 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Stale Issues'
 on:
   schedule:
     - cron: '30 1 * * *'
+  pull_request:
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,13 +16,5 @@ jobs:
           days-before-close: 5
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
-          exempt-issue-labels: 
-          - needs draft
-          - needs pilot
-          - accepted
-          - blocked
-          exempt-pr-labels:
-          - needs draft
-          - needs pilot
-          - accepted
-          - blocked
+          exempt-issue-labels: 'needs draft,needs pilot,accepted,blocked'
+          exempt-pr-labels: 'needs draft,needs pilot,accepted,blocked'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '30 1 * * *'
   pull_request:
+  push:
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,8 @@
 name: 'Stale Issues'
+
 on:
   schedule:
-    - cron: '30 1 * * *'
-  pull_request:
-  push:
+    - cron: '0 18 * * *' # approx 9:30am daily
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,7 @@ jobs:
           days-before-close: 5
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
+          stale-issue-label: stale
+          stale-pr-label: stale
           exempt-issue-labels: 'needs draft,needs pilot,accepted,blocked'
           exempt-pr-labels: 'needs draft,needs pilot,accepted,blocked'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Stale Issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          debug-only: true
+          days-before-stale: 30
+          days-before-close: 5
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
+          exempt-issue-labels: 
+          - needs draft
+          - needs pilot
+          - accepted
+          - blocked
+          exempt-pr-labels:
+          - needs draft
+          - needs pilot
+          - accepted
+          - blocked

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           debug-only: true
           days-before-stale: 30
           days-before-close: 5


### PR DESCRIPTION
### What
Close stale issues and pull requests automatically after 35 days with a 5 day warning.

### Why
@MonsieurNicolas pointed out that we've got a build up of stale issues and pull requests. This should help clean things up. It is non-destructive so issues and pull requests can be reopened by their authors if they get closed. We can improve a selection of labels that prevent auto-close.