### PR TITLE
CAP-0035 - remove unnecessary result code

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -292,10 +292,9 @@ index 7f08d757..7476f1b6 100644
 +
 +    // codes considered as "failure" for the operation
 +    CLAWBACK_MALFORMED = -1,
-+    CLAWBACK_NOT_ISSUER = -2,
-+    CLAWBACK_NOT_CLAWBACK_ENABLED = -3,
-+    CLAWBACK_NO_TRUST = -4,
-+    CLAWBACK_UNDERFUNDED = -5
++    CLAWBACK_NOT_CLAWBACK_ENABLED = -2,
++    CLAWBACK_NO_TRUST = -3,
++    CLAWBACK_UNDERFUNDED = -4
 +};
 +
 +union ClawbackResult switch (ClawbackResultCode code)
@@ -449,8 +448,6 @@ operation.
 Possible return values for the `ClawbackOp` are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
 - `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
-- `CLAWBACK_NOT_ISSUER` if the source account is the not the issuer of the
-`asset`.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
 `asset`.


### PR DESCRIPTION
`CLAWBACK_NOT_ISSUER` is unnecessary because the source account determines the issuer of the asset, similar to how `AllowTrustOp` works. 