### PR TITLE
Close stale issues and pull requests automatically after 60 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
+          debug-only: false
           days-before-stale: 30
           days-before-close: 5
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           debug-only: false
           days-before-stale: 30
-          days-before-close: 5
+          days-before-close: 30
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
           stale-issue-label: stale


### PR DESCRIPTION
### What
Enable the stale GitHub Action that will close issues and PRs after 35 days of being stale with a 5 day warning.

### Why
See previous discussion here: #833.