### PR TITLE
SEP-6 & SEP-24: make asset codes used consistent

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,7 +6,7 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2020-04-01
+Updated: 2021-01-19
 Version 3.1.2
 ```
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
 Updated: 2020-04-01
-Version 3.1.1
+Version 3.1.2
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -131,7 +131,7 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the asset the user wants to deposit with the anchor. Ex BTC, ETH, USD, INR, etc. This may be different from the asset code that the anchor issues. Ex if a user deposits BTC and receives MyBTC tokens, `asset_code` must be BTC.
+`asset_code` | string | The code of the asset the user wants to deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
@@ -245,7 +245,7 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives BTC, the `asset_code` must be MyBTC.
+`asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
@@ -502,7 +502,7 @@ The response should be a JSON object like:
 }
 ```
 
-The JSON object contains an entry for each asset that the anchor supports for SEP6 deposit and/or withdrawal.
+The JSON object contains an entry for each Stellar asset that the anchor supports for SEP6 deposit and/or withdrawal.
 
 #### For each deposit asset, response contains:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active
 Created: 2019-09-18
 Updated: 2021-01-15
-Version 1.2.1
+Version 1.2.2
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,7 +6,7 @@ Title: Interactive Anchor/Wallet Asset Transfer Server
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-01-15
+Updated: 2021-01-19
 Version 1.2.2
 ```
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -154,7 +154,7 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor.
+`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
@@ -288,7 +288,7 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. This must match the asset code issued by the anchor. Ex if a user withdraws MyBTC tokens and receives native BTC, the `asset_code` must be MyBTC.
+`asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
@@ -532,7 +532,7 @@ The response should be a JSON object like:
 }
 ```
 
-The JSON object contains an entry for each asset that the anchor supports for deposit and/or withdrawal.
+The JSON object contains an entry for each Stellar asset that the anchor supports for deposit and/or withdrawal.
 
 #### For each deposit asset, response contains:
 


### PR DESCRIPTION
88312b04e1334147b8dab8763dce0ed58dcd3ce3 clarified the `asset_code` parameter to `/deposit` to be the code of the asset being deposited to the anchor's off-chain account. For example, if an anchor issues a `MyBTC` token, the client should still pass `BTC` as the `asset_code` parameter value.

This PR changes that to require clients to use the code of the anchored asset (`MyBTC` in the example). Here is why:
1. SEP-24 specifically states that the `asset_code` parameter should be the asset code of the anchored asset, not the off-chain asset. So this PR makes SEP-6 consistent with SEP-24.
2. Using potentially different asset codes for `/deposit` makes what the `/info` response should be unclear. In the `MyBTC` example, should `MyBTC` or `BTC` be listed in the `/info` response? This change makes this question mute.
 