### PR TITLE
CAP-0035 - Add new operation to modify trustline flags

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -190,7 +190,7 @@ index 8d746391..ab914436 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..f82b6418 100644
+index 7f08d757..449de093 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -201,7 +201,7 @@ index 7f08d757..f82b6418 100644
 +    REVOKE_SPONSORSHIP = 18,
 +    CLAWBACK = 19,
 +    CLAWBACK_CLAIMABLE_BALANCE = 20,
-+    SET_TRUSTLINE_FLAGS = 21
++    SET_TRUST_LINE_FLAGS = 21
  };
  
  /* CreateAccount
@@ -228,7 +228,7 @@ index 7f08d757..f82b6418 100644
      uint32 authorize;
  };
  
-@@ -376,6 +368,58 @@ case REVOKE_SPONSORSHIP_SIGNER:
+@@ -376,6 +368,48 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
  
@@ -265,19 +265,9 @@ index 7f08d757..f82b6418 100644
 +
 +   Result: SetTrustLineFlagsResult
 +*/
-+
-+enum SetTrustLineFlagsType
-+{
-+    SET_TRUSTLINE_FLAG_AS_ISSUER = 0
-+};
-+
 +struct SetTrustLineFlagsOp
 +{
-+    union switch (SetTrustLineFlagsType type)
-+    {
-+    case SET_TRUSTLINE_FLAG_AS_ISSUER:
-+        AccountID trustor;
-+    } account;
++    AccountID trustor;
 +    AssetCode asset;
 +
 +    uint32* clearFlags; // which flags to clear
@@ -287,7 +277,7 @@ index 7f08d757..f82b6418 100644
  /* An operation is the lowest unit of work that a transaction does */
  struct Operation
  {
-@@ -424,6 +468,12 @@ struct Operation
+@@ -424,6 +458,12 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipOp revokeSponsorshipOp;
@@ -295,12 +285,12 @@ index 7f08d757..f82b6418 100644
 +        ClawbackOp clawbackOp;
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
-+    case SET_TRUSTLINE_FLAGS:
++    case SET_TRUST_LINE_FLAGS:
 +        SetTrustLineFlagsOp setTrustLineFlagsOp;
      }
      body;
  };
-@@ -868,7 +918,8 @@ enum SetOptionsResultCode
+@@ -868,7 +908,8 @@ enum SetOptionsResultCode
      SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
      SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
      SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
@@ -310,7 +300,7 @@ index 7f08d757..f82b6418 100644
  };
  
  union SetOptionsResult switch (SetOptionsResultCode code)
-@@ -1120,6 +1171,70 @@ default:
+@@ -1120,6 +1161,70 @@ default:
      void;
  };
  
@@ -362,17 +352,17 @@ index 7f08d757..f82b6418 100644
 +enum SetTrustLineFlagsResultCode
 +{
 +    // codes considered as "success" for the operation
-+    SET_TRUSTLINE_FLAGS_SUCCESS = 0,
++    SET_TRUST_LINE_FLAGS_SUCCESS = 0,
 +
 +    // codes considered as "failure" for the operation
-+    SET_TRUSTLINE_FLAGS_MALFORMED = -1,
-+    SET_TRUSTLINE_FLAGS_NO_TRUST_LINE = -2,
-+    SET_TRUSTLINE_FLAGS_CANT_REVOKE = -3
++    SET_TRUST_LINE_FLAGS_MALFORMED = -1,
++    SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
++    SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3
 +};
 +
 +union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
 +{
-+case SET_TRUSTLINE_FLAGS_SUCCESS:
++case SET_TRUST_LINE_FLAGS_SUCCESS:
 +    void;
 +default:
 +    void;
@@ -381,7 +371,7 @@ index 7f08d757..f82b6418 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1291,12 @@ case opINNER:
+@@ -1176,6 +1281,12 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -389,7 +379,7 @@ index 7f08d757..f82b6418 100644
 +        ClawbackResult clawbackResult;
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
-+    case SET_TRUSTLINE_FLAGS:
++    case SET_TRUST_LINE_FLAGS:
 +        SetTrustLineFlagsResult setTrustLineFlagsResult;
      }
      tr;
@@ -549,11 +539,7 @@ This proposal introduces the `SetTrustLineFlagsOp` operation. The operation work
 like the `AllowTrustOp`, except it uses set and clear parameters to set/clear specific
 trustline flags. This will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG`. 
 
-The account specified in `SetTrustLineFlagsOp` is in a union. In the current proposal, we maintain the 
-restriction that only the issuer can modify trustline flags, but a new type can be added to this
-union in the future to allow for the operation to act on a trustline as the owner.
-
-`SET_TRUSTLINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
+`SET_TRUST_LINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
 - Both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`.
 - `asset` is invalid. 
 - `setFlags` and `clearFlags` are modifying the same flags.
@@ -561,9 +547,9 @@ union in the future to allow for the operation to act on a trustline as the owne
 - `trustor` == source account
 
 Possible return values for the `SetTrustLineFlagsOp` during application are:
-- `SET_TRUSTLINE_FLAGS_SUCCESS` if the operation is successful.
-- `SET_TRUSTLINE_FLAGS_NO_TRUST_LINE` if the trustline doesn't exist.
-- `SET_TRUSTLINE_FLAGS_CANT_REVOKE` if `AUTH_REVOCABLE_FLAG` is not set on the issuer,
+- `SET_TRUST_LINE_FLAGS_SUCCESS` if the operation is successful.
+- `SET_TRUST_LINE_FLAGS_NO_TRUST_LINE` if the trustline doesn't exist.
+- `SET_TRUST_LINE_FLAGS_CANT_REVOKE` if `AUTH_REVOCABLE_FLAG` is not set on the issuer,
   but the authorization is downgraded (`AUTHORIZED_FLAG` -> `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, `AUTHORIZED_FLAG` -> 0,
   or `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` -> 0).
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -611,7 +611,8 @@ clawback.
 
 The `AllowTrustOp` is disallowed from operating on the new `CLAWBACK_ENABLED_FLAG`
 trustline flag because this operation doesn't have a parameter to set/clear flags.
-It requires the user to be aware of exists flags, which is an operational burden.
+It requires the user to be aware of existing flags, which is an operational burden.
+
 A new operation, `SetTrustlineFlagsOp`, is proposed in this cap to make 
 trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
 semantically intended to change authorization and clawback is outside it's scope.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -190,7 +190,7 @@ index 8d746391..ab914436 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..38f4eac8 100644
+index 7f08d757..f82b6418 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -228,7 +228,7 @@ index 7f08d757..38f4eac8 100644
      uint32 authorize;
  };
  
-@@ -376,6 +368,48 @@ case REVOKE_SPONSORSHIP_SIGNER:
+@@ -376,6 +368,58 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
  
@@ -256,18 +256,28 @@ index 7f08d757..38f4eac8 100644
 +    ClaimableBalanceID balanceID;
 +};
 +
-+/* SetTrustlineFlagsOp
++/* SetTrustLineFlagsOp
 +
 +   Updates the flags of an existing trust line.
 +   This is called by the issuer of the related asset.
 +
 +   Threshold: low
 +
-+   Result: SetTrustlineFlagsResult
++   Result: SetTrustLineFlagsResult
 +*/
-+struct SetTrustlineFlagsOp
++
++enum SetTrustLineFlagsType
 +{
-+    AccountID trustor;
++    SET_TRUSTLINE_FLAG_AS_ISSUER = 0
++};
++
++struct SetTrustLineFlagsOp
++{
++    union switch (SetTrustLineFlagsType type)
++    {
++    case SET_TRUSTLINE_FLAG_AS_ISSUER:
++        AccountID trustor;
++    } account;
 +    AssetCode asset;
 +
 +    uint32* clearFlags; // which flags to clear
@@ -277,7 +287,7 @@ index 7f08d757..38f4eac8 100644
  /* An operation is the lowest unit of work that a transaction does */
  struct Operation
  {
-@@ -424,6 +458,12 @@ struct Operation
+@@ -424,6 +468,12 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipOp revokeSponsorshipOp;
@@ -286,11 +296,11 @@ index 7f08d757..38f4eac8 100644
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
 +    case SET_TRUSTLINE_FLAGS:
-+        SetTrustlineFlagsOp setTrustlineFlagsOp;
++        SetTrustLineFlagsOp setTrustLineFlagsOp;
      }
      body;
  };
-@@ -868,7 +908,8 @@ enum SetOptionsResultCode
+@@ -868,7 +918,8 @@ enum SetOptionsResultCode
      SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
      SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
      SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
@@ -300,7 +310,7 @@ index 7f08d757..38f4eac8 100644
  };
  
  union SetOptionsResult switch (SetOptionsResultCode code)
-@@ -1120,6 +1161,71 @@ default:
+@@ -1120,6 +1171,70 @@ default:
      void;
  };
  
@@ -347,9 +357,9 @@ index 7f08d757..38f4eac8 100644
 +    void;
 +};
 +
-+/******* SetTrustlineFlags Result ********/
++/******* SetTrustLineFlags Result ********/
 +
-+enum SetTrustlineFlagsResultCode
++enum SetTrustLineFlagsResultCode
 +{
 +    // codes considered as "success" for the operation
 +    SET_TRUSTLINE_FLAGS_SUCCESS = 0,
@@ -357,11 +367,10 @@ index 7f08d757..38f4eac8 100644
 +    // codes considered as "failure" for the operation
 +    SET_TRUSTLINE_FLAGS_MALFORMED = -1,
 +    SET_TRUSTLINE_FLAGS_NO_TRUST_LINE = -2,
-+    SET_TRUSTLINE_FLAGS_CANT_REVOKE = -3,
-+    SET_TRUSTLINE_FLAGS_CANT_SET_CLAWBACK = -4
++    SET_TRUSTLINE_FLAGS_CANT_REVOKE = -3
 +};
 +
-+union SetTrustlineFlagsResult switch (SetTrustlineFlagsResultCode code)
++union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
 +{
 +case SET_TRUSTLINE_FLAGS_SUCCESS:
 +    void;
@@ -372,7 +381,7 @@ index 7f08d757..38f4eac8 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1282,12 @@ case opINNER:
+@@ -1176,6 +1291,12 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -381,7 +390,7 @@ index 7f08d757..38f4eac8 100644
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
 +    case SET_TRUSTLINE_FLAGS:
-+        SetTrustlineFlagsResult setTrustlineFlagsResult;
++        SetTrustLineFlagsResult setTrustLineFlagsResult;
      }
      tr;
  default:
@@ -490,9 +499,13 @@ continue utilizing the asset it can include another `AllowTrustOp` after the
 The clawback operation requires a medium threshold signature to authorize the
 operation.
 
-Possible return values for the `ClawbackOp` are:
+`CLAWBACK_MALFORMED` will be returned for `ClawbackOp` during validation under the following conditions:
+- `asset` value is invalid.
+- `amount` is < 1.
+- `from` == source account
+
+Possible return values for the `ClawbackOp` during application are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
-- `CLAWBACK_MALFORMED` if the `asset` value is malformed or `amount` is < 1.
 - `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
 `asset`.
@@ -519,7 +532,9 @@ function. When the operation applies, removing the claimable balance ledger
 entry, the reserve held in sponsorship will be freed for the sponsor, in the
 same way it is freed when any sponsored ledger entry is removed.
 
-Possible return values for the `ClawbackClaimableBalanceOp` are:
+`ClawbackClaimableBalanceOp` is always valid.
+
+Possible return values for the `ClawbackClaimableBalanceOp` during application are:
 - `CLAWBACK_CLAIMABLE_BALANCE_SUCCESS` if the clawback is successful.
 - `CLAWBACK_CLAIMABLE_BALANCE_DOES_NOT_EXIST` if the claimable balance does
 not exist.
@@ -528,23 +543,29 @@ the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
 `CLAWBACK_ENABLED_FLAG` is not set.
 
-#### Set Trustline Flags Operation
+#### Set TrustLine Flags Operation
 
-This proposal introduces the `SetTrustlineFlagsOp` operation. The operation works
+This proposal introduces the `SetTrustLineFlagsOp` operation. The operation works
 like the `AllowTrustOp`, except it uses set and clear parameters to set/clear specific
-trustline flags. This will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG`.
+trustline flags. This will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG`. 
 
-Possible return values for the `SetTrustlineFlagsOp` are:
+The account specified in `SetTrustLineFlagsOp` is in a union. In the current proposal, we maintain the 
+restriction that only the issuer can modify trustline flags, but a new type can be added to this
+union in the future to allow for the operation to act on a trustline as the owner.
+
+`SET_TRUSTLINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
+- Both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`.
+- `asset` is invalid. 
+- `setFlags` and `clearFlags` are modifying the same flags.
+- `setFlags` has the `CLAWBACK_ENABLED_FLAG` set.
+- `trustor` == source account
+
+Possible return values for the `SetTrustLineFlagsOp` during application are:
 - `SET_TRUSTLINE_FLAGS_SUCCESS` if the operation is successful.
-- `SET_TRUSTLINE_FLAGS_MALFORMED` if both `AUTHORIZED_FLAG` and 
-  `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`,
-  if `asset` is invalid, or if `setFlags` and `clearFlags` are modifying
-  the same flags.
 - `SET_TRUSTLINE_FLAGS_NO_TRUST_LINE` if the trustline doesn't exist.
 - `SET_TRUSTLINE_FLAGS_CANT_REVOKE` if `AUTH_REVOCABLE_FLAG` is not set on the issuer,
   but the authorization is downgraded (`AUTHORIZED_FLAG` -> `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, `AUTHORIZED_FLAG` -> 0,
   or `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` -> 0).
-- `SET_TRUSTLINE_FLAGS_CANT_SET_CLAWBACK` if `setFlags` has the `CLAWBACK_ENABLED_FLAG` set.
 
 ## Design Rationale
 
@@ -613,7 +634,7 @@ The `AllowTrustOp` is disallowed from operating on the new `CLAWBACK_ENABLED_FLA
 trustline flag because this operation doesn't have a parameter to set/clear flags.
 It requires the user to be aware of existing flags, which is an operational burden.
 
-A new operation, `SetTrustlineFlagsOp`, is proposed in this cap to make 
+A new operation, `SetTrustLineFlagsOp`, is proposed in this cap to make 
 trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
 semantically intended to change authorization and clawback is outside it's scope.
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -7,7 +7,7 @@ CAP: 0035
 Title: Asset Clawback
 Working Group:
     Owner: Tomer Weller <@tomerweller>
-    Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Siddarth Suresh <@sisuresh>
+    Authors: Dan Doney (Securrency, Inc.), Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Siddharth Suresh <@sisuresh>
     Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Eric Saunders <@ire-and-curses>
 Status: Draft
 Created: 2020-12-14
@@ -190,21 +190,22 @@ index 8d746391..ab914436 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..e0585994 100644
+index 7f08d757..38f4eac8 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -46,7 +46,9 @@ enum OperationType
+@@ -46,7 +46,10 @@ enum OperationType
      CLAIM_CLAIMABLE_BALANCE = 15,
      BEGIN_SPONSORING_FUTURE_RESERVES = 16,
      END_SPONSORING_FUTURE_RESERVES = 17,
 -    REVOKE_SPONSORSHIP = 18
 +    REVOKE_SPONSORSHIP = 18,
 +    CLAWBACK = 19,
-+    CLAWBACK_CLAIMABLE_BALANCE = 20
++    CLAWBACK_CLAIMABLE_BALANCE = 20,
++    SET_TRUSTLINE_FLAGS = 21
  };
  
  /* CreateAccount
-@@ -236,20 +238,9 @@ struct ChangeTrustOp
+@@ -236,20 +239,9 @@ struct ChangeTrustOp
  struct AllowTrustOp
  {
      AccountID trustor;
@@ -216,18 +217,18 @@ index 7f08d757..e0585994 100644
 -
 -    case ASSET_TYPE_CREDIT_ALPHANUM12:
 -        AssetCode12 assetCode12;
--
++    AssetCode asset;
+ 
 -        // add other asset types here in the future
 -    }
 -    asset;
-+    AssetCode asset;
- 
+-
 -    // 0, or any bitwise combination of TrustLineFlags
 +    // 0, or any bitwise combination of the AUTHORIZED_* flags of TrustLineFlags
      uint32 authorize;
  };
  
-@@ -376,6 +367,30 @@ case REVOKE_SPONSORSHIP_SIGNER:
+@@ -376,6 +368,48 @@ case REVOKE_SPONSORSHIP_SIGNER:
      signer;
  };
  
@@ -255,10 +256,28 @@ index 7f08d757..e0585994 100644
 +    ClaimableBalanceID balanceID;
 +};
 +
++/* SetTrustlineFlagsOp
++
++   Updates the flags of an existing trust line.
++   This is called by the issuer of the related asset.
++
++   Threshold: low
++
++   Result: SetTrustlineFlagsResult
++*/
++struct SetTrustlineFlagsOp
++{
++    AccountID trustor;
++    AssetCode asset;
++
++    uint32* clearFlags; // which flags to clear
++    uint32* setFlags;   // which flags to set
++};
++
  /* An operation is the lowest unit of work that a transaction does */
  struct Operation
  {
-@@ -424,6 +439,10 @@ struct Operation
+@@ -424,6 +458,12 @@ struct Operation
          void;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipOp revokeSponsorshipOp;
@@ -266,10 +285,12 @@ index 7f08d757..e0585994 100644
 +        ClawbackOp clawbackOp;
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceOp clawbackClaimableBalanceOp;
++    case SET_TRUSTLINE_FLAGS:
++        SetTrustlineFlagsOp setTrustlineFlagsOp;
      }
      body;
  };
-@@ -868,7 +887,8 @@ enum SetOptionsResultCode
+@@ -868,7 +908,8 @@ enum SetOptionsResultCode
      SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
      SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
      SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
@@ -279,7 +300,7 @@ index 7f08d757..e0585994 100644
  };
  
  union SetOptionsResult switch (SetOptionsResultCode code)
-@@ -1120,6 +1140,49 @@ default:
+@@ -1120,6 +1161,71 @@ default:
      void;
  };
  
@@ -326,10 +347,32 @@ index 7f08d757..e0585994 100644
 +    void;
 +};
 +
++/******* SetTrustlineFlags Result ********/
++
++enum SetTrustlineFlagsResultCode
++{
++    // codes considered as "success" for the operation
++    SET_TRUSTLINE_FLAGS_SUCCESS = 0,
++
++    // codes considered as "failure" for the operation
++    SET_TRUSTLINE_FLAGS_MALFORMED = -1,
++    SET_TRUSTLINE_FLAGS_NO_TRUST_LINE = -2,
++    SET_TRUSTLINE_FLAGS_CANT_REVOKE = -3,
++    SET_TRUSTLINE_FLAGS_CANT_SET_CLAWBACK = -4
++};
++
++union SetTrustlineFlagsResult switch (SetTrustlineFlagsResultCode code)
++{
++case SET_TRUSTLINE_FLAGS_SUCCESS:
++    void;
++default:
++    void;
++};
++
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1239,10 @@ case opINNER:
+@@ -1176,6 +1282,12 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -337,6 +380,8 @@ index 7f08d757..e0585994 100644
 +        ClawbackResult clawbackResult;
 +    case CLAWBACK_CLAIMABLE_BALANCE:
 +        ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
++    case SET_TRUSTLINE_FLAGS:
++        SetTrustlineFlagsResult setTrustlineFlagsResult;
      }
      tr;
  default:
@@ -483,6 +528,24 @@ the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
 `CLAWBACK_ENABLED_FLAG` is not set.
 
+#### Set Trustline Flags Operation
+
+This proposal introduces the `SetTrustlineFlagsOp` operation. The operation works
+like the `AllowTrustOp`, except it uses set and clear parameters to set/clear specific
+trustline flags. This will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG`.
+
+Possible return values for the `SetTrustlineFlagsOp` are:
+- `SET_TRUSTLINE_FLAGS_SUCCESS` if the operation is successful.
+- `SET_TRUSTLINE_FLAGS_MALFORMED` if both `AUTHORIZED_FLAG` and 
+  `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`,
+  if `asset` is invalid, or if `setFlags` and `clearFlags` are modifying
+  the same flags.
+- `SET_TRUSTLINE_FLAGS_NO_TRUST_LINE` if the trustline doesn't exist.
+- `SET_TRUSTLINE_FLAGS_CANT_REVOKE` if `AUTH_REVOCABLE_FLAG` is not set on the issuer,
+  but the authorization is downgraded (`AUTHORIZED_FLAG` -> `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, `AUTHORIZED_FLAG` -> 0,
+  or `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` -> 0).
+- `SET_TRUSTLINE_FLAGS_CANT_SET_CLAWBACK` if `setFlags` has the `CLAWBACK_ENABLED_FLAG` set.
+
 ## Design Rationale
 
 In the event of regulatory action, erroneous transaction, or loss of custody,
@@ -546,10 +609,12 @@ clawback.
 
 ### Allow Trust Operation
 
-The `AllowTrustOp` is disallowed from operating on the new
-`CLAWBACK_ENABLED_FLAG` trustline flag because the flag is immutable.
-Additionally the `AllowTrustOp` operation is semantically intended to change
-authorization and clawback is outside it's scope.
+The `AllowTrustOp` is disallowed from operating on the new `CLAWBACK_ENABLED_FLAG`
+trustline flag because this operation doesn't have a parameter to set/clear flags.
+It requires the user to be aware of exists flags, which is an operational burden.
+A new operation, `SetTrustlineFlagsOp`, is proposed in this cap to make 
+trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
+semantically intended to change authorization and clawback is outside it's scope.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
Added a new operation to set and clear only the specified trustline flags. This operation will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG` from a trustline.