### PR TITLE
SEP-6: update SEP-6 for claimable balances

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -301,12 +301,6 @@ Predicates are one of the [claimable balance parameters](https://developers.stel
 
 This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
 
-The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify the url for the interactive webapp to continue with the anchor's side of the withdraw.
-
-## Withdraw
-
-This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
-
 The `/withdraw` endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify additional information (if desired) that the user must submit via [SEP-12](sep-0012.md) to be able to withdraw.
 
 ### Request

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -143,6 +143,7 @@ Name | Type | Description
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 `amount` | string | (optional) The amount of the asset the user would like to deposit with the anchor. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`claimable_balance_supported` | string | (optional) `true` if the client supports receiving deposit transactions as a claimable balance, `false` otherwise.
 
 Example:
 
@@ -211,8 +212,8 @@ Mexican peso (MXN) response example:
 }
 ```
 
-##### Special Cases
-###### Stellar account does not exist
+### Special Cases
+#### Stellar account does not exist
 
 If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
@@ -220,17 +221,87 @@ Since the anchor doesn't have the user account's secret key, the user must creat
 
 If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
-###### Stellar account doesn't trust asset
+#### Stellar account doesn't trust asset
 
-The deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
+Unless [Claimable Balances](#claimable-balanecs) are supported by both the wallet and anchor, the deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
 
 1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
 2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.
 3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` may charge a service fee to cover the cost of the XLM, but this must be communicated to the user.
-4. `Anchor` then starts listening for trust line creations for that `account`.
-5. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
+4. `Anchor` updates the transaction's `status` to `pending_trust`, signaling to `Wallet` that it is waiting for a trustline to be established.
+5. `Wallet` detects the that transactions status is `pending_trust`, confirms the arrival of XLM in the `account`, and establishes a trust line.
 6. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
 7. `Anchor` proceeds with the deposit flow.
+
+#### Claimable Balances
+
+[Claimable Balances](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0023.md) are an optional feature that enable payments to accounts that do not have a trustline for the asset being deposited. This feature splits a payment into two separate parts: the creation of a balance, and the claiming of a balance. A claimable balance can be claimed by the designated claimant (user) after it has been created by the anchor.
+
+Using this feature, anchors will no longer have to wait until the user's Stellar account has a trustline to the asset before sending funds. Instead, anchors can make the payment using a [CreateClaimableBalance](https://developers.stellar.org/api/resources/operations/object/create-claimable-balance/) operation and the user's Stellar account can claim the funds at their own convenience using a [ClaimClaimableBalance](https://developers.stellar.org/api/resources/operations/object/claim-claimable-balance/) operation.
+
+**NOTE**: Supporting this feature will be made mandatory in the future. Therefore, it is highly recommended for wallets to implement this functionality now.
+
+**Wallets**: To support claimable balances wallets must
+
+* Send the additional `claimable_balance_supported=true` request parameter in the `GET /deposit` request.
+* Periodically poll for account's available claimable balances.
+* Provide a UI that allows users to claim claimable balances.
+
+**Anchors**: To support claimable balances anchors must
+
+* Accept the `claimable_balance_supported` request parameter in `GET /deposit` requests
+* Submit deposit transactions using `CreateClaimableBalance` operations to Stellar accounts that don't yet have a trustline to the asset requested.
+* Add the `claimable_balance_id` attribute to `GET /transaction(s)` deposit records
+
+**Anchors and Wallets**: Both anchors and wallets still must support the aforementioned [Stellar account doesn't trust asset](#stellar-account-doesnt-trust-asset) flow. Wallets need to be interoperable with anchors that have not adopted the claimable balance feature and vice versa.
+
+##### Wallet Claimable Balance Flow
+
+1. Make a request to `/deposit` and provide the `claimable_balance_supported=true` request parameter.
+2. Register the user's KYC information with the anchor via [SEP-12](sep-0012.md) if requested and resubmit the deposit request.
+3. Once a successful deposit request has been made and the transaction's status is `pending_user_transfer_start`, the user must send the required payment as described by the `how` attribute in the deposit success response.
+4. If the anchor doesn't support claimable balances, the anchor's `/transaction(s)` endpoint will contain the `pending_trust` status. In this case, use the flow described [above](#stellar-account-doesnt-trust-asset).
+5. Otherwise, detect the `claimable_balance_id` value populated in the anchor's `/transaction(s)` endpoint or poll Horizon's [/claimable_balances](https://developers.stellar.org/api/resources/claimablebalances/) endpoint for outstanding claimable balances. When a claimable balance is detected using either method, the transaction status should be `completed`.
+6. Claim the balance using the value via the `ClaimClaimableBalance` operation. See the ["Claiming Claimable Balances"](#claiming-claimable-balances) section to learn more about how to claim a balance.
+
+##### Claiming Claimable Balances
+
+In order to claim a balance of an asset, the Stellar accounts must establish a trustline to the asset. Adding a trustline only needs to happen once per asset sent.
+
+Below is an example of how to claim a claimable balance. Omitted from the example is the [Change Trust](https://developers.stellar.org/docs/start/list-of-operations/#change-trust) operation required if the Stellar account does not have a trustline.
+
+```javascript
+const transaction = new TransactionBuilder(account, {
+  fee: 100,
+  networkPassphrase: this.network_passphrase,
+})
+  .addOperation(
+    Operation.claimClaimableBalance({ balanceId })
+  )
+  .setTimeout(0)
+  .build()
+transaction.sign(keypair)
+const result = await this.server.submitTransaction(transaction)
+```
+
+##### Anchor Claimable Balance Flow
+
+1. Wallets make a request to `/deposit` providing the `claimable_balance_supported` request parameter.
+2. Anchors update their internal database record of the transaction to indicate the wallet supports receiving a claimable balance.
+3. Users send the external asset to the anchor's off-chain account.
+4. Anchors detect that the user's Stellar account doesn't have a trustline.
+5. Anchors submits a Stellar transaction containing a claimable balance operation.
+6. Anchors update the `/transaction(s)` attriutes `status` to `completed` and `claimable_balance_id` to the ID returned in the Horizon response.
+
+##### Claimable Balance Claimants and Predicates
+
+Predicates are one of the [claimable balance parameters](https://developers.stellar.org/docs/glossary/claimable-balance/#parameters) used to craft a Claimable Balance transaction. They are conditions that must be satisfied in order for the recipient to claim the balance. Anchors are free to set whichever predicates they feel are necessary in order to claim the balance. If there are no predicate preferences, `UNCONDITIONAL` allows accounts to claim balances at anytime.
+
+## Withdraw
+
+This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
+
+The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify the url for the interactive webapp to continue with the anchor's side of the withdraw.
 
 ## Withdraw
 
@@ -653,6 +724,7 @@ Name | Type | Description
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
 `refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`claimable_balance_id` | string | (optional) ID of the Claimable Balance used to send the asset initially requested. Only relevant for deposit transactions.
 
 `status` should be one of:
 


### PR DESCRIPTION
resolves #796 

Adds support to SEP-6 for using claimable balance operations instead of waiting for a trustline to be established. The changes mirror [those made to SEP-24](#757) as closely as possible.