### PR TITLE
CAP-0035 - Add SetTrustLineFlags op result code and expand design rationale

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -638,6 +638,11 @@ It is also not possible to add the existing flag to the `AllowTrustOp` operation
 breaking existing users of that operation since they will not be expecting to include the
 current state of the `CLAWBACK_ENABLED_FLAG` in the flags field.
 
+Clearing the `CLAWBACK_ENABLED_FLAG` allows the issuer to create a clawback enabled asset,
+with a subset of trustlines that are not subject to clawback. The ability to clear flag will also
+allow an issuer to disable clawback on an asset entirely by removing `AUTH_CLAWBACK_ENABLED_FLAG`
+on its own account and clearing `CLAWBACK_ENABLED_FLAG` from all existing trustlines to that asset.
+
 ## Protocol Upgrade Transition
 
 ### Backwards Incompatibilities

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -190,7 +190,7 @@ index 8d746391..ab914436 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..449de093 100644
+index 7f08d757..ebbf45f5 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -300,7 +300,7 @@ index 7f08d757..449de093 100644
  };
  
  union SetOptionsResult switch (SetOptionsResultCode code)
-@@ -1120,6 +1161,70 @@ default:
+@@ -1120,6 +1161,71 @@ default:
      void;
  };
  
@@ -357,7 +357,8 @@ index 7f08d757..449de093 100644
 +    // codes considered as "failure" for the operation
 +    SET_TRUST_LINE_FLAGS_MALFORMED = -1,
 +    SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
-+    SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3
++    SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
++    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
 +};
 +
 +union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
@@ -371,7 +372,7 @@ index 7f08d757..449de093 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1176,6 +1281,12 @@ case opINNER:
+@@ -1176,6 +1282,12 @@ case opINNER:
          EndSponsoringFutureReservesResult endSponsoringFutureReservesResult;
      case REVOKE_SPONSORSHIP:
          RevokeSponsorshipResult revokeSponsorshipResult;
@@ -552,6 +553,8 @@ Possible return values for the `SetTrustLineFlagsOp` during application are:
 - `SET_TRUST_LINE_FLAGS_CANT_REVOKE` if `AUTH_REVOCABLE_FLAG` is not set on the issuer,
   but the authorization is downgraded (`AUTHORIZED_FLAG` -> `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG`, `AUTHORIZED_FLAG` -> 0,
   or `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` -> 0).
+- `SET_TRUST_LINE_FLAGS_INVALID_STATE` if the final state of the trustline flag has both
+  `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` set.
 
 ## Design Rationale
 
@@ -623,6 +626,12 @@ It requires the user to be aware of existing flags, which is an operational burd
 A new operation, `SetTrustLineFlagsOp`, is proposed in this cap to make 
 trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
 semantically intended to change authorization and clawback is outside it's scope.
+
+### Set TrustLine Flags Operation
+The `SetTrustLineFlagsOp` will make it easier for issuers to modify trustline flags.
+In the context of clawback, an issuer can clear the `CLAWBACK_ENABLED_FLAG` from a trustline
+without knowledge of the current state of the other flags. This is not possible with
+`AllowTrustOp` because it sets the trustline flags to the value passed in by `AllowTrustOp`.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -628,7 +628,9 @@ trustline flag modification simpler. Additionally the `AllowTrustOp` operation i
 semantically intended to change authorization and clawback is outside it's scope.
 
 ### Set TrustLine Flags Operation
+
 The `SetTrustLineFlagsOp` will make it easier for issuers to modify trustline flags.
+
 In the context of clawback, an issuer can clear the `CLAWBACK_ENABLED_FLAG` from a trustline
 without knowledge of the current state of the other flags. This is not possible with
 `AllowTrustOp` because it sets the trustline flags to the value passed in by `AllowTrustOp`.

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -634,6 +634,9 @@ The `SetTrustLineFlagsOp` will make it easier for issuers to modify trustline fl
 In the context of clawback, an issuer can clear the `CLAWBACK_ENABLED_FLAG` from a trustline
 without knowledge of the current state of the other flags. This is not possible with
 `AllowTrustOp` because it sets the trustline flags to the value passed in by `AllowTrustOp`.
+It is also not possible to add the existing flag to the `AllowTrustOp` operation without
+breaking existing users of that operation since they will not be expecting to include the
+current state of the `CLAWBACK_ENABLED_FLAG` in the flags field.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
1. Added a `SET_TRUST_LINE_FLAGS_INVALID_STATE` code that is returned if both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set during application.
2. Explained why `SetTrustLineFlagsOp` is useful. 