### PR TITLE
CAP-0035: Remove word weaking statement

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -473,8 +473,8 @@ will result in `SET_OPTIONS_AUTH_REVOCABLE_REQUIRED`.
 
 This proposal introduces the `ClawbackOp` operation. The `ClawbackOp`
 operation reduces the balance of the asset in the account by the specified
-amount of the specific `asset` from the `from` account, effectively returning
-it to the issuer account, burning it.
+amount of the specific `asset` from the `from` account, returning it to the
+issuer account, burning it.
 
 Similar to other operations the clawback operation will fail if the account
 balance is less than the amount specified when accounting for selling


### PR DESCRIPTION
### What
Remove the word `effectively` that was weakening the statement about conceptually the asset in a clawback is returned to the asset issuers.

### Why
The CAP states that the asset is burned and that it is returned to the issuer, but it uses the word effectively that implies that isn't what happens. In some ways this isn't what happens because issuer accounts do not hold a balance of an asset they issue. Any amount of an asset they issue sent to them via a payment or a trade is burned. On Stellar the way that an asset is burned is to return it to the issuer. It's worth us discussing what happens with a clawback using the same terms and concepts so that there is clear that this burn is no different to any other burn.

In the real world clawback means taking back of something. The thing isn't vaporized in place.

In discussions about the clawback feature it's clear that some of the use cases will be to clawback and reissue to a new account, different account, or the same account after sometime of dispute resolution. In concept the asset returns to the issuer, so I think it is clearer for us to say that's what happens rather than say that's what effectively happens.