### PR TITLE
CAP-0035: Remove word weaking statement

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -506,7 +506,7 @@ available balance of `asset` after accounting for selling liabilities.
 
 This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
 `ClawbackClaimableBalanceOp` operation destroys a claimable balance,
-effectively returning the asset to the issuer account, burning it.
+returning the asset to the issuer account, burning it.
 
 The operation will only succeed if the claimable balance has its
 `CLAWBACK_ENABLED_FLAG` set.


### PR DESCRIPTION
### What
Remove the word `effectively` that was weakening the statement about conceptually the asset in a clawback is returned to the asset issuers.

### Why
Same as #845.