### PR TITLE
Fix the stale notification message to say 30 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,8 +14,8 @@ jobs:
           debug-only: false
           days-before-stale: 30
           days-before-close: 30
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
-          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 5 days unless the stale label is removed, or a comment is posted.'
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed, or a comment is posted.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed, or a comment is posted.'
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: 'needs draft,needs pilot,accepted,blocked'


### PR DESCRIPTION
### What
Change the stale notification message to say that issues and pull requests will be closed after 30 days.

### Why
That's what the stale workflow will do, but the message says 5 days.