### PR TITLE
CAP-0036: Change status to Rejected

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -65,7 +65,6 @@
 | [CAP-0029](cap-0029.md) | AllowTrust when not AUTH_REQUIRED | Tomer Weller | Draft |
 | [CAP-0032](cap-0032.md) | Trustline Preauthorization | Jonathan Jove | Draft |
 | [CAP-0035](cap-0035.md) | Asset Clawback | Dan Doney | Draft |
-| [CAP-0036](cap-0036.md) | Claimable Balance Clawback | Leigh McCulloch | Draft |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |
@@ -73,6 +72,7 @@
 | [CAP-0013](cap-0013.md) | Change Trustlines to Balances | Dan Robinson | Rejected |
 | [CAP-0016](cap-0016.md) | Cosigned assets: NopOp and COAUTHORIZED_FLAG | David Mazières | Rejected |
 | [CAP-0031](cap-0031.md) | Sponsored Reserve | Jonathan Jove | Rejected |
+| [CAP-0036](cap-0036.md) | Claimable Balance Clawback | Leigh McCulloch | Rejected |
 
 # Contribution Process
 

--- a/core/cap-0036.md
+++ b/core/cap-0036.md
@@ -9,7 +9,7 @@ Working Group:
     Owner: Tomer Weller <@tomerweller>
     Authors: Leigh McCulloch <@leighmcculloch>
     Consulted: Nicolas Barry <@MonsieurNicolas>, Jon Jove <@jonjove>, Dan Doney (Securrency, Inc.), Bartek Nowotarski <@bartekn>
-Status: Draft
+Status: Rejected
 Created: 2020-12-16
 Discussion: https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/ZF6eJcqKAgAJ
 Protocol version: TBD


### PR DESCRIPTION
### What
Change the status of CAP-36 to rejected.

### Why
Support for the clawback of claimable balances has been adopted into CAP-35 and CAP-36 is no longer needed. There's been no formal call to reject it, but I authored it and think it should be withdrawn and status updated to reflect that we are not entertaining this idea.