### PR TITLE
CAP-0035 - Add MASK_ACCOUNT_FLAGS_V16 and fix flag names

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -63,8 +63,8 @@ assets in a manner that is fast, cheap, and highly usable.
 ## Abstract
 This proposal introduces new operations `ClawbackOp` and
 `ClawbackClaimableBalanceOp`, a new account flag
-`AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `CLAWBACK_ENABLED_FLAG`,
-and a new claimable balance flag `CLAWBACK_ENABLED_FLAG`.
+`AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `TRUSTLINE_CLAWBACK_ENABLED_FLAG`,
+and a new claimable balance flag `CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG`.
 
 The `AUTH_CLAWBACK_ENABLED_FLAG` flag on the issuing account must be set when a
 trustline is created to authorize a `ClawbackOp` operation submitted by the
@@ -95,7 +95,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..ab914436 100644
+index 8d746391..26ff33d4 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -28,6 +28,17 @@ enum AssetType
@@ -116,7 +116,7 @@ index 8d746391..ab914436 100644
  union Asset switch (AssetType type)
  {
  case ASSET_TYPE_NATIVE: // Not credit
-@@ -99,11 +110,15 @@ enum AccountFlags
+@@ -99,11 +110,16 @@ enum AccountFlags
      // otherwise, authorization cannot be revoked
      AUTH_REVOCABLE_FLAG = 0x2,
      // Once set, causes all AUTH_* flags to be read-only
@@ -129,12 +129,12 @@ index 8d746391..ab914436 100644
  };
  
  // mask for all valid flags
--const MASK_ACCOUNT_FLAGS = 0x7;
-+const MASK_ACCOUNT_FLAGS = 0xF;
+ const MASK_ACCOUNT_FLAGS = 0x7;
++const MASK_ACCOUNT_FLAGS_V16 = 0xF;
  
  // maximum number of signers
  const MAX_SIGNERS = 20;
-@@ -187,12 +202,16 @@ enum TrustLineFlags
+@@ -187,12 +203,16 @@ enum TrustLineFlags
      AUTHORIZED_FLAG = 1,
      // issuer has authorized account to maintain and reduce liabilities for its
      // credit
@@ -152,7 +152,7 @@ index 8d746391..ab914436 100644
  
  struct TrustLineEntry
  {
-@@ -337,6 +356,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
+@@ -337,6 +357,27 @@ case CLAIMABLE_BALANCE_ID_TYPE_V0:
      Hash v0;
  };
  
@@ -180,7 +180,7 @@ index 8d746391..ab914436 100644
  struct ClaimableBalanceEntry
  {
      // Unique identifier for this ClaimableBalanceEntry
-@@ -356,6 +396,8 @@ struct ClaimableBalanceEntry
+@@ -356,6 +397,8 @@ struct ClaimableBalanceEntry
      {
      case 0:
          void;
@@ -425,7 +425,7 @@ existing `AUTH_*` flags may be set or unset unless the immutable flag is set.
 
 #### Trustline
 
-This proposal introduces a new flag to trustlines, `CLAWBACK_ENABLED_FLAG`,
+This proposal introduces a new flag to trustlines, `TRUSTLINE_CLAWBACK_ENABLED_FLAG`,
 that is set at the time the trustline is created if the issuer account of the
 asset of the trustline has its `AUTH_CLAWBACK_ENABLED_FLAG` flag set.
 
@@ -436,9 +436,9 @@ claimable balance created by the account will also be clawback enabled.
 #### Claimable Balance
 
 This proposal introduces the first flag to claimable balances,
-`CLAWBACK_ENABLED_FLAG`, that is set at the time the claimable balance is
-created if the account creating the claimable balance has
-`CLAWBACK_ENABLED_FLAG` set on the trustline of the asset of the claimable
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG`, that is set at the time the claimable 
+balance is created if the account creating the claimable balance has
+`TRUSTLINE_CLAWBACK_ENABLED_FLAG` set on the trustline of the asset of the claimable
 balance.
 
 If the new flag is set it indicates that the balance held by the claimable
@@ -448,12 +448,12 @@ balance can be clawed back by the issuer using the
 #### Allow Trust Operation
 
 This proposal introduces no changes to the `AllowTrustOp` operation XDR, but
-the operation will not accept the `CLAWBACK_ENABLED_FLAG` as a valid flag
+the operation will not accept the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` as a valid flag
 that it will operate. The definition of what flags the operation supports
 will be limited to `AUTHORIZED_*` flags. When applying new flags to accounts
-the operation will not change the `CLAWBACK_ENABLED_FLAG`.
+the operation will not change the `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
 
-If an `AllowTrustOp` operation is submitted with the `CLAWBACK_ENABLED_FLAG`
+If an `AllowTrustOp` operation is submitted with the `TRUSTLINE_CLAWBACK_ENABLED_FLAG`
 set, the operation will fail with the existing result code
 `ALLOW_TRUST_MALFORMED`.
 
@@ -497,7 +497,7 @@ operation.
 
 Possible return values for the `ClawbackOp` during application are:
 - `CLAWBACK_SUCCESS` if the clawback is successful.
-- `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `CLAWBACK_ENABLED_FLAG` is not set.
+- `CLAWBACK_NOT_CLAWBACK_ENABLED` if the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` is not set.
 - `CLAWBACK_NO_TRUST` if the `from` account does not have a trustline for
 `asset`.
 - `CLAWBACK_UNDERFUNDED` if the `from` account does not have sufficient
@@ -510,7 +510,7 @@ This proposal introduces the `ClawbackClaimableBalanceOp` operation. The
 returning the asset to the issuer account, burning it.
 
 The operation will only succeed if the claimable balance has its
-`CLAWBACK_ENABLED_FLAG` set.
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` set.
 
 The operation source account must be the issuer account of the asset held in
 the claimable balance.
@@ -532,19 +532,19 @@ not exist.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_ISSUER` if the source account is the not
 the issuer of the `asset`.
 - `CLAWBACK_CLAIMABLE_BALANCE_NOT_CLAWBACK_ENABLED` if the
-`CLAWBACK_ENABLED_FLAG` is not set.
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` is not set.
 
 #### Set TrustLine Flags Operation
 
 This proposal introduces the `SetTrustLineFlagsOp` operation. The operation works
 like the `AllowTrustOp`, except it uses set and clear parameters to set/clear specific
-trustline flags. This will allow an issuer to clear the `CLAWBACK_ENABLED_FLAG`. 
+trustline flags. This will allow an issuer to clear the `TRUSTLINE_CLAWBACK_ENABLED_FLAG`. 
 
 `SET_TRUST_LINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
 - Both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`.
 - `asset` is invalid. 
 - `setFlags` and `clearFlags` are modifying the same flags.
-- `setFlags` has the `CLAWBACK_ENABLED_FLAG` set.
+- `setFlags` has the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` set.
 - `trustor` == source account
 
 Possible return values for the `SetTrustLineFlagsOp` during application are:
@@ -584,12 +584,12 @@ able to revoke authorization to release any offers creating selling
 liabilities with the asset. If an issuer enables clawback but not
 `AUTH_REVOCABLE_FLAG` it will likely be oversight.
 
-By setting the `CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners
+By setting the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` flag on the trustline, account owners
 have confidence that the clawback feature may not be enabled if it was not
 enabled when they created their trustline.
 
-By setting the `CLAWBACK_ENABLED_FLAG` flag on the claimable balance based on
-the state of the trustline of the account creating the claimable balance,
+By setting the `CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` flag on the claimable balance 
+based on the state of the trustline of the account creating the claimable balance,
 account owners have confidence that the clawback feature may not be enabled
 for claimable balances they create if it was not enabled when they created
 their trustline.
@@ -619,7 +619,7 @@ clawback.
 
 ### Allow Trust Operation
 
-The `AllowTrustOp` is disallowed from operating on the new `CLAWBACK_ENABLED_FLAG`
+The `AllowTrustOp` is disallowed from operating on the new `TRUSTLINE_CLAWBACK_ENABLED_FLAG`
 trustline flag because this operation doesn't have a parameter to set/clear flags.
 It requires the user to be aware of existing flags, which is an operational burden.
 
@@ -631,17 +631,18 @@ semantically intended to change authorization and clawback is outside it's scope
 
 The `SetTrustLineFlagsOp` will make it easier for issuers to modify trustline flags.
 
-In the context of clawback, an issuer can clear the `CLAWBACK_ENABLED_FLAG` from a trustline
+In the context of clawback, an issuer can clear the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` from a trustline
 without knowledge of the current state of the other flags. This is not possible with
 `AllowTrustOp` because it sets the trustline flags to the value passed in by `AllowTrustOp`.
 It is also not possible to add the existing flag to the `AllowTrustOp` operation without
 breaking existing users of that operation since they will not be expecting to include the
-current state of the `CLAWBACK_ENABLED_FLAG` in the flags field.
+current state of the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` in the flags field.
 
-Clearing the `CLAWBACK_ENABLED_FLAG` allows the issuer to create a clawback enabled asset,
+Clearing the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` allows the issuer to create a clawback enabled asset,
 with a subset of trustlines that are not subject to clawback. The ability to clear flag will also
 allow an issuer to disable clawback on an asset entirely by removing `AUTH_CLAWBACK_ENABLED_FLAG`
-on its own account and clearing `CLAWBACK_ENABLED_FLAG` from all existing trustlines to that asset.
+on its own account and clearing `TRUSTLINE_CLAWBACK_ENABLED_FLAG` from all existing trustlines to 
+that asset.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
1. I removed `MASK_ACCOUNT_FLAGS_V16` from the original proposal, but I'm adding it back in since it'll be helpful to check for invalid flags based on protocol version in the invariants.
2. Updated usage of the outdated `CLAWBACK_ENABLED_FLAG` flag name.