### PR TITLE
SEP-10: Clarifying Participants

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -162,7 +162,6 @@ To validate the challenge transaction the following steps are performed by the *
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
 * verify that transaction's first operation is a [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation that:
   * has a non-null source account
-  * has the **Home Domain** as the key of the operation
 * verify that transaction envelope has a correct signature by the **Server Account**
 * if the operation's source account exists:
   * verify that the remaining signature count is one or more;

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -160,7 +160,9 @@ To validate the challenge transaction the following steps are performed by the *
 * decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
 * verify that transaction source account is equal to the **Server Account**
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
-* verify that transaction's first operation is a [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation that:
+* verify that transaction contains at least one operation;
+* verify that transaction's first operation:
+  * is a Manage Data operation
   * has a non-null source account
 * verify that transaction envelope has a correct signature by the **Server Account**
 * if the operation's source account exists:

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2021-02-10
-Version 3.1.1
+Updated: 2021-03-03
+Version 3.1.2
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -18,57 +18,58 @@ This SEP defines the standard way for clients such as wallets or exchanges to cr
 
 This protocol is a variation of mutual challenge-response, which uses Stellar transactions to encode challenges and responses.
 
-It involves three components:
-- A domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_ENDPOINT` (URL) and `SIGNING_KEY` (`G...`), referred to as the home domain.
-- An endpoint providing the GET and POST operations discussed in this document. The endpoint may be hosted on the home domain, a sub-domain of the home domain, or any other domain. The domain where the endpoint is hosted is referred to as the web auth domain. 
-- A client who will authenticate using a Stellar account.
+It involves the following components:
+- A **Home Domain**: a domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_ENDPOINT` (URL) and `SIGNING_KEY` (`G...`).
+- A **Server**: a server providing the `WEB_AUTH_ENDPOINT` that implements the GET and POST operations discussed in this document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or any other domain.
+    - The `SIGNING_KEY` from the **Home Domain** will be refered to as the **Server Account**.
+- A **Client**: the software used by the holder of the account being authenticated by the **Server**.
+    - The account being authenticated will be refered to as the **Client Account**.
 
 The discovery flow is as follows:
 
-1. The client retrieves the `stellar.toml` from the home domain in accordance with [SEP-1 stellar.toml](sep-0001.md).
-1. The client looks up the `WEB_AUTH_ENDPOINT` and `SIGNING_KEY` from the `stellar.toml`.
+1. The **Client** retrieves the `stellar.toml` from the **Home Domain** in accordance with [SEP-1 stellar.toml](sep-0001.md).
+1. The **Client** looks up the `WEB_AUTH_ENDPOINT` and `SIGNING_KEY` (i.e. **Server Account**) from the `stellar.toml`.
 
 The authentication flow is as follows:
-1. The client obtains a unique [`challenge`](#challenge) from the `WEB_AUTH_ENDPOINT`, which is represented as specially formed Stellar transaction
-1. The client verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
-1. The client verifies that the transaction is signed by the `SIGNING_KEY` obtained through discovery flow.
-1. The client verifies that the transaction's first operation is a Manage Data operation that has its:
-   1. Source account set to the user's account.
-   1. Key set to `<home domain> auth` where the home domain is the home domain from the discovery flow.
+
+1. The **Client** obtains a unique [`challenge`](#challenge) from the **Server**, which is represented as specially formed Stellar transaction
+1. The **Client** verifies that the transaction has an invalid sequence number 0.  This is extremely important to ensure the transaction isn't malicious.
+1. The **Client** verifies that the transaction is signed by the **Server Account** obtained through discovery flow.
+1. The **Client** verifies that the transaction's first operation is a Manage Data operation that has its:
+   1. Source account set to the **Client Account**
+   1. Key set to `<home domain> auth` where the home domain is the **Home Domain**.
    1. Value set to a nonce value.
-1. The client verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
-   1. Source account set to the server's account.
-   1. Key set to `web_auth_domain`.
-   1. Value set to the domain name of the SEP-10 server from which the client requested the challenge.
-1. The client verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the the server's account.
-1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
-1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
-1. The server checks that the user's account exists
-1. If the user's account exists:
-  1. The server gets the signers of the user's account
-  1. The server verifies the client signatures count is one or more;
-  1. The server verifies the client signatures on the transaction are signers of the user's account;
-  1. The server verifies the weight provided by the signers meets the required threshold(s), if any
-  1. If the signatures check out, the server responds with a [JWT](https://jwt.io) that represents the user's session
-1. If the user's account does not exist (optional):
-  1. The server verifies the client signature count is one
-  1. The server verifies the client signature is correct for the master key of the account
-1. Any future calls to the server can be authenticated by including the JWT as a parameter
+1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
+   1. Source account set to the **Server Account**.
+   1. Value set to the **Server**'s domain.
+1. The **Client** verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the **Server Account**
+1. The **Client** signs the transaction using the secret key(s) of the signer(s) for the **Client Account**
+1. The **Client** submits the signed challenge back to the **Server** using [`token`](#token) endpoint
+1. The **Server** checks that the **Client Account** exists
+1. If the **Client Account** exists:
+  1. The **Server** gets the signers of the **Client Account**
+  1. The **Server** verifies that one or more signatures are from signers of the **Client Account**.
+  1. The **Server** verifies that there is only one additional signature from the **Server Account**
+  1. The **Server** verifies the weight provided by the signers of the **Client Account** meets the required threshold(s), if any
+1. If the **Client Account** does not exist (optional):
+  1. The **Server** verifies the signature count is two
+  1. The **Server** verifies that one signature is correct for the master key of the **Client Account**
+  1. The **Server** verified that the other signature is from the **Server Account**
+1. If the signatures check out, the **Server** responds with a [JWT](https://jwt.io) that represents the authenticated session
 
 The flow achieves several things:
 
-* Both client and server part can be implemented using well-established Stellar libraries
-* The client can verify that the server holds the secret key to a particular account
-* The server can verify that the client holds the secret key(s) to signers of their account
-* The client is able to prove their identity using a Ledger or other hardware wallet as well as by having direct access to the secret key(s)
-* The server can choose its own timeout for the user's session
-* The server can choose required threshold(s) that the user needs on the account, if any
-* The server can choose to include other application specific claims
-* The server can choose to authenticate accounts that do not yet exist
+* Both **Client** and **Server** can be implemented using well-established Stellar libraries
+* The **Client** can verify that the **Server** holds the secret key to the **Server Account**
+* The **Server** can verify that the **Client** holds the secret key(s) to signer(s) of the **Client Account**
+* The **Server** can choose its own timeout for the authenticated session
+* The **Server** can choose required signing threshold(s) that must be met, if any
+* The **Server** can choose to include other application-specific claims
+* The **Server** can choose to authenticate Stellar accounts that do not yet exist
 
 ## Authentication Endpoint
 
-A web service indicates that it supports user authentication via this protocol by specifying `WEB_AUTH_ENDPOINT` in their [`stellar.toml`](sep-0001.md) file. This is how a wallet knows where to find the authentication server. A web server is required to implement the following behavior for the web authentication endpoint:
+The organization with a **Home Domain** indicates that it supports authentication via this protocol by specifying `WEB_AUTH_ENDPOINT` in their [`stellar.toml`](sep-0001.md) file. This is how a wallet knows where to find the **Server**. A **Server** is required to implement the following behavior for the web authentication endpoint:
 
 * [`GET <WEB_AUTH_ENDPOINT>`](#challenge): request a challenge (step 1)
 * [`POST <WEB_AUTH_ENDPOINT>`](#token): exchange a signed challenge for session JWT (step 2)
@@ -85,8 +86,7 @@ In order for browsers-based wallets to validate the CORS headers, as [specified 
 
 ### Challenge
 
-This endpoint must respond with a Stellar transaction signed by the server that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The client can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that they control their account. This approach is compatible with hardware wallets such as Ledger. The client must also verify the server's signature to be sure the challenge is signed by the `SIGNING_KEY`, and the home domain in the challenge is the home domain from the discovery flow.
-
+This endpoint must respond with a Stellar transaction signed by the **Server Account** that has an invalid sequence number (0) and thus cannot be executed on the Stellar network. The **Client** can then sign the transaction using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that it controls the **Client Account**. This approach is compatible with hardware wallets such as Ledger. The **Client Application** must also verify the server's signature to be sure the challenge is signed by the **Server Account**, that the home domain in the first operation of the challenge is the **Home Domain**, and that the web auth domain in a subsequent operation is the **Server** domain.
 
 #### Request
 
@@ -98,8 +98,8 @@ Request Parameters:
 
 Name      | Type          | Description
 ----------|---------------|------------
-`account` | `G...` string | The stellar account that the wallet wishes to authenticate with the server
-`home_domain` | string | (optional) The home domain the client would like to authenticate with. Servers that generate tokens for multiple home domains can use this parameter to identify which home domain the client hopes to authenticate. If not provided by the client, the server should assume a default for backwards compatibility with older clients.
+`account` | `G...` string | The stellar account that the wallet wishes to authenticate with the **Server** 
+`home_domain` | string | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.
 
 Example:
 
@@ -112,19 +112,21 @@ GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDI
 On success the endpoint must return `200 OK` HTTP status code and a JSON object with these fields:
 
 * `transaction`: an XDR-encoded Stellar transaction with the following:
-  * source account set to server's signing account
+  * source account set to the **Server Account**
   * invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
-  * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give user time to sign transaction)
+  * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give the **Client** time to sign transaction)
   * operations:
-    * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
-      * The value of key is the home domain the client is authenticating with, followed by `auth`. It can be at most 64 characters.
+    * `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
+      * The source account is the **Client Account**
+      * The value of key is the **Home Domain**, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
     * subsequent operations, order unimportant:
-      * `manage_data(source: server_account, key: 'web_auth_domain', value: web_auth_domain)`
-        * The value is the web auth domain, the domain hosting the web auth endpoint and that the client connected to when requesting the challenge transaction. It can be at most 64 characters.
-      * zero or more `manage_data(source: server_account, ...)` reserved for future use
-  * signature by the service's stellar.toml `SIGNING_KEY`
-* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing and is useful for identifying when a client or server have been configured incorrectly.
+      * `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
+        * The source account is the **Server Account**
+        * The value is the **Server**'s domain. It can be at most 64 characters.
+      * zero or more `manage_data(source: server account, ...)` reserved for future use
+  * signature by the **Server Account**
+* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the **Home Domain**. This allows a **Client** to verify that it's using the correct passphrase when signing and is useful for identifying when a **Client** or **Server** have been configured incorrectly.
 
 Example:
 ```json
@@ -146,38 +148,36 @@ Every other HTTP status code will be considered an error. For example:
 
 ### Token
 
-This endpoint accepts a signed challenge transaction, validates it and responds with a session [JSON Web Token](https://jwt.io/) authenticating the user.
+This endpoint accepts a signed challenge transaction, validates it and responds with a session [JSON Web Token](https://jwt.io/) authenticating the account.
 
-Client submits a challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint) as a HTTP POST request to `WEB_AUTH_ENDPOINT` using one of the following formats (both should be equally supported by the server):
+The **Client** submits a challenge transaction (that was previously returned by the [`challenge`](#challenge) endpoint) as a HTTP POST request to `WEB_AUTH_ENDPOINT` using one of the following formats (both should be equally supported by the server):
 
 * Content-Type: `application/x-www-form-urlencoded`, body: `transaction=<signed XDR (URL-encoded)>`)
 * Content-Type: `application/json`, body: `{"transaction": "<signed XDR>"}`
 
-To validate the challenge transaction the following steps are performed by the server. If any of the listed steps fail, then the authentication request must be rejected — that is, treated by the application as an invalid input.
+To validate the challenge transaction the following steps are performed by the **Server**. If any of the listed steps fail, then the authentication request must be rejected — that is, treated by the **Server** as an invalid input.
 
 * decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
-* verify that transaction source account is equal to the server's signing key;
+* verify that transaction source account is equal to the **Server Account**
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
-* verify that transaction contains at least one operation;
-* verify that transaction's first operation:
-  * is a Manage Data operation
+* verify that transaction's first operation is a [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation that:
   * has a non-null source account
-* verify that transaction envelope has a correct signature by server's signing key;
-* if the first operation's source account exists:
-  * verify that client signatures count is one or more;
-  * verify that client signatures on the transaction are signers of the first operation's source account;
-  * verify that client signatures are correct;
-  * verify that client signatures provide weight that meets the required threshold(s), if any;
-* if the first operation's source account does not exist:
-  * verify that client signature count is one;
-  * verify that client signature is correct for the master key of the first operation's source account address;
-* verify that transaction containing additional Manage Data operations have their source account as the server signing key;
+  * has the **Home Domain** as the key of the operation
+* verify that transaction envelope has a correct signature by the **Server Account**
+* if the operation's source account exists:
+  * verify that the remaining signature count is one or more;
+  * verify that remaining signatures on the transaction are signers of the operation's source account;
+  * verify that remaining signatures are correct;
+  * verify that remaining signatures provide weight that meets the required threshold(s), if any;
+* if the operation's source account does not exist:
+  * verify that remaining signature count is one;
+  * verify that remaining signature is correct for the master key of the **Client Account**
+* verify that transaction containing additional Manage Data operations have their source account set to the **Server Account**;
 * verify that transaction sequenceNumber is equal to zero;
-* use operations's source account to determine the authenticating client and perform any additional service-specific validations.
 
-The verification process confirms that a user holds an account. Depending on your application this may mean complete signing authority, some threshold of control, or being a signer of the account. See [Verification](#verification) for examples.
+The verification process confirms that the **Client** controls the **Client Account**. Depending on your application this may mean complete signing authority, some threshold of control, or being a signer of the account. See [Verification](#verification) for examples.
 
-Upon successful verification, service responds with a session JWT, containing the following claims:
+Upon successful verification, **Server** responds with a session JWT, containing the following claims:
 
 * `iss` (the principal that issued a token, [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)) — a [Uniform Resource Identifier (URI)] for the issuer (`https://example.com` or `https://example.com/G...`)
 * `sub` (the principal that is the subject of the JWT, [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2)) — the public key of the authenticating Stellar account (`G...`)
@@ -214,11 +214,11 @@ You can examine the example signed challenge transaction in the [XDR Viewer](htt
 
 #### Response
 
-If the web service successfully validates the submitted challenge transaction, the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
+If the **Server** successfully validates the submitted challenge transaction, the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
 Name    | Type   | Description
 --------|--------|------------
-`token` | string | The JWT that a user can use to authenticate future endpoint calls with the anchor
+`token` | string | The JWT that can be used to authenticate future endpoint calls with the anchor
 
 Example:
 
@@ -240,41 +240,41 @@ Every other HTTP status code will be considered an error. For example:
 
 ## Verification
 
-The verification process confirms that a user holds an account. Depending on your application this may mean complete signing authority, some threshold of control, or being a signer of the account.
+The verification process confirms that a **Client** controls the **Client Account**. Depending on your application this may mean complete signing authority, some threshold of control, or being a signer of the account.
 
 An account's master key may not meet any threshold of control or could have had its weight reduced to zero. Most applications should not assume possession of the master key is possession of an account.
 
-An account's signers may include third-party services providing services to the user. Authenticating users with less than any threshold may allow a third-party to authenticate as a user.
+An account's signers may include third-party services providing services to the account holder of the **Client Account**. Authenticating accounts with less than any threshold may allow a third-party to authenticate.
 
-An account's signers may include the server's signing key if the server is a signer for the account. When determining the weight of the client sigantures the server's signature should be explicitly excluded. A server should not assist a client in authentication.
+An account's signers may include the **Server Account** if the server is a signer for the account. When determining the weight of the remaining sigantures the signature from the **Server Account** should be explicitly excluded. A **Server** should not assist in authentication.
 
-The server should only issue a JWT if the appropriate thresholds are met, but if a server is supporting a variety of applications it may choose to use additional application specific claims to capture the threshold of control the user has proven.
+The **Server** should only issue a JWT if the appropriate thresholds are met, but if a **Server** is supporting a variety of applications it may choose to use additional application specific claims to capture the threshold of control the **Client** has proven.
 
 ### Verifying Authority to Move Funds
 
-A server that needs to verify that a user has authority aligned with the capability to move money out of an account can verify that the user meets the medium threshold. It should do this by checking that the sum of the weights of the challenge transaction signers is equal or greater to the medium threshold.
+A **Server** that needs to verify that the **Client** has authority aligned with the capability to move money out of an **Client Account** can verify that the medium threshold is met. It should do this by checking that the sum of the weights of the challenge transaction signers is equal or greater to the medium threshold.
 
 #### Example
 
-An anchor implementing [SEP-24] will let an authenticated user define the destination of withdrawn funds. This level of control is similar to the capability to choose the destination of payments on the network which require a medium threshold.
+An anchor implementing [SEP-24] will let an authenticated **Client** define the destination of withdrawn funds. This level of control is similar to the capability to choose the destination of payments on the network which require a medium threshold.
 
 [SEP-24]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
 
 ### Verifying Complete Authority
 
-A server that needs to verify a user has complete authority of an account should verify that the weight of the client signatures meet the high threshold. It should do this by checking that the sum of the weights is equal or greater to the high threshold.
+A **Server** that needs to verify the **Client** has complete authority of an **Client Account** should verify that the weight of the client signatures meet the high threshold. It should do this by checking that the sum of the weights is equal or greater to the high threshold.
 
 ### Verifying Being a Signer
 
-A server may choose to issue JWTs for less than all thresholds and based on any other application specific logic. It's important to keep in mind that a Stellar account may have third-parties who are signers. Authenticating users with less than any threshold may allow a third-party to authenticate as a user.
+A **Server** may choose to issue JWTs for less than all thresholds and based on any other application specific logic. It's important to keep in mind that a Stellar account may have third-parties who are signers. Authenticating accounts with less than any threshold may allow a third-party to authenticate.
 
 ### Verifying Accounts that Do Not Exist
 
-A server that needs to support validating accounts that do not exist can require a signature of the master key of the account address for accounts that do not exist.
+A **Server** that needs to support validating accounts that do not exist can require a signature of the master key of the account address for accounts that do not exist.
 
 ## JWT Expiration
 
-Servers should select an expiration time for the JWT that is appropriate for the assumptions and risk of the interactions a user can perform with it. A user may be in control of an account at the time the JWT is issued but they may lose control of the account through a change in signers. Expiration times that are too long increase the risk that control on the account has changed. Expiration times that are too short increase the number of times authentication must reoccur, and a user using a hardware signing device or who must complete a complex signing process could have a poor user experience.
+Servers should select an expiration time for the JWT that is appropriate for the assumptions and risk of the interactions the **Client** can perform with it. A **Client** may be in control of an account at the time the JWT is issued but they may lose control of the account through a change in signers. Expiration times that are too long increase the risk that control on the account has changed. Expiration times that are too short increase the number of times authentication must reoccur, and a user using a hardware signing device or who must complete a complex signing process could have a poor user experience.
 
 ## A convention for signatures
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -20,10 +20,10 @@ This protocol is a variation of mutual challenge-response, which uses Stellar tr
 
 It involves the following components:
 - A **Home Domain**: a domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_ENDPOINT` (URL) and `SIGNING_KEY` (`G...`).
-- A **Server**: a server providing the `WEB_AUTH_ENDPOINT` that implements the GET and POST operations discussed in this document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or any other domain.
-    - The `SIGNING_KEY` from the **Home Domain** will be refered to as the **Server Account**.
+- A **Server**: a server providing the `WEB_AUTH_ENDPOINT` that implements the GET and POST operations discussed in this document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or a different domain.
+    - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
 - A **Client**: the software used by the holder of the account being authenticated by the **Server**.
-    - The account being authenticated will be refered to as the **Client Account**.
+    - The account being authenticated is the **Client Account**.
 
 The discovery flow is as follows:
 
@@ -41,7 +41,7 @@ The authentication flow is as follows:
    1. Value set to a nonce value.
 1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
    1. Source account set to the **Server Account**.
-   1. Value set to the **Server**'s domain.
+   1. Value set to the **Server**'s domain that the client requested the challenge from.
 1. The **Client** verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the **Server Account**
 1. The **Client** signs the transaction using the secret key(s) of the signer(s) for the **Client Account**
 1. The **Client** submits the signed challenge back to the **Server** using [`token`](#token) endpoint
@@ -126,7 +126,7 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
         * The value is the **Server**'s domain. It can be at most 64 characters.
       * zero or more `manage_data(source: server account, ...)` reserved for future use
   * signature by the **Server Account**
-* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the **Home Domain**. This allows a **Client** to verify that it's using the correct passphrase when signing and is useful for identifying when a **Client** or **Server** have been configured incorrectly.
+* `network_passphrase`: (optional but recommended) Stellar network passphrase used by the **Server**. This allows a **Client** to verify that it's using the correct passphrase when signing and is useful for identifying when a **Client** or **Server** have been configured incorrectly.
 
 Example:
 ```json


### PR DESCRIPTION
This change does not change any functionality related to SEP-10. Rather, it better defines the participants involved in the process and updating the document to always reference those participant definitions. This will help avoid confusion when referencing the participants, instead of using general terms like `client` and `server`.

If merged, I'll update #760 to use the term **Client Server**