### PR TITLE
CAP-0035: Changes from the Open Protocol Meeting held on 2021-01-28

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -87,7 +87,7 @@ The `ClawbackOp` may result in revocation of some or all of the specified
 assets from the designated account based on the amount provided in the
 operation.
 
-The `SetTrustLineFlagsOp` will allow the user to set and clear specific trustline 
+The `SetTrustLineFlagsOp` allows the user to set and clear specific trustline 
 flags. This operation can be used to unset `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
 
 ## Specification

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -653,11 +653,7 @@ allow an issuer to disable clawback on an asset entirely by removing `AUTH_CLAWB
 on its own account and clearing `TRUSTLINE_CLAWBACK_ENABLED_FLAG` from all existing trustlines to 
 that asset.
 
-`SetTrustLineFlagsOp` uses an `Asset` as a parameter instead of an `AssetCode`. This won't matter
-in protocol 16 because the operation is invalid if the issuer on `Asset` is not the source account,
-but it'll allow us to explore options for an account that's not the issuer to change trustline flags.
-The two scenarios we currently have in mind are the owner changing the trustline flag and the issuer
-delegating trustline flag modification to a different account.
+`SetTrustLineFlagsOp` uses an `Asset` as a parameter instead of an `AssetCode` to defer the decision of who all future authorizers of the operation can be. The `Asset` includes the issuer account, where-as use of `AssetCode` would assume the source account is always the issuer account. In this proposal, only the issuer may authorize the operation. This decision makes it possible in a future proposal to expand the accounts that may be allowed to issue the operation.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -193,7 +193,7 @@ index 8d746391..26ff33d4 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..59061025 100644
+index 7f08d757..da11bce9 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -243,7 +243,7 @@ index 7f08d757..59061025 100644
 +*/
 +struct ClawbackOp
 +{
-+    AssetCode asset;
++    Asset asset;
 +    MuxedAccount from;
 +    int64 amount;
 +};
@@ -653,7 +653,14 @@ allow an issuer to disable clawback on an asset entirely by removing `AUTH_CLAWB
 on its own account and clearing `TRUSTLINE_CLAWBACK_ENABLED_FLAG` from all existing trustlines to 
 that asset.
 
-`SetTrustLineFlagsOp` uses an `Asset` as a parameter instead of an `AssetCode` to defer the decision of who all future authorizers of the operation can be. The `Asset` includes the issuer account, where-as use of `AssetCode` would assume the source account is always the issuer account. In this proposal, only the issuer may authorize the operation. This decision makes it possible in a future proposal to expand the accounts that may be allowed to issue the operation.
+
+### Asset instead of AssetCode
+
+Both `SetTrustLineFlagsOp` and `ClawbackOp` use an `Asset` as a parameter instead of an `AssetCode` 
+to defer the decision of who all future authorizers of the operation can be. The `Asset` includes 
+the issuer account, where-as use of `AssetCode` would assume the source account is always the issuer
+account. In this proposal, only the issuer may authorize the operation. This decision makes it possible
+in a future proposal to expand the accounts that may be allowed to issue the operation.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -633,7 +633,8 @@ A new operation, `SetTrustLineFlagsOp`, is proposed in this cap to make
 trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
 semantically intended to change authorization and clawback is outside it's scope.
 
-The `AllowTrustOp` is being deprecated for `SetTrustLineFlagsOp`.
+The `AllowTrustOp` is deprecated for `SetTrustLineFlagsOp`.
+
 
 ### Set TrustLine Flags Operation
 

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -61,8 +61,8 @@ exchange of assets, throughout the globe, enabling users to make payments betwee
 assets in a manner that is fast, cheap, and highly usable.
 
 ## Abstract
-This proposal introduces new operations `ClawbackOp` and
-`ClawbackClaimableBalanceOp`, a new account flag
+This proposal introduces new operations `ClawbackOp`,
+`ClawbackClaimableBalanceOp`, and `SetTrustLineFlagsOp`, a new account flag
 `AUTH_CLAWBACK_ENABLED_FLAG`, a new trustline flag `TRUSTLINE_CLAWBACK_ENABLED_FLAG`,
 and a new claimable balance flag `CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG`.
 
@@ -86,6 +86,9 @@ asset owners are aware of rights.
 The `ClawbackOp` may result in revocation of some or all of the specified
 assets from the designated account based on the amount provided in the
 operation.
+
+The `SetTrustLineFlagsOp` will allow the user to set and clear specific trustline 
+flags. This operation can be used to unset `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
 
 ## Specification
 
@@ -190,7 +193,7 @@ index 8d746391..26ff33d4 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..ebbf45f5 100644
+index 7f08d757..59061025 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -268,7 +271,7 @@ index 7f08d757..ebbf45f5 100644
 +struct SetTrustLineFlagsOp
 +{
 +    AccountID trustor;
-+    AssetCode asset;
++    Asset asset;
 +
 +    uint32* clearFlags; // which flags to clear
 +    uint32* setFlags;   // which flags to set
@@ -542,10 +545,13 @@ trustline flags. This will allow an issuer to clear the `TRUSTLINE_CLAWBACK_ENAB
 
 `SET_TRUST_LINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
 - Both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`.
-- `asset` is invalid. 
+- `asset` is invalid.
+- `asset` is `ASSET_TYPE_NATIVE`.
 - `setFlags` and `clearFlags` are modifying the same flags.
+- `setFlags` or `clearFlags` are modifying unsupported flags.
 - `setFlags` has the `TRUSTLINE_CLAWBACK_ENABLED_FLAG` set.
 - `trustor` == source account
+- `asset.issuer` != source account
 
 Possible return values for the `SetTrustLineFlagsOp` during application are:
 - `SET_TRUST_LINE_FLAGS_SUCCESS` if the operation is successful.
@@ -627,6 +633,8 @@ A new operation, `SetTrustLineFlagsOp`, is proposed in this cap to make
 trustline flag modification simpler. Additionally the `AllowTrustOp` operation is
 semantically intended to change authorization and clawback is outside it's scope.
 
+The `AllowTrustOp` is being deprecated for `SetTrustLineFlagsOp`.
+
 ### Set TrustLine Flags Operation
 
 The `SetTrustLineFlagsOp` will make it easier for issuers to modify trustline flags.
@@ -643,6 +651,12 @@ with a subset of trustlines that are not subject to clawback. The ability to cle
 allow an issuer to disable clawback on an asset entirely by removing `AUTH_CLAWBACK_ENABLED_FLAG`
 on its own account and clearing `TRUSTLINE_CLAWBACK_ENABLED_FLAG` from all existing trustlines to 
 that asset.
+
+`SetTrustLineFlagsOp` uses an `Asset` as a parameter instead of an `AssetCode`. This won't matter
+in protocol 16 because the operation is invalid if the issuer on `Asset` is not the source account,
+but it'll allow us to explore options for an account that's not the issuer to change trustline flags.
+The two scenarios we currently have in mind are the owner changing the trustline flag and the issuer
+delegating trustline flag modification to a different account.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
This PR has a few changes -

1. Change `SetTrustLineFlagsOp` `AssetCode` parameter to `Asset` so we can extend use of this operation in the future.
2. Add additional validation conditions for the `Asset` parameter specified above.
3. Expand existing explanations.