### PR TITLE
SEP-0008: Address ambiguities in the action_required use case

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -234,7 +234,7 @@ Name | Type | Description
 `message` | string | A human readable string containing information regarding the action required.
 `action_url` | string | A URL that allows the user to complete the actions required to have the transaction approved.
 `action_method` | string | (optional) `GET` or `POST`, indicating the type of request that should be made to the `action_url`. If not provided, `GET` is assumed.
-`action_fields` | string[] | (optional) An array of additional fields defined by [SEP-9 Standard KYC / AML fields] that the client may optionally provide to the approval service when sending the request to the `action_url`.
+`action_fields` | string[] | (optional) An array of additional fields defined by [SEP-9 Standard KYC / AML fields] that the client may optionally provide to the approval service when sending the request to the `action_url` so as to circumvent the need for the user to enter the information manually.
 
 ###### Example
 
@@ -248,14 +248,20 @@ Name | Type | Description
 }
 ```
 
-###### Action URL
-If the `action_method` is provided, the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information, the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
+###### Following the Action URL
+If the `action_method` field is provided, the client uses the method specified when making the request to the `action_url`.
 
-- In the case that `action_method` is `GET`, any fields requested may be passed as query parameters in the `action_url`.
+If the `action_fields` field is provided, the client may optionally supply the fields if they already have the information so as to reduce the user's need to re-enter the information. If the requested fields contain sensitive or personal information, the server should use `action_method` `POST` so that sensitive information is not transmitted in a URL.
 
-- In the case that `action_method` is `POST`, any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json`. The body should contain either an acknowledgement that the `POST` was sufficient and no further action is required, or the next URL that the user should be taken to if action is still required.
+There are two possible values for `action_method`.
 
-   The next URL in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser can redirect the user to the next URL and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the next URL. Separating the next URL also makes it possible for the server to indicate that the fields provided in the POST request were sufficient and no further user interaction is required.
+- In the case that `action_method` is `GET`, or not defined:
+
+   Fields requested may be passed as query parameters in the `action_url`. The URL should be opened in a browser. Any fields passed should allow the server to proceed without collecting user information, or at the least pre-fill the provided information.
+
+- In the case that `action_method` is `POST`:
+
+   Fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json`. The body should contain either an acknowledgement that the `POST` was sufficient and no further action is required, or the next URL if action is still required. If a next URL is provided, it should be loaded in a browser for the user to complete any action required.
 
    Request Parameters:
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-25
-Version 1.5.0
+Updated: 2021-01-29
+Version 1.5.1
 ```
 
 ## Simple Summary


### PR DESCRIPTION
### What
Add and change statements that discuss the action_required response to state that the use of `action_fields` is optional for both the server to provide, and the client to use, and exists to allow the client to improve the UX by circumventing the need for the user to enter information.

Removed statements about the POST flow that were confusing and did not add a lot of value.

### Why
@howardtw pointed out some gaps in understanding when reviewing SEP-8 since #_ was merged.

This makes no functional changes to the specification, and only clarifies existing behavior.