### PR TITLE
CAP-0035: Define what happens if an issuer creates a claimable balance

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -71,9 +71,10 @@ trustline is created to authorize a `ClawbackOp` operation submitted by the
 issuer account.
 
 A claimable balance inherits its clawback enabled status from the account
-creating the claimable balance and a `ClawbackClaimableBalanceOp` operation
-is only valid for claimable balances created by accounts whose trustline for
-the asset has clawback enabled.
+creating the claimable balance. A `ClawbackClaimableBalanceOp` operation is
+valid for claimable balances created by accounts whose trustline for the
+asset has clawback enabled, and for claimable balances created by an issuer
+account when the issuer account has clawback enabled.
 
 The `ClawbackOp` and `ClawbackClaimableBalanceOp` operations result in the
 removal of the specified assets issued from the network.
@@ -415,6 +416,10 @@ In order to execute a clawback of a claimable balance, the claimable balance
 must have been created by an account that has clawback enabled on its
 trustline.
 
+In order to execute a clawback of a claimable balance created by an issuer
+account, the claimable balance must have been created when clawback was
+enabled on the issuer account.
+
 #### Account
 
 This proposal introduces a new flag to accounts,
@@ -439,10 +444,17 @@ claimable balance created by the account will also be clawback enabled.
 #### Claimable Balance
 
 This proposal introduces the first flag to claimable balances,
-`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG`, that is set at the time the claimable 
-balance is created if the account creating the claimable balance has
-`TRUSTLINE_CLAWBACK_ENABLED_FLAG` set on the trustline of the asset of the claimable
-balance.
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG`.
+
+The `CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` flag is set at the time the
+claimable balance is created if the account creating the claimable balance
+has `TRUSTLINE_CLAWBACK_ENABLED_FLAG` set on the trustline of the asset of
+the claimable balance.
+
+If an issuer account creates a claimable balance for an asset it issues, the
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` flag is set at the time the
+claimable balance is created if the issuer account creating the claimable
+balance has `AUTH_CLAWBACK_ENABLED` set.
 
 If the new flag is set it indicates that the balance held by the claimable
 balance can be clawed back by the issuer using the
@@ -622,6 +634,21 @@ highly visible in comparison to routine claiming of a claimable balance and
 to allow issuers that use claimable balances routinely to distinguish between
 claimable balances they can routinely claim and claimable balances they may
 clawback.
+
+### Claimable Balances Created by an Issuer
+
+An issuer account has no trustline to itself for assets it issues, therefore
+setting the `CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` flag based on the state
+of a trustline is not possible in this case. By setting the
+`CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG` flag on the claimable balance based
+on the state of the issuer account flags when the issuer account creates a
+claimable balance, the issuer account retains control to specify if claimable
+balances it creates are clawed back. This is intuitive, but not overly
+flexible. Issuer accounts that need to create claimable balances with
+clawback disabled, but need to have clawback enabled for new trustlines, can
+create claimable balances via a second account that it allows to have a
+trustline that is clawback disabled.
+
 
 ### Allow Trust Operation
 


### PR DESCRIPTION
### What
Define what happens if an issuer creates a claimable balance.

### Why
@jonjove pointed out in https://github.com/stellar/stellar-core/pull/2893#discussion_r567064267 that the issuer can create a claimable balance but doesn't have a trustline to itself, and we need to define what the clawback enabled state of the claimable balance is in this case.

This was discussed on the mailing list starting [here](https://groups.google.com/g/stellar-dev/c/hPhkXhrl5-Y/m/Eg6VwKiCAQAJ) and consensus appears to be to set the claimable balances clawback enabled state based on the account flags in the case of the issuer account.