### PR TITLE
SEP-8: add next step for action_required status

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -254,6 +254,8 @@ If the `action_method` field is provided, the client uses the method specified w
 
 If the `action_fields` field is provided, the client may optionally supply the fields if they already have the information so as to reduce the user's need to re-enter the information. If the requested fields contain sensitive or personal information, the server should use `action_method` `POST` so that sensitive information is not transmitted in a URL.
 
+When no further action is to be taken by the user, the client can re-submit the transaction to the approval server. However, there is no guarantee to receive a `"success"` status in the following call. Clients should expect to receive a response with any of the status.
+
 There are two possible values for `action_method`.
 
 - In the case that `action_method` is `GET`, or not defined:
@@ -305,8 +307,6 @@ There are two possible values for `action_method`.
      "next_url": "https://..."
    }
    ```
-
-When no further actions can be taken by the user, the client can re-submit the transaction to the approval server. However, there is no guarantee to receive a `"success"` status in the following call. Clients should expect to receive a response with any of the status.
 
 ##### Rejected
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-29
-Version 1.5.1
+Updated: 2021-02-02
+Version 1.5.2
 ```
 
 ## Simple Summary
@@ -249,6 +249,7 @@ Name | Type | Description
 ```
 
 ###### Following the Action URL
+
 If the `action_method` field is provided, the client uses the method specified when making the request to the `action_url`.
 
 If the `action_fields` field is provided, the client may optionally supply the fields if they already have the information so as to reduce the user's need to re-enter the information. If the requested fields contain sensitive or personal information, the server should use `action_method` `POST` so that sensitive information is not transmitted in a URL.
@@ -304,6 +305,8 @@ There are two possible values for `action_method`.
      "next_url": "https://..."
    }
    ```
+
+When no further actions can be taken by the user, the client can re-submit the transaction to the approval server. However, there is no guarantee to receive a `"success"` status in the following call. Clients should expect to receive a response with any of the status.
 
 ##### Rejected
 


### PR DESCRIPTION
**What**

This PR adds the next step for the client to take after there is no more action to be done.

**Why**

It is unclear about what to do and what to expect when a user completes all the action required by the approval service.