### PR TITLE
SEP-8: add an optional message field along with next_url

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-29
-Version 1.5.1
+Updated: 2021-02-02
+Version 1.6.0
 ```
 
 ## Simple Summary
@@ -241,7 +241,7 @@ Name | Type | Description
 ```json
 {
   "status": "action_required",
-  "message": "Please sign the terms of service via the provided URL.",
+  "message": "Please provide the information specified in the action_fields via the provided URL.",
   "action_url": "https://...",
   "action_method": "POST",
   "action_fields": ["email_address", "mobile_number"]
@@ -295,13 +295,15 @@ There are two possible values for `action_method`.
    -----|------|------------
    `result` | string | `follow_next_url`.
    `next_url` | string | A URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
+   `message` | string | (optioanl) A human readable string containing information regarding the further action required.
 
    Response Example:
 
    ```json
    {
      "result": "follow_next_url",
-     "next_url": "https://..."
+     "next_url": "https://...",
+     "message": "Please sign the terms of service via the provided URL."
    }
    ```
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -241,7 +241,7 @@ Name | Type | Description
 ```json
 {
   "status": "action_required",
-  "message": "Please provide the information specified in the action fields via the provided URL.",
+  "message": "Please provide an email address and mobile phone number.",
   "action_url": "https://...",
   "action_method": "POST",
   "action_fields": ["email_address", "mobile_number"]
@@ -306,7 +306,7 @@ There are two possible values for `action_method`.
    {
      "result": "follow_next_url",
      "next_url": "https://...",
-     "message": "Please sign the terms of service via the provided URL."
+     "message": "Please sign the terms of service."
    }
    ```
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -295,7 +295,7 @@ There are two possible values for `action_method`.
    -----|------|------------
    `result` | string | `follow_next_url`.
    `next_url` | string | A URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
-   `message` | string | (optioanl) A human readable string containing information regarding the further action required.
+   `message` | string | (optional) A human readable string containing information regarding the further action required.
 
    Response Example:
 


### PR DESCRIPTION
**What**

This PR adds an optional field `message` to the `follow_next_url` response.

**Why**

The client can choose to display the message to the user if the approval server requires further actions.