### PR TITLE
SEP-6: added on_change_callback parameter to /withdraw and /deposit requests

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -140,6 +140,7 @@ Name | Type | Description
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or properties change. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 Example:
 
@@ -255,6 +256,7 @@ Name | Type | Description
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or properties change. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 Example:
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -357,7 +357,9 @@ Example:
 
 #### Transaction Polling
 
-Once the deposit or withdraw request has been made and KYC information has been passed to the anchor via [SEP-12](sep-0012.md), the wallet will need to detect that the anchor has completed the flow by sending funds to the user. The wallet needs to poll the [Transaction History](#transaction-history) endpoint response from the anchor and match the transaction objects returned using the `memo` and `memo_type` parameters used in the deposit or withdraw success response.
+Once the deposit or withdraw request has been made and KYC information has been passed to the anchor via [SEP-12](sep-0012.md), the wallet will need to detect that the anchor has completed the flow by sending funds to the user. 
+
+The wallet either needs to provide the anchor with an `on_change_callback` or to poll the [Transaction History](#transaction-history) endpoint response from the anchor and match the transaction objects returned using the `memo` and `memo_type` parameters used in the deposit or withdraw success response.
 
 If transaction response object has a JSON `status` field set to `incomplete`, it means the user still needs to be KYC'ed using [SEP-12](sep-0012.md). In this case, the wallet should collect the fields requested in the `non_interactive_customer_info_needed` response and send them back to the anchor.
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -140,7 +140,7 @@ Name | Type | Description
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
-`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or properties change. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 Example:
 
@@ -256,7 +256,7 @@ Name | Type | Description
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
-`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or properties change. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 Example:
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
 Updated: 2021-02-03
-Version 3.2.2
+Version 3.2.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-01-19
-Version 3.1.2
+Updated: 2021-02-03
+Version 3.2.2
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -357,9 +357,9 @@ Example:
 
 #### Transaction Polling
 
-Once the deposit or withdraw request has been made and KYC information has been passed to the anchor via [SEP-12](sep-0012.md), the wallet will need to detect that the anchor has completed the flow by sending funds to the user. 
+Once the deposit or withdraw request has been made and KYC information has been passed to the anchor via [SEP-12](sep-0012.md), the wallet will need to detect that the anchor has completed flow by checking the `status` field of the transaction.
 
-The wallet either needs to provide the anchor with an `on_change_callback` or to poll the [Transaction History](#transaction-history) endpoint response from the anchor and match the transaction objects returned using the `memo` and `memo_type` parameters used in the deposit or withdraw success response.
+The wallet can either provide the anchor with an `on_change_callback` and check the `status` property of the transaction object passed in the callback request, or the wallet can poll the anchor's `GET /transactions` endpoints and match the transaction object using the `memo` and `memo_type` used in the deposit request or withdraw success response.
 
 If transaction response object has a JSON `status` field set to `incomplete`, it means the user still needs to be KYC'ed using [SEP-12](sep-0012.md). In this case, the wallet should collect the fields requested in the `non_interactive_customer_info_needed` response and send them back to the anchor.
 


### PR DESCRIPTION
resolves stellar/stellar-protocol#775

Adds the `on_change_callback` request parameter to `/deposit` and `/withdraw` requests to match the functionality added SEP-24 ([PR](https://github.com/stellar/stellar-protocol/pull/739)).

The `kyc_verified` attribute is not relevant in SEP-6 because requests to `/deposit` and `/withdraw` return 400 until KYC has been verified. Only after KYC is verified do `/deposit` and `/withdraw` requests succeed and records are created and retrievable from `GET /transaction(s)`.

One thing that is not clear is if the anchor should return 400 if `on_change_callback` is not supported. I think it should, but its more likely that anchors would simply ignore the parameter (especially since it's a new addition and they don't know to check for it)