### PR TITLE
SEP-24: anchors or users should close interactive popups

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active
 Created: 2019-09-18
 Updated: 2021-01-19
-Version 1.2.2
+Version 1.3.0
 ```
 
 ## Simple Summary
@@ -432,8 +432,6 @@ When the popup is closed, the transaction's status should be `pending_user_trans
 Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the anchor closes the popup and the wallet allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
 The wallet needs to wait for the transaction's status to be `pending_user_transfer_start` before sending a payment on Stellar to the anchor's account. To detect the transaction's status, either poll the `/transaction` endpoint with the `id` provided in the `/transactions/withdraw/interactive` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
-
-In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
 
 When a successful response comes back (either from polling or via callback), the response will contain the transaction fields described in the [/transactions](#transaction-history) endpoint.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -139,7 +139,7 @@ A deposit is when a user sends some non-stellar asset (BTC via Bitcoin network, 
 
 The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information that the user must submit interactively via a popup or embedded browser window to be able to deposit.
 
-After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. At that point, the transaction must transition to `pending_user_transfer_start`. See the [Status Diagram](status-diagram) for more information.
+After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. At that point, the transaction must transition to `pending_user_transfer_start`.
 
 If the given account does not exist, or if the account doesn't have a trustline for that specific asset, see the [Special Cases](#special-cases) section below.
 
@@ -277,7 +277,7 @@ This operation allows a user to redeem an asset currently on the Stellar network
 
 The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify the url for the interactive webapp to continue with the anchor's side of the withdraw.
 
-After a successful withdraw request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. Unless the [no additional information needed](1-success-no-additional-information-needed) response is returned, this transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received on-chain. At that point, the transaction must transition to `pending_user_transfer_start`. See the [Status Diagram](status-diagram) for more information.
+After a successful withdraw request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. Unless the [no additional information needed](#1-success-no-additional-information-needed) response is returned, this transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received on-chain. At that point, the transaction must transition to `pending_user_transfer_start`.
 
 ### Request
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,7 +6,7 @@ Title: Interactive Anchor/Wallet Asset Transfer Server
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-01-19
+Updated: 2021-02-04
 Version 1.3.0
 ```
 
@@ -139,8 +139,9 @@ A deposit is when a user sends some non-stellar asset (BTC via Bitcoin network, 
 
 The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information that the user must submit interactively via a popup or embedded browser window to be able to deposit.
 
-If the given account does not exist, or if the account doesn't have a trustline for that specific asset, see the [Special Cases](#special-cases) section below.
+After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. At that point, the transaction must transition to `pending_user_transfer_start`. See the [Status Diagram](status-diagram) for more information.
 
+If the given account does not exist, or if the account doesn't have a trustline for that specific asset, see the [Special Cases](#special-cases) section below.
 
 ### Request
 
@@ -275,6 +276,8 @@ Predicates are one of the [claimable balance parameters](https://developers.stel
 This operation allows a user to redeem an asset currently on the Stellar network for the real asset (BTC, USD, stock, etc...) via the anchor of the Stellar asset.
 
 The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify the url for the interactive webapp to continue with the anchor's side of the withdraw.
+
+After a successful withdraw request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. Unless the [no additional information needed](1-success-no-additional-information-needed) response is returned, this transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received on-chain. At that point, the transaction must transition to `pending_user_transfer_start`. See the [Status Diagram](status-diagram) for more information.
 
 ### Request
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -395,7 +395,7 @@ If the wallet wants to be notified that the user has completed the anchor's inte
 
 **Differences between `callback` and `on_change_callback`**
 
-Anchors may make _at most one request_ containing a `/transaction` response body to `callback` when the user is finished with the interactive flow _and_ the anchor has verified that it is safe for the wallet to close the popup window.
+Anchors may make _at most one request_ containing a `/transaction` response body to `callback` when the user is finished with the interactive flow.
 
 `on_change_callback` should be called each time the `status` or `kyc_verified` properties of the transaction change. It can be called any number of times.
 
@@ -421,11 +421,17 @@ target.postMessage({
 
 As an alternative to using the `callback` or `on_change_callback` parameters, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
 
+#### Guidance for anchors: closing the interactive popup
+
+After the user has provided all necessary information to the anchor through the interactive popup (`url`), the anchor should either close the popup automatically or instruct the user to close it themselves. If the anchor needs to provide instructions to the user for sending funds to it's off-chain account (in the deposit case), the anchor should not close the popup until the user has indicated to do so.
+
+When the popup is closed, the transaction's status should be `pending_user_transfer_start`, signaling to the wallet that the anchor is waiting to receive the funds.
+
 #### Guidance for wallets: completing an interactive withdrawal
 
-Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the wallet detects this and allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
+Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the anchor closes the popup and the wallet allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
-To detect that the user has completed their interaction with the anchor, the wallet needs to either poll the `/transaction` endpoint with the `id` provided in the `/transactions/withdraw/interactive` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
+The wallet needs to wait for the transaction's status to be `pending_user_transfer_start` before sending a payment on Stellar to the anchor's account. To detect the transaction's status, either poll the `/transaction` endpoint with the `id` provided in the `/transactions/withdraw/interactive` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
 
 In the polling case, if the anchor responds with HTTP status `404` or with a JSON `status` field set to `incomplete`, it means the user is either still going through the interactive flow with the anchor, or has abandoned the transaction part way through. The wallet should simply keep polling or waiting in this case. The wallet should provide the user with an `x` or other way to abort the transaction and return to their wallet. When the user aborts on the wallet side, the wallet must close the popup containing the anchor's flow as well.
 


### PR DESCRIPTION
resolves #862

Adds a new section outlines how the interactive flow popups should be closed. Previously it was implied that the wallet would close interactive flows, but this is unnecessary and having the anchor or user close the popup reduced complexity and provides a better UX.

Once merged, we'll announce the change to the ecosystem and set a date on which we expect anchors to update by.

@pitsevich
@dmgmyza
