### PR TITLE
SEP-0010: Fix inconsistencies in flow defined by the token endpoint (v3.1.1)

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2021-01-11
-Version 3.1.0
+Updated: 2021-02-10
+Version 3.1.1
 ```
 
 ## Simple Summary
@@ -158,18 +158,19 @@ To validate the challenge transaction the following steps are performed by the s
 * decode the received input as a base64-urlencoded XDR representation of Stellar transaction envelope;
 * verify that transaction source account is equal to the server's signing key;
 * verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
-* verify that transaction contains a single [Manage Data](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) operation that:
+* verify that transaction contains at least one operation;
+* verify that transaction's first operation:
+  * is a Manage Data operation
   * has a non-null source account
-  * has the home domain as the key of the operation
 * verify that transaction envelope has a correct signature by server's signing key;
-* if the operation's source account exists:
+* if the first operation's source account exists:
   * verify that client signatures count is one or more;
-  * verify that client signatures on the transaction are signers of the operation's source account;
+  * verify that client signatures on the transaction are signers of the first operation's source account;
   * verify that client signatures are correct;
   * verify that client signatures provide weight that meets the required threshold(s), if any;
-* if the operation's source account does not exist:
+* if the first operation's source account does not exist:
   * verify that client signature count is one;
-  * verify that client signature is correct for the master key of the account address;
+  * verify that client signature is correct for the master key of the first operation's source account address;
 * verify that transaction containing additional Manage Data operations have their source account as the server signing key;
 * verify that transaction sequenceNumber is equal to zero;
 * use operations's source account to determine the authenticating client and perform any additional service-specific validations.


### PR DESCRIPTION
### What
Make clear in the token endpoint flow that there are multiple operations in the challenge transaction and that the verification steps are focused on the first operation.

### Why
In SEP-10 v3.1 we added a new operation that is included but the token endpoint flow was not updated to reflect that this was the case. The token endpoint flow talks about the transaction having a single operation and verifying that operation which is confusing.

This change makes no functional changes and updates the token endpoint section to align with the rest of the document.