### PR TITLE
SEP-6: Added optional 'amount' & 'country_code' parameters

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -453,7 +453,8 @@ The response should be a JSON object like:
           "description": "amount in USD that you plan to deposit"
         },
         "country_code": {
-          "description": "The ISO 3166-1 alpha-3 code of the user's current address"
+          "description": "The ISO 3166-1 alpha-3 code of the user's current address",
+          "choices": ["USA", "PRI"]
         },
         "type" : {
           "description": "type of deposit to make",
@@ -483,7 +484,10 @@ The response should be a JSON object like:
               "dest_extra": { "description": "your routing number" },
               "bank_branch": { "description": "address of your bank branch" },
               "phone_number": { "description": "your phone number in case there's an issue" },
-              "country_code": { "description": "The ISO 3166-1 alpha-3 code of the user's current address"}
+              "country_code": { 
+                "description": "The ISO 3166-1 alpha-3 code of the user's current address",
+                "choices": ["USA", "PRI"]
+              }
           }
         },
         "cash": {

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-02-03
-Version 3.2.0
+Updated: 2021-02-10
+Version 3.3.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -136,11 +136,13 @@ Name | Type | Description
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
-`type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`.
+`type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`. This field may be necessary for the anchor to determine which KYC fields to collect.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
+`amount` | string | (optional) The amount of the asset the user would like to deposit with the anchor. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 
 Example:
 
@@ -247,7 +249,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
-`type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values.
+`type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
@@ -257,6 +259,8 @@ Name | Type | Description
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
+`amount` | string | (optional) The amount of the asset the user would like to deposit with the anchor. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 
 Example:
 
@@ -448,6 +452,9 @@ The response should be a JSON object like:
         "amount" : {
           "description": "amount in USD that you plan to deposit"
         },
+        "country_code": {
+          "description": "The ISO 3166-1 alpha-3 code of the user's current address"
+        },
         "type" : {
           "description": "type of deposit to make",
           "choices": ["SEPA", "SWIFT", "cash"]
@@ -475,7 +482,8 @@ The response should be a JSON object like:
               "dest": {"description": "your bank account number" },
               "dest_extra": { "description": "your routing number" },
               "bank_branch": { "description": "address of your bank branch" },
-              "phone_number": { "description": "your phone number in case there's an issue" }
+              "phone_number": { "description": "your phone number in case there's an issue" },
+              "country_code": { "description": "The ISO 3166-1 alpha-3 code of the user's current address"}
           }
         },
         "cash": {


### PR DESCRIPTION
Originally discussed in stellar/stellar-protocol#808 

Adds two optional parameters to both `/deposit` and `/withdraw`: `amount` and `country_code`. These fields may be necessary for the anchor to know what SEP-9 `fields` to return in the response.

One change I didn't make, is adding a `sep12_type` parameter that is associated with the `fields` list returned. We could add this attribute to enable the client to make `GET /customer?type=` requests. However, specifying both `fields` and `sep12_type` is redundant, so `fields` may need to be deprecated if we wanted to add `sep12_type`.