### PR TITLE
SEP-24: deprecated postMessage callbacks

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -396,7 +396,11 @@ The URL supplied by both callback parameters should receive the full transaction
 
 If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. 
 
-**Deprecated**: If `callback=postMessage` is passed, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
+**`postMessage` deprecation**
+
+Instead of using `postMessage` callbacks, the wallet should either provide a public-facing URL as the `callback` parameter value or poll the anchor's [`GET /transaction(s)`] endpoint for updates to the transaction's status.
+
+The anchor should still support the use of `postMessage` callbacks. If provided, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
 **Differences between `callback` and `on_change_callback`**
 
@@ -426,8 +430,6 @@ fetch(callback, {
   })
 });
 ```
-
-As an alternative to using the `callback` or `on_change_callback` parameters, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.
 
 #### Guidance for anchors: closing the interactive popup
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -387,14 +387,16 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. Can also be set to `postMessage`.
-`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. Can also be set to `postMessage`.
+`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. The use of `postMessage` is **deprecated**.
+`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. The use of `postMessage` is **deprecated**.
 
-The postMessage or URL supplied by both callback parameters should receive the full transaction object.
+The URL supplied by both callback parameters should receive the full transaction object.
 
 **`callback` details**
 
-If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. If `callback=postMessage` is passed, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
+If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. 
+
+**Deprecated**: If `callback=postMessage` is passed, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
 **Differences between `callback` and `on_change_callback`**
 
@@ -407,19 +409,22 @@ Anchors may make _at most one request_ containing a `/transaction` response body
 The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint.
 
 ```javascript
-// Example postMessage callback at the end of an interactive withdraw, indicating that the anchor is waiting for the wallet to send a payment in the amount of 80 of the asset in question.
-const target = window.opener || window.parent;
-target.postMessage({
- transaction: {
-   id: "anchors_identifier_for_this_transaction",
-   status: "pending_user_transfer_start",
-   withdraw_anchor_account: "ANCHORS_STELLAR_ACCOUNT_ID",
-   withdraw_memo: "MEMO_ANCHOR_EXPECTS_TO_SEE",
-   withdraw_memo_type: "text|hash|id",
-   amount_in: "80"
-   // ... Any other values from the /transaction endpoint can and should be passed as well
- }
-}, "*");
+// Example callback at the end of an interactive withdraw, indicating that the anchor is waiting for the wallet to send a payment in the amount of 80 of the asset in question.
+fetch(callback, {
+  method: "POST",
+  headers: {"Content-Type": "application/json"},
+  body: JSON.stringify({
+    transaction: {
+      id: "anchors_identifier_for_this_transaction",
+      status: "pending_user_transfer_start",
+      withdraw_anchor_account: "ANCHORS_STELLAR_ACCOUNT_ID",
+      withdraw_memo: "MEMO_ANCHOR_EXPECTS_TO_SEE",
+      withdraw_memo_type: "text|hash|id",
+      amount_in: "80"
+      // ... Any other values from the /transaction endpoint can and should be passed as well
+    }
+  })
+});
 ```
 
 As an alternative to using the `callback` or `on_change_callback` parameters, the wallet can poll the transaction endpoint [`/transaction`](#single-historical-transaction) with the request `id` to check the status of the request.


### PR DESCRIPTION
Deprecates the use of `postMessage` callbacks.

Question: Do we want to deprecate the `callback` parameter altogether? `callback` is used for when the interactive flow has completed. But now that ~it is the anchor's responsibility to close the popup~ the user must close the popup, I can't think of a reason why `callback` is valuable. `on_change_callback` can be used for all status changes, so the wallet could get an update when the transaction moves to `pending_user_transfer_start`.