### PR TITLE
SEP-24: users must close the popups, anchors cannot

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -426,13 +426,13 @@ As an alternative to using the `callback` or `on_change_callback` parameters, th
 
 #### Guidance for anchors: closing the interactive popup
 
-After the user has provided all necessary information to the anchor through the interactive popup (`url`), the anchor should either close the popup automatically or instruct the user to close it themselves. If the anchor needs to provide instructions to the user for sending funds to it's off-chain account (in the deposit case), the anchor should not close the popup until the user has indicated to do so.
+After the user has provided all necessary information to the anchor through the interactive popup (`url`), the anchor should instruct the user to close the popup. This is necessary for deposit flows because the user must read and understand the instructions provided by the anchor for sending deposit funds. While this is not the case for withdrawal flows, anchors cannot assume the wallet will close the popup in a timely manner after updating the transaction's status.
 
-When the popup is closed, the transaction's status should be `pending_user_transfer_start`, signaling to the wallet that the anchor is waiting to receive the funds.
+When the popup is closed, the transaction's status should have transitioned from `incomplete` to `pending_user_transfer_start`, signaling to the wallet that the anchor is waiting to receive the funds.
 
 #### Guidance for wallets: completing an interactive withdrawal
 
-Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the anchor closes the popup and the wallet allows the user to complete the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
+Given the nature of the interactive withdrawal, the user will interact with the anchor via the popup. They enter information needed to complete the withdrawal like destination bank account or KYC details. Once the anchor has enough information to know how to complete the withdrawal, the user closes the popup and the wallet allows the user to confirm the withdrawal inside the wallet's app. It has to work this way because the wallet must transfer the correct amount of the withdrawal asset to the anchor's Stellar account before the anchor can complete its end of the withdrawal.
 
 The wallet needs to wait for the transaction's status to be `pending_user_transfer_start` before sending a payment on Stellar to the anchor's account. To detect the transaction's status, either poll the `/transaction` endpoint with the `id` provided in the `/transactions/withdraw/interactive` response from the anchor until the necessary information is available, or register a callback with the anchor as described above.
 


### PR DESCRIPTION
SEP-24 was [recently updated](https://github.com/stellar/stellar-protocol/pull/863) to instruct anchors to close the popup instead of the wallet. However, modern browsers only allow the opener of the popup to close it via javascript's `window.close()`, meaning anchors cannot close their own popups. See the [window.close()](https://developer.mozilla.org/en-US/docs/Web/API/Window/close#closing_the_current_window) spec.

Therefore SEP-24 needs to be updated so that it no longer implies the anchor is able to close the popup.