### PR TITLE
SEP-26: reject in favor of SEP-6

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -76,6 +76,7 @@
 | --- | --- | --- | --- | --- |
 | [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Deprecated |
 | [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Rejected |
+| [SEP-0026](sep-0026.md) | Non-interactive Anchor/Wallet Asset Transfer | SDF, Fritz Ekwoge (@efritze), Ernest Mbenkum (@cameroon) | Standard | Rejected |
 
 
 # Contribution Process

--- a/ecosystem/sep-0026.md
+++ b/ecosystem/sep-0026.md
@@ -4,9 +4,9 @@
 SEP: 0026
 Title: Non-interactive Anchor/Wallet Asset Transfer
 Authors: SDF, Fritz Ekwoge (@efritze), Ernest Mbenkum (@cameroon)
-Status: Draft
+Status: Rejected (in favor of SEP-6)
 Created: 2019-11-16
-Updated: 2019-11-23
+Updated: 2021-02-23
 Version: 0.8.0
 Discussion: https://github.com/stellar/stellar-protocol/issues/484
 ```


### PR DESCRIPTION
resolves #793

SEP-6 is already used in the wild and it would be a burden on client applications to support SEP-26 as well. SEP-6 is still in _Active_ status and can be improved upon if desired.