### PR TITLE
SEP-24: deprecate 'callback' in favor of 'on_change_callback'

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -387,18 +387,20 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. The use of `postMessage` is **deprecated**.
+`callback` | string | (**deprecated**, optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. The use of `postMessage` is **deprecated**.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. The use of `postMessage` is **deprecated**.
 
 The URL supplied by both callback parameters should receive the full transaction object.
 
 **`callback` details**
 
-If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. 
+The use of `callback` is deprecated in favor of using `on_change_callback`. The transaction's `status` property should be changed from the initial `incomplete` value when the interactive flow is completed, so the `callback` parameter is redundant.
+
+If the user abandons the process, the anchor does not need to report anything to the wallet. If the value is a URL, the anchor must `POST` to it with a JSON message as the body. 
 
 **`postMessage` deprecation**
 
-Instead of using `postMessage` callbacks, the wallet should either provide a public-facing URL as the `callback` parameter value or poll the anchor's [`GET /transaction(s)`] endpoint for updates to the transaction's status.
+Instead of using `postMessage` callbacks, the wallet should either provide a public-facing URL as the `on_change_callback` parameter value or poll the anchor's [`GET /transaction(s)`] endpoint for updates to the transaction's status.
 
 The anchor should still support the use of `postMessage` callbacks. If provided, the anchor must post a JSON message to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
@@ -414,7 +416,7 @@ The JSON message should be identical to the response format for the [/transactio
 
 ```javascript
 // Example callback at the end of an interactive withdraw, indicating that the anchor is waiting for the wallet to send a payment in the amount of 80 of the asset in question.
-fetch(callback, {
+fetch(on_change_callback, {
   method: "POST",
   headers: {"Content-Type": "application/json"},
   body: JSON.stringify({


### PR DESCRIPTION
Originally discussed in #870

The original `callback` parameter has become redundant with the introduction of `on_change_callback`. 

Clients who specify an `on_change_callback` can expect to receive an updated transaction body on each change to the transaction's status, including the initial transition away from `incomplete`. This means `callback`, which is used when the interactive flow completes (i.e. when the status changes from `incomplete`) is no longer necessary.

**Side note:** I'd like to confirm whether or not `incomplete` _always_ transitions to `pending_user_transfer_start` (if not `error`). I can see a case where `incomplete` transitions to `pending_anchor` if the KYC information needs to be manually verified -- in which case the SEP should be updated to clarify this. Currently, the SEP states `incomplete` _must_ transition to `pending_user_transfer_start`.