### PR TITLE
SEP-24: clarify 'incomplete' status transition

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Interactive Anchor/Wallet Asset Transfer Server
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-02-04
-Version 1.3.0
+Updated: 2021-03-29
+Version 1.3.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -139,7 +139,7 @@ A deposit is when a user sends some non-stellar asset (BTC via Bitcoin network, 
 
 The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information that the user must submit interactively via a popup or embedded browser window to be able to deposit.
 
-After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. See [Closing the Interactive Popup](#guidance-for-anchors-closing-the-interactive-popup) for more information.
+After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain.
 
 If the given account does not exist, or if the account doesn't have a trustline for that specific asset, see the [Special Cases](#special-cases) section below.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -139,7 +139,7 @@ A deposit is when a user sends some non-stellar asset (BTC via Bitcoin network, 
 
 The deposit endpoint allows a wallet to get deposit information from an anchor, so a user has all the information needed to initiate a deposit. It also lets the anchor specify additional information that the user must submit interactively via a popup or embedded browser window to be able to deposit.
 
-After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. At that point, the transaction must transition to `pending_user_transfer_start`.
+After a successful deposit request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. This transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received off-chain. See [Closing the Interactive Popup](#guidance-for-anchors-closing-the-interactive-popup) for more information.
 
 If the given account does not exist, or if the account doesn't have a trustline for that specific asset, see the [Special Cases](#special-cases) section below.
 
@@ -277,7 +277,7 @@ This operation allows a user to redeem an asset currently on the Stellar network
 
 The withdraw endpoint allows a wallet to get withdrawal information from an anchor, so a user has all the information needed to initiate a withdrawal. It also lets the anchor specify the url for the interactive webapp to continue with the anchor's side of the withdraw.
 
-After a successful withdraw request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. Unless the [no additional information needed](#1-success-no-additional-information-needed) response is returned, this transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received on-chain. At that point, the transaction must transition to `pending_user_transfer_start`.
+After a successful withdraw request has been made, a transaction record with the `id` provided in the response should be retreivable from `GET /transaction(s)`. Unless the [no additional information needed](#1-success-no-additional-information-needed) response is returned, this transaction must be in the `incomplete` status until the user has provided the anchor all information necessary for the transaction to be completed once received on-chain.
 
 ### Request
 
@@ -435,7 +435,12 @@ fetch(callback, {
 
 After the user has provided all necessary information to the anchor through the interactive popup (`url`), the anchor should either close the popup automatically or instruct the user to close it themselves. If the anchor needs to provide instructions to the user for sending funds to it's off-chain account (in the deposit case), the anchor should not close the popup until the user has indicated to do so.
 
-When the popup is closed, the transaction's status should be `pending_user_transfer_start`, signaling to the wallet that the anchor is waiting to receive the funds.
+When the popup is closed, the transaction's status should no longer be `incomplete`. Instead, it should be one of the following:
+
+* `pending_user_transfer_start` if anchor is ready to receive the funds. This is the most common status after `incomplete`.
+* `pending_anchor` if the anchor must verify KYC information given prior to receiving funds.
+* `pending_user` if the user must take some action before sending funds to the anchor.
+* `pending_trust` if the user does not have a trustline to the asset requested for deposit. Note that a trustline can be established after the anchor has received funds. A trustline is not required if both the wallet and anchor support [Claimable Balances](#claimable-balances).
 
 #### Guidance for wallets: completing an interactive withdrawal
 
@@ -689,7 +694,7 @@ Name | Type | Description
 `status` should be one of:
 
 * `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
-* `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the necessary first step in any deposit or withdrawal flow.
+* `pending_user_transfer_start` -- the user has not yet initiated their transfer to the anchor. This is the next necessary step in any deposit or withdrawal flow after transitioning from `incomplete`.
 * `pending_external` -- deposit/withdrawal has been submitted to external network, but is not yet confirmed. This is the status when waiting on Bitcoin or other external crypto network to complete a transaction, or when waiting on a bank transfer.
 * `pending_anchor` -- deposit/withdrawal is being processed internally by anchor. This can also be used when the anchor must verify KYC information prior to deposit/withdrawal.
 * `pending_stellar` -- deposit/withdrawal operation has been submitted to Stellar network, but is not yet confirmed.


### PR DESCRIPTION
Originally discussed in #875 

The SEP was recently updated to re-enforce the expectation that transaction begin in the `incomplete` status. However in that change we also incorrectly made the assumption that `pending_user_transfer_start` would always be the next status.

In fact, there are cases where other status are used directly after `incomplete`, such as if the anchor needs additional time to verify KYC information provided before accepting funds.