### PR TITLE
CAP-0035 - Changes after code review

### DIFF
--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -99,7 +99,7 @@ This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 8d746391..26ff33d4 100644
+index 8d7463915..26ff33d43 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -28,6 +28,17 @@ enum AssetType
@@ -194,7 +194,7 @@ index 8d746391..26ff33d4 100644
      ext;
  };
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 7f08d757..da11bce9 100644
+index 7f08d7579..3c2b1f0be 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -46,7 +46,10 @@ enum OperationType
@@ -274,8 +274,8 @@ index 7f08d757..da11bce9 100644
 +    AccountID trustor;
 +    Asset asset;
 +
-+    uint32* clearFlags; // which flags to clear
-+    uint32* setFlags;   // which flags to set
++    uint32 clearFlags; // which flags to clear
++    uint32 setFlags;   // which flags to set
 +};
 +
  /* An operation is the lowest unit of work that a transaction does */
@@ -553,7 +553,9 @@ the issuer of the `asset`.
 
 This proposal introduces the `SetTrustLineFlagsOp` operation. The operation works
 like the `AllowTrustOp`, except it uses set and clear parameters to set/clear specific
-trustline flags. This will allow an issuer to clear the `TRUSTLINE_CLAWBACK_ENABLED_FLAG`. 
+trustline flags. This will allow an issuer to clear the `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
+An important detail to note here is that `SetTrustLineFlagsOp` will mimic the changes to `AllowTrustOp`
+specified in [CAP-0029](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0029.md).
 
 `SET_TRUST_LINE_FLAGS_MALFORMED` will be returned for `SetTrustLineFlagsOp` during validation under the following conditions:
 - Both `AUTHORIZED_FLAG` and `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` are set on `setFlags`.


### PR DESCRIPTION
This PR changes the `SetTrustLineFlagsOp` `setFlags`/`clearFlags` parameter to no longer be optional. They were made optional initially because that is how `setOptionsOp` worked, and we were mimicking the structure of that operation. After some discussion, we came to the conclusion that it would be simpler if we just dropped the pointer. Tagging @2opremio as this will affect Horizon.

I also added a comment about how `SetTrustLineFlagsOp` uses the updated logic in CAP-0029.