### PR TITLE
SEP-0008: Fix inconsistency by updating snippet JSON field from "message" to "error"

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-02-03
-Version 1.6.0
+Updated: 2021-03-04
+Version 1.6.1
 ```
 
 ## Simple Summary
@@ -328,7 +328,7 @@ Name | Type | Description
 ```json
 {
   "status": "rejected",
-  "message": "The destination account is blocked."
+  "error": "The destination account is blocked."
 }
 ```
 


### PR DESCRIPTION
### What

Fix inconsistency by updating snippet JSON field from `message` to `error`.

### Why

While the table recommended using `error` the JSON snippet had the `message` field instead. 
Also, it was already called `error` in previous protocol versions.