### PR TITLE
Change the stale issue comment message.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,8 +14,8 @@ jobs:
           debug-only: false
           days-before-stale: 30
           days-before-close: 30
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed, or a comment is posted.'
-          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed, or a comment is posted.'
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 30 days unless the stale label is removed.'
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: 'needs draft,needs pilot,accepted,blocked'


### PR DESCRIPTION
### What
Change the message that is posted as a comment when issues are identified as stale to remove the statement about leaving a comment.

### Why
I've noticed a pattern that when we want to keep issues alive we post brief and mostly meaningless messages to issues like "Not stale". We should recommend folks just remove the stale label so we don't add unnecessary comments to peoples inboxes and to the issue history.