### PR TITLE
SEP-6: added 'id' response attributes for /deposit & /withdraw

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Anchor/Client interoperability
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-02-10
-Version 3.3.0
+Updated: 2021-03-08
+Version 3.4.0
 ```
 
 ## Simple Summary
@@ -168,6 +168,7 @@ The response body should be a JSON object with the following fields:
 Name | Type | Description
 -----|------|------------
 `how` | string | Terse but complete instructions for how to deposit the asset. In the case of most cryptocurrencies it is just an address to which the deposit should be sent.
+`id` | string | The anchor's internal ID for this deposit request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the deposit will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can deposit.
 `max_amount` | float | (optional) Maximum amount of asset that a user can deposit.
@@ -186,6 +187,7 @@ Bitcoin response example:
 ```json
 {
   "how" : "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
+  "id": "9421871e-0623-4356-b7b5-5996da122f3e",
   "fee_fixed" : 0.0002
 }
 ```
@@ -195,6 +197,7 @@ Ripple response example:
 ```json
 {
   "how" : "Ripple address: rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrHGbf tag: 88",
+  "id": "9421871e-0623-4356-b7b5-5996da122f3e",
   "eta": 60,
   "fee_percent" : 0.1,
   "extra_info": {
@@ -208,6 +211,7 @@ Mexican peso (MXN) response example:
 ```json
 {
   "how" : "Make a payment to Bank: STP Account: 646180111803859359",
+  "id": "9421871e-0623-4356-b7b5-5996da122f3e",
   "eta": 1800
 }
 ```
@@ -352,6 +356,7 @@ Name | Type | Description
 `account_id` | `G...` string | The account the user should send its token back to.
 `memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
+`id` | string | The anchor's internal ID for this withdraw request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
 `max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
@@ -365,7 +370,8 @@ Example:
 {
   "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
   "memo_type": "id",
-  "memo": "123"
+  "memo": "123",
+  "id": "9421871e-0623-4356-b7b5-5996da122f3e"
 }
 ```
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -168,7 +168,7 @@ The response body should be a JSON object with the following fields:
 Name | Type | Description
 -----|------|------------
 `how` | string | Terse but complete instructions for how to deposit the asset. In the case of most cryptocurrencies it is just an address to which the deposit should be sent.
-`id` | string | (optional) The anchor's internal ID for this deposit request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
+`id` | string | (optional) The anchor's ID for this deposit. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the deposit will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can deposit.
 `max_amount` | float | (optional) Maximum amount of asset that a user can deposit.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -168,7 +168,7 @@ The response body should be a JSON object with the following fields:
 Name | Type | Description
 -----|------|------------
 `how` | string | Terse but complete instructions for how to deposit the asset. In the case of most cryptocurrencies it is just an address to which the deposit should be sent.
-`id` | string | The anchor's internal ID for this deposit request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
+`id` | string | (optional) The anchor's internal ID for this deposit request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the deposit will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can deposit.
 `max_amount` | float | (optional) Maximum amount of asset that a user can deposit.
@@ -356,7 +356,7 @@ Name | Type | Description
 `account_id` | `G...` string | The account the user should send its token back to.
 `memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
-`id` | string | The anchor's internal ID for this withdraw request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
+`id` | string | (optional) The anchor's internal ID for this withdraw request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
 `max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -356,7 +356,7 @@ Name | Type | Description
 `account_id` | `G...` string | The account the user should send its token back to.
 `memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
-`id` | string | (optional) The anchor's internal ID for this withdraw request. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
+`id` | string | (optional) The anchor's ID for this withdrawal. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
 `eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
 `min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
 `max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.


### PR DESCRIPTION
resolves stellar/stellar-protocol#861

Adds optional `id` attributes to the `/deposit` & `/withdraw` success responses. This removes need for clients to infer which `/transactions` record is associated with a particular request.