### PR TITLE
SEP-0033: Set version and make active

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -48,6 +48,7 @@
 | [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
 | [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Active |
 | [SEP-0031](sep-0031.md) | Direct Payments | SDF | Standard | Active |
+| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Active |
 
 ### Draft Proposals
 
@@ -63,7 +64,6 @@
 | [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières and Tomer Weller | Standard | Draft |
 | [SEP-0030](sep-0030.md) | Recoverysigner: multi-party key management of Stellar accounts | Leigh McCulloch, Lindsay Lin | Standard | Draft |
 | [SEP-0032](sep-0032.md) | Asset Address | Leigh McCulloch | Standard | Draft |
-| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Draft |
 | [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Final Comment Period |
 | [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
 | [SEP-0037](sep-0037.md) | Address Directory API | OrbitLens | Informational | Draft |

--- a/ecosystem/sep-0033.md
+++ b/ecosystem/sep-0033.md
@@ -4,8 +4,9 @@
 SEP: 0033
 Title: Identicons for Stellar Accounts
 Author: Lobstr.co, Gleb Pitsevich (@pitsevich)
-Status: Draft
+Status: Active
 Created: 2019-11-20
+Version: 1.0.0
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/kAqhpCMe96c
 ```
 


### PR DESCRIPTION
### What
Make SEP-33 active and set the version to v1.

### Why
The SEP is being used in several products in the ecosystem, namely stellar.expert, the Lobstr.co wallet, and I think some other places. There are several implementations, and the number of implementations is growing (#890). These are all indicators that this proposal/protocol is more than just a draft at this point. It's actively in use and the status should reflect that.

@pitsevich You're the author of this proposal. Do you agree?