### PR TITLE
CAP-0021: Fix diff

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -401,7 +401,6 @@ index c561b7c7d..1d187a017 100644
 +    Preconditions cond;
  
      Memo memo;
- 
 
 ```
 

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -402,6 +402,7 @@ index c561b7c7d..1d187a017 100644
  
      Memo memo;
 
+
 ```
 
 ## Design Rationale


### PR DESCRIPTION
### What
Fix the XDR diff so it can be applied successfully by git.

### Why
The diff is corrupted and git errors when applying on the last line, because the last line has a space at the beginning of it.

Note that an extra line is required in the code block so that the rendered markdown on GitHub includes the necessary last empty line. This is because GitHub gobbles the last empty line in code blocks.