### PR TITLE
SEP-23: Improve proposed Horizon API changes

### DIFF
--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -118,7 +118,7 @@ accounts in a backwards-compatible way:
       account.  (For non-multiplexed accounts, this will be the same
       as `account_id`.)
 
-    - Base field name + `_id` is the integer.
+    - Base field name + `_muxer` is the integer.
 
   For example, given the MuxedAccount
   `MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY`,
@@ -126,7 +126,7 @@ accounts in a backwards-compatible way:
 
 ~~~
     account_id: GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY
-    account_id_id: 1234
+    account_id_muxer: 1234
     account_id_muxed: MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY
 ~~~~
 

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -114,20 +114,18 @@ accounts in a backwards-compatible way:
   type (currently just `KEY_TYPE_MUXED_ED2551`), two new fields are
   added to the JSON.
 
-    - Base field name + `_muxed` is the strkey of the multiplexed
-      account.  (For non-multiplexed accounts, this will be the same
-      as `account_id`.)
+    - Base field name + `_muxed` is the strkey of the multiplexed account.
 
-    - Base field name + `_muxer` is the integer.
+    - Base field name + `_muxed_id` is the integer.
 
   For example, given the MuxedAccount
   `MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY`,
   you might get the following fields:
 
 ~~~
-    account_id: GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY
-    account_id_muxer: 1234
-    account_id_muxed: MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY
+    source_account: GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY
+    source_account_muxed: MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY
+    source_account_muxed_id: 1234
 ~~~~
 
 * Queries for a multiplexed MuxedAccount (starting M...) return only


### PR DESCRIPTION
### What
Improve the proposed Horizon API changes to rename the suffix `_id` to `_muxed_id`.

### Why
OrbitLens was talking to me about how the _id_id example highlights how using an _id suffix is not very pretty or specific to this new data we're displaying. _muxed_id would more clearly identify the field apart from others. 

It's possible there are better improvements, but this at least better than what's here.