### PR TITLE
SEP-0008: Update author list to current standards

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,7 +3,7 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
+Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
 Updated: 2021-03-04


### PR DESCRIPTION
For a brief moment in time we were using company names as authors. As per current standards this update replaces Lightyear.io with the original author - me :)