### PR TITLE
SEP-0008: Add discussion about when to use a revised status and when not to

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-03-04
-Version 1.6.1
+Updated: 2021-03-26
+Version 1.7.0
 ```
 
 ## Simple Summary
@@ -174,6 +174,8 @@ Name | Type | Description
 ##### Revised
 
 This response means that the transaction was revised to be made compliant.
+
+A revised transaction should only add operations to the transaction to make it compliant and should not change the intent of the operations that the user has included. If an operation the user has included cannot be made compliant, the rejected status should be returned. For example, if a user includes a payment operation to an account not authorized, the server can revise the transaction including allow trust operations to authorize the account. And for example, if a user includes a payment operation for $1000, but amounts over $100 are not compliant, the transaction should not be revised lowering the amount and should be rejected, because altering the payment amount would change the intent of the transaction.
 
 A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -175,7 +175,7 @@ Name | Type | Description
 
 This response means that the transaction was revised to be made compliant.
 
-A revised transaction should only add operations to the transaction to make it compliant and should not change the intent of the operations that the user has included. If an operation the user has included cannot be made compliant by adding another operation, the rejected status should be returned. For example, if a user includes a payment operation to an account not authorized, the server can revise the transaction including allow trust operations to authorize the account. But, for example, if a user includes a payment operation for $1000, but amounts over $100 are not compliant, the transaction should not be revised lowering the amount and should be rejected, because altering the payment amount would change the intent of the transaction.
+A revised transaction should only add operations to the transaction to make it compliant and should not change the intent of the operations that the user has included. If an operation the user has included cannot be made compliant by adding another operation, the rejected status should be returned. For example, if a user includes a payment operation to an account not authorized, the server can revise the transaction including allow trust operations to authorize the account. But, for example, if a user includes a payment operation for $1000, but amounts over $100 are not compliant, the transaction should not be revised lowering the amount and instead be rejected, because altering the payment amount would change the intent of the transaction.
 
 A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -175,7 +175,7 @@ Name | Type | Description
 
 This response means that the transaction was revised to be made compliant.
 
-A revised transaction should only add operations to the transaction to make it compliant and should not change the intent of the operations that the user has included. If an operation the user has included cannot be made compliant, the rejected status should be returned. For example, if a user includes a payment operation to an account not authorized, the server can revise the transaction including allow trust operations to authorize the account. And for example, if a user includes a payment operation for $1000, but amounts over $100 are not compliant, the transaction should not be revised lowering the amount and should be rejected, because altering the payment amount would change the intent of the transaction.
+A revised transaction should only add operations to the transaction to make it compliant and should not change the intent of the operations that the user has included. If an operation the user has included cannot be made compliant by adding another operation, the rejected status should be returned. For example, if a user includes a payment operation to an account not authorized, the server can revise the transaction including allow trust operations to authorize the account. But, for example, if a user includes a payment operation for $1000, but amounts over $100 are not compliant, the transaction should not be revised lowering the amount and should be rejected, because altering the payment amount would change the intent of the transaction.
 
 A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
 


### PR DESCRIPTION
### What
Add discussion about when to use a revised status and when not to. Specifically distinguish that a revised transaction should never change the intent or semantics of the operations the user provided.

### Why
There was some conversation about this recently within SDF and we realize it is not clear in SEP-8 when to use reject or when to use revised. In general revised shouldn't alter the intent. If the user wants to perform an operation and it can succeed if the server adds operations, that's the perfect use case for revised. If the user wants to perform an operation that is not compliant no matter what operations can be added, it should just reject the transaction rather than try and modify the transaction.