### PR TITLE
SEP-31: improve grammar, phrasing, and structure

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -30,14 +30,17 @@ At a high level, the following steps are performed to complete a transaction:
 2. The Sending Anchor sends the associated amount of funds to the Receiving Anchor's Stellar account
 3. The Receiving Anchor sends funds to the Receiving Client's financial account
 
+Typically, the Sending and Receiving Clients reside in different regulatory jurisdictions and therefore a payment between their financial accounts must be facilitated by two business entities, the Sending and Receiving Anchors, who have the necessary licenses in their respective jurisdictions.
+
 ## Example
 
-Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with NigeriaPay to make this payment to send money directly into Bob’s bank account. Bob doesn’t need to do anything, or know anything about this payment, besides letting Alice know what his bank account information is. Alice only needs to deal with her anchor (NigeriaPay). NigeriaPay will utilize its European rail, enabled with EuroPay Anchor service, to move the money to EuroPay in order to deposit it into Bob’s bank account.
+Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with NigeriaPay to make this payment to send money directly into Bob’s bank account. Bob doesn’t need to do anything, or know anything about this payment, besides letting Alice know what his bank account information is. Alice only needs to deal with her anchor (NigeriaPay). Alice passes this information and her money to NigeriaPay, and NigeriaPay sends those funds to the EuroPay Anchor service, and Europay deposits those funds into Bob’s bank account.
 
 ## Prerequisites
 
 * The Receiving Anchor must define `DIRECT_PAYMENT_SERVER` in their [`stellar.toml`](sep-0001.md).
 * The Sending and Reciving Anchors must create bi-lateral agreements to interoperate with each other. This differs from other protocols in that there is no concept of 'discoverability'.
+* If the Receiving Anchor requires KYC information for the Sending or Receiving Clients, the Receiving Anchor must implement [SEP-12](sep-0012.md) and define a `KYC_SERVER` in their [stellar.toml](sep-0001.md).
 
 ## Authentication
 
@@ -79,8 +82,8 @@ All endpoints respond with content type:
 1. The Sending Anchor makes a request to the Receiving Anchor's `GET /info` endpoint to collect asset information and the `transaction.fields` describing the transaction-related information required by the Receiving Anchor.
 1. The Sending Anchor fetches the relevant KYC `type` values from the `sep12` object for the Sending and Receiving Client. If no `type` values are defined for either client, KYC information is not required for that client.
 1. The Sending Anchor makes [SEP-12 GET /customer?type=](sep-0012.md#customer-get) requests for the Sending and Receiving Clients. The response includes the [SEP-9](sep-0009.md) KYC attributes required for registering a client of the associated `type`.
-1. The Sending Anchor collects all information from the Sending Client. This includes the custom fields listed in the Receiving Anchor's `GET /info` response as well as the KYC fields described in the `GET /customer` responses for both the Sending and Recieving Clients. How the Sending Anchor collects this information from the Sending Client is out of the scope of this document, but the Receving Client should not be required to take any action in order for the Sending Client to make the payment to the Receiving Anchor.
-1. The Sending Anchor makes [SEP-12 PUT KYC_SERVER/customer](sep-0012.md#customer-put) requests containing the collected information for each client.
+1. The Sending Anchor collects all required information from the Sending Client. This includes the custom fields listed in the Receiving Anchor's `GET /info` response as well as the KYC fields described in the `GET /customer` responses for both the Sending and Recieving Clients. How the Sending Anchor collects this information from the Sending Client is out of the scope of this document, but the Receving Client should not be required to take any action in order for the Sending Client to make the payment to the Receiving Anchor.
+1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected information for each client.
 1. On successful registration (`202` HTTP status), the Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction amount and asset information. The response will include a `id` that will be used to check the status of the transaction.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`. 
 1. The Sending Anchor submits the payment transaction to Stellar.
@@ -212,7 +215,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`types` | object | (optional) An object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests. Each key should map to an object value with a human-readable `description`.
+`types` | object | (optional) An object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests. Each key should map to an object with a human-readable `description`.
 
 If KYC is required for a Sending or Receiving client in some cases but not others, it is recommended to provide values in the respective `types` object for all cases and return an empty `fields` object from [SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) for the cases where no KYC is necessary.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -26,9 +26,9 @@ The entities involved in a transaction are:
 
 At a high level, the following steps are performed to complete a transaction:
 
-1. The Sending Client sends funds from a financial account to the Sending Anchor
-2. The Sending Anchor sends the associated amount of funds to the Receiving Anchor's Stellar account
-3. The Receiving Anchor sends funds to the Receiving Client's financial account
+1. The Sending Client sends funds from their financial account to the Sending Anchor's financial account (off/on-Stellar)
+2. The Sending Anchor sends the funds to the Receiving Anchor's Stellar account (on-Stellar)
+3. The Receiving Anchor sends funds to the Receiving Client's financial account (off-Stellar)
 
 Typically, the Sending and Receiving Clients reside in different regulatory jurisdictions and therefore a payment between their financial accounts must be facilitated by two business entities, the Sending and Receiving Anchors, who have the necessary licenses in their respective jurisdictions.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -387,7 +387,7 @@ Example response:
 {
   "transaction": {
       "id": "82fhs729f63dh0v4",
-      "status": "pending_info_update",
+      "status": "pending_transaction_info_update",
       "status_eta": 3600,
       "external_transaction_id": "ABCDEFG1234567890",
       "amount_in": "18.34",

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -13,30 +13,38 @@ Version 1.2.0
 
 ## Simple Summary
 
-This SEP defines a protocol for enabling direct fiat to fiat payments between two financial accounts that exist outside of the Stellar network. The payments are facilitated by two anchors.
+This SEP defines a protocol for enabling payments between two financial accounts that exist outside the Stellar network.
 
 ## Abstract
 
-This proposal facilitates the ability for anchors to build a rail between two regions, allowing end users to send fiat from one bank account directly into another end user's bank account.  In this flow, neither user needs to deal with the Stellar network as the two anchors take care of everything for them.
+The entities involved in a transaction are:
+
+- A **Sending Client**: The owner of the origin financial account.
+- A **Sending Anchor**: The business offering outbound payment services, who must have a business relationship with the Receiving Anchor.
+- A **Receiving Anchor**: The business offering inbound payment processing.
+- A **Receiving Client**: The owner of the destination financial account.
+
+At a high level, the following steps are performed to complete a transaction:
+
+1. The Sending Client sends funds from a financial account to the Sending Anchor
+2. The Sending Anchor sends the associated amount of funds to the Receiving Anchor's Stellar account
+3. The Receiving Anchor sends funds to the Receiving Client's financial account
 
 ## Example
 
-Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with NigeriaPay to make this payment to send money directly into Bob’s bank account. Bob doesn’t need to do anything, or know anything about this payment, besides letting Alice know what his bank account information is. Alice only needs to deal with her anchor (NigeriaPay).
-
-NigeriaPay will utilize its European rail, enabled with EuroPay Anchor service, to move the money to EuroPay in order to deposit it into Bob’s bank account.
+Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with NigeriaPay to make this payment to send money directly into Bob’s bank account. Bob doesn’t need to do anything, or know anything about this payment, besides letting Alice know what his bank account information is. Alice only needs to deal with her anchor (NigeriaPay). NigeriaPay will utilize its European rail, enabled with EuroPay Anchor service, to move the money to EuroPay in order to deposit it into Bob’s bank account.
 
 ## Prerequisites
 
-* An anchor must define the location of their `DIRECT_PAYMENT_SERVER` in their [`stellar.toml`](sep-0001.md). Anchors will find each other's servers by pulling this TOML file from their home domains.
-* Anchors will create bi-lateral agreements to interoperate with each other.  This differs from other protocols in that there is no concept of 'discoverability'.  Anchors should keep a mapping of their partnerships in different regions to their home domains.
-* Each anchor registers a Stellar key with each counterparty anchor they interact with in order to identify themselves via [SEP-10 Web Authentication](sep-0010.md).
-
+* The Receiving Anchor must define `DIRECT_PAYMENT_SERVER` in their [`stellar.toml`](sep-0001.md).
+* The Sending and Reciving Anchors must create bi-lateral agreements to interoperate with each other. This differs from other protocols in that there is no concept of 'discoverability'.
 
 ## Authentication
 
-Anchors should support [SEP-10](sep-0010.md) web authentication to ensure the counterparty they're interoperating with is actually who they say they are.  Clients must submit the JWT obtained via the SEP-10 authentication flow to all API endpoints except `/info`.
+Sending Anchors must authenticate with Receiving Anchors via [SEP-10 Web Authentication](sep-0010.md). Sending Anchors must provide the Stellar account they will authenticate with to their Receiving Anchors, and Receiving Anchors must ensure that the authenticated Stellar account belongs to a Sending Anchor for which a bi-lateral agreement has been made.
 
-The JWT should be included as a request header:
+The SEP-10 JWT be included as a header in requests to all endpoints:
+
 ```
 Authorization: Bearer <JWT>
 ```
@@ -59,73 +67,51 @@ All endpoints respond with content type:
 
 ## API Endpoints
 
-* [`GET /info`](#info)
-* [`POST /transactions`](#transactions)
-* [`GET /transactions/:id`](#transaction)
-* [`PATCH /transactions/:id`](#update)
+* [`GET /info`](#get-info)
+* [`POST /transactions`](#post-transactions)
+* [`GET /transactions/:id`](#get-transaction)
+* [`PATCH /transactions/:id`](#patch-transaction)
 
-## Implementation Notes
+### Detailed Sending Anchor Flow
 
-### Entities Involved
-
-- Sending Client: The end user who is initiating a payment via the sending anchor.
-- Sending Anchor: The business offering outbound payment services.  Takes fiat in from the sending client, and has a business relationship with the receiving anchor.
-- Receiving Anchor: The business offering inbound payment processing. Deposits fiat in the receiving client's bank account, and has a business relationship with the sending anchor.
-- Receiving Client: The owner of the destination bank account.
-
-### Setting up rails
-
-1. To create a rail, find a counterparty who implements this SEP in the region you wish to provide access to and agrees to do business with you.
-1. Trade public keys with each other in order to identify and securely interoperate with each other.
-1. Keep a mapping of region to home_domain, using home_domain as your initial entry point to interoperating.
-
-### Sender Flow
-
-1. The Sending Client (user) iniates a direct payment to the Receiving Client.
-1. The Sending Anchor identifies the Receiving Anchor it will use for the payment based on the receipient's location and desired currency.
-1. The Sending Anchor makes a request to the Receiving Anchor's `/info` endpoint to collect asset information and the `transaction.fields` describing the pieces of information required by the Receiving Anchor.
-1. If the Receiving Anchor has a `sender_sep12_type` and/or a `receiver_sep12_type` attribute in the `/info` endpoint response,
-   1. The Sending Anchor must collect the Receiving Anchor's `KYC_SERVER` URI from the Receiving Anchor's [SEP-1 stellar.toml](sep-0001.md) file.
-   1. The Sending Anchor must make a `GET KYC_SERVER/customer` request for each `_sep12_type` value listed in the `/info` response. Each `/customer` response contains [SEP-9](sep-0009.md) fields required by the Receiving Anchor for that user.
-1. The Sending Anchor collects all required information from the Sending Client. This includes the custom fields listed in the Receiving Anchor's `/info` response as well as the KYC fields described in the `/customer` responses for both the Sending and Recieving Clients. How the Sending Anchor collects this information from the Sending Client is out of the scope of this document, but the Receving Client should not be required to take any action in order for the Sending Client to make the payment to the Receiving Anchor.
-1. The Sending Anchor makes `PUT KYC_SERVER/customer` requests containing the SEP-9 values listed in the `GET KYC_SERVER/customer` responses to register the Clients with the Receiving Anchor.
-1. On successful registration (`202` HTTP status), the Sending Anchor makes a `POST DIRECT_PAYMENT_SERVER/transactions` request to create a `pending_sender` transaction with the Receiving Anchor.
-   1. Note that this request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction amount and asset information.
-1. Once the transaction is included in the `GET DIRECT_PAYMENT_SERVER/transactions` response and the transaction's `status` is `pending_sender`, the Sending Anchor submits the path payment transaction to Stellar.
-   1. The destination account of the transaction must be the `stellar_account_id` returned in the `POST /transactions` response.
-   1. The memo of the transaction must match the `stellar_memo` and `stellar_memo_type` returned in the `POST /transactions` response.
-1. The Sending Anchor polls the Receiving Anchor's `GET DIRECT_PAYMENT_SERVER/transactions` endpoint until the transaction's `status` changes to `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
-1. If `completed`, the job is done and the Sending Anchor should notify the Sending Client.
+1. The Sending Client iniates a payment to the Receiving Client.
+1. The Sending Anchor identifies the Receiving Anchor it will use for the payment based on the receipient's location.
+1. The Sending Anchor makes a request to the Receiving Anchor's `GET /info` endpoint to collect asset information and the `transaction.fields` describing the transaction-related information required by the Receiving Anchor.
+1. The Sending Anchor fetches the relevant KYC `type` values from the `sep12` object for the Sending and Receiving Client. If no `type` values are defined for either client, KYC information is not required for that client.
+1. The Sending Anchor makes [SEP-12 GET /customer?type=](sep-0012.md#customer-get) requests for the Sending and Receiving Clients. The response includes the [SEP-9](sep-0009.md) KYC attributes required for registering a client of the associated `type`.
+1. The Sending Anchor collects all information from the Sending Client. This includes the custom fields listed in the Receiving Anchor's `GET /info` response as well as the KYC fields described in the `GET /customer` responses for both the Sending and Recieving Clients. How the Sending Anchor collects this information from the Sending Client is out of the scope of this document, but the Receving Client should not be required to take any action in order for the Sending Client to make the payment to the Receiving Anchor.
+1. The Sending Anchor makes [SEP-12 PUT KYC_SERVER/customer](sep-0012.md#customer-put) requests containing the collected information for each client.
+1. On successful registration (`202` HTTP status), the Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction amount and asset information. The response will include a `id` that will be used to check the status of the transaction.
+1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`. 
+1. The Sending Anchor submits the payment transaction to Stellar.
+1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
+1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.
-1. If `pending_transaction_info_update`, the `transaction.fields` values collected from the Sending Client were invalid and must be corrected by the Sending Client
-   1. This requires the Sending Anchor to detect which fields were invalid from the `required_info_updates` object on the `/transactions` record.
-   1. Then the Sending Anchor must reach out the Sending Client again, collect valid values, and make a `PATCH DIRECT_PAYMENT_SERVER/transactions` request to the Receiving Anchor
-1. If `pending_customer_info_update`, the SEP-9 KYC values collected were invalid and must be corrected by the Sending Client
-   1. This requires the Sending Anchor to make a `GET KYC_SERVER/customer` request for each customer associated with the transaction to determine which fields need to be updated
-   1. The Sending Anchor then reaches out to the Sending Client again, collects valid values for the invalid fields, and makes a `PUT KYC_SERVER/customer` request to the Receiving Anchor
-1. After providing the Receiving Anchor with updated values, the status should ultimately change to `completed`
+1. If `pending_transaction_info_update`, the `transaction.fields` values collected from the Sending Client were invalid and must be corrected by the Sending Client. See the [Pending Transaction Info Update](#pending-transaction-info-update) section for more information.
+1. If `pending_customer_info_update`, the SEP-9 KYC values collected were invalid and must be corrected by the Sending Client. See the [Pending Customer Info Update](#pending-customer-info-update) section for more information.
+1. After providing the Receiving Anchor with updated values, the status should ultimately change to `completed`.
 
-### Receiver Flow
+### Detailed Receiving Anchor Flow
 
-1. The Sending Anchor makes a request to the Receiving Anchor's `DIRECT_PAYMENT_SERVER/info` endpoint.
-1. The Sending Anchor makes a `GET KYC_SERVER/customer` request for each `_sep12_type` attribute included in the response.
-1. The Sending Anchor makes a `PUT KYC_SERVER/customer` request for each `_sep12_type` attribute.
-   1. The Receiving Anchor must validate the KYC data provided and reject the request with useful error messages if invalid. This is _critical_ for limiting the number of times a transaction ends up in a `pending_customer_info_update` `status`. 
-1. The Sending Anchor makes a `POST DIRECT_PAYMENT_SERVER/transactions` request.
-   1. The Receiving Anchor must validate the asset, amount, transaction fields, and customers.
-   1. The Recieving Anchor must create a transaction record in their database and expose it via `/transactions`.
-   1. Transactions should initially be `pending_sender`. If any preprocessing is required before receiving a payment, mark the transaction as `pending_receiving` until ready.
+1. The Sending Anchor makes a request to the Receiving Anchor's `GET /info` endpoint.
+1. The Sending Anchor makes a `SEP-12 GET /customer` request for the Sending and Receiving Clients if required.
+1. The Sending Anchor makes a `SEP-12 PUT /customer` request for the Sending and Receiving Clients if required.
+  1. The Receiving Anchor must validate the KYC data provided and reject the request with useful error messages if invalid.
+1. The Sending Anchor makes a `POST /transactions` request.
+  1. The Receiving Anchor must ensure the asset, amount, transaction fields, and customers IDs are valid.
+  1. The Recieving Anchor must create a transaction record in their database and expose it via `GET /transactions/:id`.
+  1. Transactions should initially be `pending_sender`. If any preprocessing is required before receiving a payment, mark the transaction as `pending_receiver` until ready to receive funds.
 1. The Receiving Anchor then waits to receive the payment identified by the `stellar_memo` returned in the `POST /transactions` response.
-1. Once the Stellar payment has been received and matched with the internal transaction record, the Receiving Anchor must attempt to transfer an equivalent amount of the asset (minus fees) off-chain to the Receiving Client using the KYC and rails data collected by the Sending Anchor
-1. If the off-chain payment succeeds, the transaction's status should be updated to `completed`
-1. If the off-chain payment cannot be received by the Recieving Client almost immediately, the transaction's status should be updated to `pending_external` until received. Then, `completed`.
-1. If the off-chain payment fails, the Recieving Anchor must determine why, which is outside the scope of this document. Once determined, the Reciving Anchor must either correct it themselves (internal error) or receive updated values from the Sending Anchor for the fields that were discovered to be invalid.
-   1. If the invalid values were described in `/info`'s `transaction.fields` object, the transaction's status should be updated to `pending_transaction_info_update` and `required_info_updates` should contain an object describing the errors.
-   1. If the invalid values were described in `GET /customer` responses, the transaction's status should be updated to `pending_customer_info_update` and the invalid field names should be returned in the next `GET /customer?id=` request for each Client.
-   1. The Sending Client will detect transaction's status and invalid fields, collect the info from the Sending Client, and make requests to the Recieving Anchor containing the updated information.
-   1. Once the passed information is validated, the Receiving Anchor should update the transaction's status to `pending_receiver` and retry the off-chain transfer. This loop of attempting the transfer and waiting for updated information should continue until the transfer is successful.
+1. Once the Stellar payment has been received and matched with the internal transaction record, the Receiving Anchor must attempt to transfer an equivalent amount of the asset (minus fees) off-chain to the Receiving Client using the KYC and rails data collected by the Sending Anchor.
+1. If the off-chain payment succeeds, the transaction's status should be updated to `completed`.
+1. If the off-chain payment cannot be received by the Recieving Client almost immediately, the transaction's status should be updated to `pending_external` until received.
+1. If the off-chain payment fails, the Recieving Anchor must determine why, which is outside the scope of this document. Once determined, the Receiving Anchor must either correct it themselves (internal error) or receive updated values from the Sending Anchor for the fields that were discovered to be invalid.
+  1. If the invalid values were described in `GET /info`'s `transaction.fields` object, the transaction's status should be updated to `pending_transaction_info_update` and `required_info_updates` should contain an object describing the errors.
+  1. If the invalid values were described in `SEP-12 GET /customer` responses, the transaction's status should be updated to `pending_customer_info_update` and the invalid field names should be returned in the next `GET /customer?id=` request for each Client.
+  1. The Sending Anchor will detect the transaction's status and invalid fields, collect the info from the Sending Client, and make requests to the Receiving Anchor containing the updated information.
+  1. Once the provided information is validated, the Receiving Anchor should update the transaction's status to `pending_receiver` and retry the off-chain transfer. This loop of attempting the transfer and waiting for updated information should continue until the transfer is successful.
 
-### Info
+### GET Info
 #### Request
 
 ```
@@ -200,34 +186,51 @@ The response should be a JSON object like:
 }
 ```
 
-The JSON object contains an entry for each asset that the anchor supports for receiving and completing a direct payment.
+The JSON object contains an entry for each currency that the anchor supports for receiving and completing a direct payment.
 
-#### For each asset available for receiving, response contains:
+#### Currency Object Schema
 
-* `sep12`: an object containing `sender` and `receiver` keys.
-  * `sender`: an object containing a `types` key if KYC information is required for the sending client, empty otherwise.
-    * `types`: (optional) an object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests for sending clients. Each key should map to an object value with a human-readable `description`. This field can be omitted if no KYC is necessary for the sending client.
-  * `receiver`: an object containing a `types` key if KYC information is required for the receiving client, empty otherwise.
-    * `types`: (optional) an object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests for receiving clients. Each key should map to an object value with a human-readable `description`. This field can be omitted if no KYC is necessary for the receiving client.
-* `min_amount`: (optional) minimum amount. No limit if not specified.
-* `max_amount`: (optional) maximum amount. No limit if not specified.
-* `fee_fixed`: (optional) fixed (flat) fee for deposit. In units of the received asset. Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: (optional) percentage fee for deposit. In percentage points. Leave blank if there is no fee or the fee schedule is complex.
-* `sender_sep12_type`: (**deprecated**, optional) value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use the values in `sep12.sender.types` instead if it is present.
-* `receiver_sep12_type`: (**deprecated**, optional) value of the `type` parameter the sending anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use the values in `sep12.receiver.types` instead if it is present.
-* `fields`: as explained below.
+Name | Type | Description
+-----|------|------------
+`sep12` | object | An object containing `sender` and `receiver` keys.
+`min_amount` | number | (optional) Minimum amount. No limit if not specified.
+`max_amount` | number | (optional) Maximum amount. No limit if not specified.
+`fee_fixed` | number | (optional) A fixed fee in units of the destination currency. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.
+`fee_percent` | number |(optional) A percentage fee in percentage points. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.
+`sender_sep12_type` | string | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a value from `sep12.sender.types` instead if any are present.
+`receiver_sep12_type` | string | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a values from `sep12.receiver.types` instead if any are present.
+`fields` | object | An object containing the per-transaction parameters required in `POST /transactions` requests.
 
-The `fields` object allows an anchor to describe fields that must be passed into `POST /transactions`.  Only fields related to the transaction should be described in the `fields` object.  In the example above, the receiving anchor requires the account and routing number of the receiving client's bank account.  
+#### `sep12` Object Schema
 
-Each `fields` sub-object contains a key for each field name and an object with the following fields as the value:
+Name | Type | Description
+-----|------|------------
+`sender` | object | An object containing a `types` key if KYC information is required for the Sending Client, empty otherwise.
+`receiver` | object | An object containing a `types` key if KYC information is required for the Receiving Client, empty otherwise.
 
-* `description`: (required) description of field to show to user.
-* `choices`: (optional) list of possible values for the field.
-* `optional`: (optional) false if not specified.
+#### `types` Object Schema
 
-If KYC is required for a sending or receiving client in some cases but not others, it is recommended to provide values in the respective `types` object for all cases and return an empty `fields` object from [SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) for the cases where no KYC is necessary.
- 
-### Transactions
+Name | Type | Description
+-----|------|------------
+`types` | object | (optional) An object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests. Each key should map to an object value with a human-readable `description`.
+
+If KYC is required for a Sending or Receiving client in some cases but not others, it is recommended to provide values in the respective `types` object for all cases and return an empty `fields` object from [SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) for the cases where no KYC is necessary.
+
+#### `fields` Object Schema
+
+Name | Type | Description
+-----|------|------------
+`fields` | object | An object containing single `transaction` key.
+
+#### `transaction` Object Schema
+
+Name | Type | Description
+-----|------|------------
+`description` | string | A description of field to show to user.
+`choices` | array | (optional) A list of possible values for the field.
+`optional` | boolean | (optional) false if not specified.
+
+### POST Transactions
 
 #### Request
 
@@ -251,55 +254,54 @@ Content-Type: application/json
 }
 ```
 
-This post requests attempts to initiate a payment through this anchor.  It should provide the amount and all the required fields (specified in the [`/info`](#info) endpoint). The values for `sender_id` and `receiver_id` are from the receiving anchor's [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` responses.
-
-If the request describes a valid transaction that this anchor can fulfill, we return a success response with details on what to send. If the request is not valid, or we need more info, we can return with an error response and expect the sending anchor to try again with updated values.
+This request initiates a payment. The Sending and Receiving Client must be registered via [SEP-12](sep-0012.md) if required by the Receiving Anchor.
 
 ##### Request Parameters
 
 Name | Type | Description
 -----|-----|------
 `amount` | number | Amount of payment in destination currency.
-`asset_code` | string | Code of the asset the sending anchor intends to send. This must match one of the entries listed in the receiving anchor's `/info` endpoint.
-`asset_issuer` | string | (optional) The issuer of the Stellar asset the sending anchor intends to send. If not specified, the asset sent must be issued by the receiving anchor.
-`sender_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the sending client. If `sender_sep12_type` was included in the `/info` response, this field is required.
-`receiver_id` | `string` | (optional) The ID included in the [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) `PUT /customer` response for the receiving client. If `receiver_sep12_type` was included in the `/info` response, this field is required.
-`fields` | object | A key-pair object containing the values requested by the receiving anchor in their `/info` endpoint containing a single `"transaction"` object.
+`asset_code` | string | Code of the asset the Sending Anchor intends to send. This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
+`asset_issuer` | string | (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
+`sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Only required if the `GET /info` response's `sep12.sender.types` object is non-empty.
+`receiver_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Receiving Client. Only required if the `GET /info` response's `sep12.receiver.types` object is non-empty. 
+`fields` | object | An object containing the values requested by the Receiving Anchor in the `GET /info` endpoint.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human-readable error codes or field descriptions will be returned in this language.
 
 #### Responses
 
 ##### Success (201 Created)
-This is the successful case where a receiving anchor confirms that they can fulfill this payment as described. The response body should be a JSON object with the following values
+
+This is the successful case where a Receiving Anchor confirms that they can fulfill this payment as described. The response body should be a JSON object with the following values
 
 Name | Type | Description
 -----|------|------------
-`id` | string | Persistent identifier to check the status of this payment
-`stellar_account_id` | string | Stellar account to send payment to
-`stellar_memo_type` | string | Type of memo to attach to the Stellar payment (`text`, `hash`, or `id`)
-`stellar_memo` | string | The memo to attach to the Stellar payment
+`id` | string | The persistent identifier to check the status of this payment.
+`stellar_account_id` | string | The Stellar account to send payment to.
+`stellar_memo_type` | string | The type of memo to attach to the Stellar payment (`text`, `hash`, or `id`).
+`stellar_memo` | string | The memo to attach to the Stellar payment.
 
 ##### Customer Info Needed (400 Bad Request)
 
-In the case where the sending anchor didn't provide all the KYC information requested in `GET /customer`, or where the receiver requires additional KYC information after learning of the transaction `amount`, the request should fail with a 400 status code and the following body in JSON format. The sender should then retry both the `GET /customer` request to collect the additional fields and the `PUT /customer` request including all fields described in the `GET /customer` response.
+In the case where the Sending Anchor didn't provide all the KYC information requested in `SEP-12 GET /customer`, or where the Receiving Anchor requires additional KYC information after `amount`, the response should include a 400 status code and the following body. The sender should then retry both the `SEP-12 GET /customer` request to collect the additional fields and the `SEP-12 PUT /customer` request including all fields described in the `GET /customer` response.
 
 Name | Type | Description
 -----|------|------------
 `error`| string | `customer_info_needed`
-`type` | string | (optional) A string for the `type` URL argument the sending anchor should use when making the `GET /customer` request. The value should be included in the `sender` or `receiver` `types` response object from `/info`.
+`type` | string | (optional) A string for the `type` URL argument the Sending Anchor should use when making the `SEP-12 GET /customer` request. The value should be included in the `sender.types` or `receiver.types` object from `GET /info`.
 
 ##### Transaction Info Needed (400 Bad Request)
 
-In the case where the sending anchor didn't provide all the information requested in `/info`, or if the transaction requires extra information, the request should fail with a 400 status code and the following body in JSON format.  The sender should then retry the entire request including all the previously sent fields plus the fields described in the response.
+In the case where the Sending Anchor didn't provide all the information requested in `GET /info`, the response should include a 400 status code the following body.  The Sending Anchor should then retry the entire request including all the previously sent fields plus the fields described in the response.
 
 Name | Type | Description
 -----|------|------------
 `error`| string | `transaction_info_needed`
-`fields` | object | A key-value pair of missing fields in the same format as fields described in [`/info`](#info).
+`fields` | object | A key-value pair of missing fields in the same format as fields described in [`GET /info`](#info).
 
 ##### Error (400 Bad Request)
 
-In the case where the transaction just cannot be completed, return an error response with a JSON object containing an `error` key describing the error in human-readable format in the language indicated in the request.
+In the case where the transaction cannot be completed, return an error response body containing an `error` key describing the error in human-readable format in the language indicated in the request.
 
 ```
 {
@@ -311,9 +313,9 @@ In the case where the transaction just cannot be completed, return an error resp
 }
 ```
 
-### Transaction
+### GET Transaction
 
-The transaction endpoint enables senders to query/validate a specific transaction at a receiving anchor.
+The transaction endpoint enables Sending Clients to fetch information on a specific transaction with the Receiving Anchor.
 
 ```
 GET DIRECT_PAYMENT_SERVER/transactions/:id
@@ -325,42 +327,42 @@ Name | Type | Description
 -----|------|------------
 `id` | string | The id of the transaction.
 
-On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
+On success the response should include a `200 OK` HTTP status code and the following body:
 
 Name | Type | Description
 -----|------|------------
 `transaction` | object | The transaction that was requested by the client.
 
-The `transaction` object should be of the following schema.
+`transaction` Object Schema
 
 Name | Type | Description
 -----|------|------------
-`id` | string | Unique, anchor-generated id for the deposit/withdrawal.
-`status` | string | Processing status of deposit/withdrawal.
-`status_eta` | number | (optional) Estimated number of seconds until a status change is expected
-`amount_in` | string | (optional) Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
-`amount_out` | string | (optional) Amount sent by anchor to user at end of transaction as a string with up to 7 decimals.
-`amount_fee` | string | (optional) Amount of fee charged by anchor.
-`stellar_account_id` | string | Stellar account to send payment to.
-`stellar_memo_type` | string | Type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
+`id` | string | The ID returned from the `POST /transactions` request that created this transaction record.
+`status` | string | The status of the transaction. Values are outlined below.
+`status_eta` | number | (optional) The estimated number of seconds until a status change is expected.
+`amount_in` | string | (optional) The amount received or to be received by the Receiving Anchor. Up to 7 decimals are permitted. Excludes any fees charged after Receiving Anchor receives the funds.
+`amount_out` | string | (optional) The amount sent by the Rending Anchor to Receiving Client. Up to 7 decimals are permitted.
+`amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor.
+`stellar_account_id` | string | The Stellar account to send the payment to.
+`stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
-`stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that initiated the payment.
-`external_transaction_id` | string | (optional) ID of transaction on external network that completes the payment into the receivers account.
+`stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
+`external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
 `refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
-`required_info_updates` | object | (optional) A set of fields that require update from the sender, in the same format as described in [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.
+`required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 
 `status` should be one of:
 
-* `pending_sender` -- awaiting payment to be initiated by sending anchor.
+* `pending_sender` -- awaiting payment to be sent by Sending Anchor.
 * `pending_stellar` -- transaction has been submitted to Stellar network, but is not yet confirmed.
-* `pending_customer_info_update` -- certain pieces of information need to be updated by the sending anchor.  See [pending customer info update](#pending-customer-info-update) section
-* `pending_transaction_info_update` -- certain pieces of information need to be updated by the sending anchor.  See [pending transaction info update](#pending-transaction-info-update) section
-* `pending_receiver` -- payment is being processed by the receiving anchor
+* `pending_customer_info_update` -- certain pieces of information need to be updated by the Sending Anchor. See the [Pending Customer Info Update](#pending-customer-info-update) section for more information.
+* `pending_transaction_info_update` -- certain pieces of information need to be updated by the sending anchor. See the [Pending Transaction Info Update](#pending-transaction-info-update) section for more information.
+* `pending_receiver` -- payment is being processed by the Receiving Anchor.
 * `pending_external` -- payment has been submitted to external network, but is not yet confirmed.
-* `completed` -- deposit/withdrawal fully completed.
+* `completed` -- funds have been delivered to the Receiving Client.
 * `error` -- catch-all for any error not enumerated above.
 
 Example response:
@@ -406,17 +408,17 @@ Example response:
 
 If the transaction cannot be found, the endpoint should return a `404 NOT FOUND` result.
 
-#### Pending customer info update
+#### Pending Customer Info Update
 
-In certain cases the receiver might need to request updated information.  For example, if the bank tells the anchor that the provided receiver's name is incorrect or missing a middle initial.  Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` state until the sender makes another `PUT /customer` request to update. The sending anchor can check which fields need to be updated by making a `GET /customer` request including the `id` or `account` & `memo` parameters. The receiving anchor should respond with a `NEEDS_INFO` status and `last_name` included in the fields described.
+In certain cases the Receiving Anchor might need to request updated information from the Sending Anchor.  For example, if the bank tells the Receiving Anchor that the provided Receiving Client's name is incorrect or missing a middle initial. Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` state until the Sending Anchor makes another `SEP-12 PUT /customer` request to update. The Sending Anchor can check which fields need to be updated by making a `SEP-12 GET /customer` request including the `id` or `account` & `memo` parameters. The Receiving Anchor should respond with a `NEEDS_INFO` status and `last_name` included in the fields described.
 
-#### Pending transaction info update
+#### Pending Transaction Info Update
 
-Another possibility is that the bank tells the receiving anchor that the provided account or routing number is incorrect. Since this information was sent via a `POST /transactions` request, the transaction should go into the `pending_transaction_info_update` state until the sender makes a request to the endpoint outlined below. 
+Another possibility is that the per-transaction information provided in the `POST /transactions` `fields` object was later discovered to be invalid. In this case, the transaction should go into the `pending_transaction_info_update` state until the Sending Anchor makes a request to the endpoint outlined below. 
 
-### Update
+### PATCH Transaction
 
-This endpoint should only be used when the receiver requests more info via the `pending_transaction_info_update` status.  The `required_info_updates` transaction field should contain the fields required for the update. If the sender tries to update at a time when no info is requested the receiver should fail with an error response.
+This endpoint should only be used when the Receiver Anchor requests more info via the `pending_transaction_info_update` status.  The `required_info_updates` transaction field should contain the fields required for the update. If the Sending Anchor tries to update at a time when no info is requested, the Receiver Anchor should fail with an error response.
 
 ```
 PATCH DIRECT_PAYMENT_SERVER/transactions/:id
@@ -427,7 +429,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `id` | string | The id of the transaction.
-`fields` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as [`/transactions`](#transactions).
+`fields` | object | A key-pair object containing the values requested to be updated by the receiving anchor in the same format as `fields` in the [`POST /transactions`](#post-transactions) request.
 
 #### Example
 
@@ -446,7 +448,7 @@ PATCH DIRECT_PAYMENT_SERVER/transactions/82fhs729f63dh0v4
 
 #### Success 200 OK
 
-If the information was successfully updated, respond with a 200 status code, and return the transaction JSON in the body. The transaction should return to `pending_receiver`, though it is possible that the information could still need to be updated again.
+If the information was successfully updated, respond with a 200 status code, and return a response body matching `GET /transactions/:id`. The transaction should return to `pending_receiver`, though it is possible that the information could still need to be updated again.
 
 #### Not Found 404
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Direct Payments
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2020-12-15
-Version 1.2.0
+Updated: 2021-04-20
+Version 1.2.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -20,8 +20,8 @@ This SEP defines a protocol for enabling payments between two financial accounts
 The entities involved in a transaction are:
 
 - A **Sending Client**: The owner of the origin financial account.
-- A **Sending Anchor**: The business offering outbound payment services, who must have a business relationship with the Receiving Anchor.
-- A **Receiving Anchor**: The business offering inbound payment processing.
+- A **Sending Anchor**: The business receiving funds from the Sending Client and delivering them to the Receiving Anchor for the Receiving Client. Must have a business relationship with the Receiving Anchor.
+- A **Receiving Anchor**: The business receiving funds from the Sending Anchor and delivering them to the Receiving Client.
 - A **Receiving Client**: The owner of the destination financial account.
 
 At a high level, the following steps are performed to complete a transaction:

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -297,7 +297,7 @@ In the case where the Sending Anchor didn't provide all the information requeste
 Name | Type | Description
 -----|------|------------
 `error`| string | `transaction_info_needed`
-`fields` | object | A key-value pair of missing fields in the same format as fields described in [`GET /info`](#info).
+`fields` | object | A key-value pair of missing fields in the same format as fields described in [`GET /info`](#get-info).
 
 ##### Error (400 Bad Request)
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -39,7 +39,7 @@ Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with Niger
 ## Prerequisites
 
 * The Receiving Anchor must define `DIRECT_PAYMENT_SERVER` in their [`stellar.toml`](sep-0001.md).
-* The Sending and Receiving Anchors must create bi-lateral agreements to interoperate with each other. This differs from other protocols in that there is no concept of 'discoverability'.
+* The Sending and Receiving Anchors must create bi-lateral agreements to interoperate with each other.
 * If the Receiving Anchor requires KYC information for the Sending or Receiving Clients, the Receiving Anchor must implement [SEP-12](sep-0012.md) and define a `KYC_SERVER` in their [stellar.toml](sep-0001.md).
 
 ## Authentication

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -39,7 +39,7 @@ Alice in Nigeria wants to send money to Bob in Europe. Alice signs up with Niger
 ## Prerequisites
 
 * The Receiving Anchor must define `DIRECT_PAYMENT_SERVER` in their [`stellar.toml`](sep-0001.md).
-* The Sending and Reciving Anchors must create bi-lateral agreements to interoperate with each other. This differs from other protocols in that there is no concept of 'discoverability'.
+* The Sending and Receiving Anchors must create bi-lateral agreements to interoperate with each other. This differs from other protocols in that there is no concept of 'discoverability'.
 * If the Receiving Anchor requires KYC information for the Sending or Receiving Clients, the Receiving Anchor must implement [SEP-12](sep-0012.md) and define a `KYC_SERVER` in their [stellar.toml](sep-0001.md).
 
 ## Authentication


### PR DESCRIPTION
While working on a change to SEP-31, I noticed how many grammar & punctuation mistakes there were, as well as how information could be better presented. This is a low-priority PR but would be nice to get merged.