### PR TITLE
SEP-1: Add ORG_SUPPORT_EMAIL, updated definition of ORG_OFFICIAL_EMAIL

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -6,8 +6,8 @@ Title: stellar.toml
 Author: stellar.org
 Status: Active
 Created: 2017-10-30
-Updated: 2021-03-05
-Version: 2.2.1
+Updated: 2021-04-20
+Version: 2.3.0
 ```
 
 ## Simple Summary
@@ -80,7 +80,8 @@ ORG_PHONE_NUMBER_ATTESTATION | `https://` url | URL on the same domain as your `
 ORG_KEYBASE | string | A [Keybase](https://keybase.io/) account name for your organization. Should contain proof of ownership of any public online accounts you list here, including your organization's domain.
 ORG_TWITTER | string | Your organization's Twitter account
 ORG_GITHUB | string | Your organization's Github account
-ORG_OFFICIAL_EMAIL | string | An email where clients can contact your organization. Must be hosted at your `ORG_URL` domain.
+ORG_OFFICIAL_EMAIL | string | An email that business partners such as wallets, exchanges, or anchors can use to contact your organization. Must be hosted at your `ORG_URL` domain.
+ORG_SUPPORT_EMAIL | string | An email that users can use to request support regarding your Stellar assets or applications.
 ORG_LICENSING_AUTHORITY | string | Name of the authority or agency that issued a license, registration, or authorization to your organization, if applicable
 ORG_LICENSE_TYPE | string | Type of financial or other license, registration, or authorization your organization holds, if applicable
 ORG_LICENSE_NUMBER | string | Official license, registration, or authorization number of your organization, if applicable


### PR DESCRIPTION
resolves #903 

Adds an explicit support email attribute to the organization fields for SEP-1, and redefines the `ORG_OFFICIAL_EMAIL` to be for business inquiries.