### PR TITLE
Updating SEP-6 title for clarity and usability

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0006
-Title: Anchor/Client interoperability
+Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-03-22
-Version 3.5.0
+Updated: 2021-05-17
+Version 3.5.1
 ```
 
 ## Simple Summary


### PR DESCRIPTION
**Context**
As part of an ongoing effort to improve the usability of our protocols, in Q1 of 2021 SDF held an internal review of several SEP titles with the goal of choosing usable, descriptive names. 

Our protocols have developed over many years and as they and the ecosystem have grown, the names that they were originally given have sometimes become less meaningful. We’ve found ourselves often referring to a protocol by its number instead of its title, which can be confusing for new members as it abstracts the meaning of the SEP in discussion. While we’ll continue to use the SEP-# namespace in technical discussions and in order to maintain searchability, this step towards plain language names will hopefully encourage their usage in addition to the numeric shorthand.

**Before: Anchor/Client interoperability
After: Deposit and Withdrawal API**
The naming considerations of SEP-6 were strongly tied to that of SEP-24, as they’re similar protocols with one major difference: where the collection of KYC occurs. 

Other names considered were Programmatic Asset Transfer, Anchor Facilitated Deposit and Withdrawal API, Anchor/Wallet Interoperability, and Fiat On/Off Ramp. However, asset transfer doesn’t distinguish this protocol from cross-border payments, and while fiat is often used when referring to this protocol, discussion resolved that it’s too restrictive as it means government-issued currency and excludes cryptocurrency. Finally, "programmatic" and "interactive" as differentiators were deemed not broad enough.

Deposit and Withdrawal API distinguishes SEP-6 from SEP-24 (proposed new title: Hosted Deposit and Withdrawal) by indicating that the client (wallet) submits KYC via API, as opposed to the server (anchor) hosting the collection.