### PR TITLE
Updating SEP-9 title for clarity and usability

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0009
-Title: Standard KYC / AML fields
+Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27


### PR DESCRIPTION
**Context**
As part of an ongoing effort to improve the usability of our protocols, in Q1 of 2021 SDF held an internal review of several SEP titles with the goal of choosing usable, descriptive names. 

Our protocols have developed over many years and as they and the ecosystem have grown, the names that they were originally given have sometimes become less meaningful. We’ve found ourselves often referring to a protocol by its number instead of its title, which can be confusing for new members as it abstracts the meaning of the SEP in discussion. While we’ll continue to use the SEP-# namespace in technical discussions and in order to maintain searchability, this step towards plain language names will hopefully encourage their usage in addition to the numeric shorthand.

**Before: Standard KYC / AML fields
After: Standard KYC Fields**
This title changes only slightly in that “AML” will be removed, as Anti Money Laundering (AML) is only one of many reasons KYC is collected. 

Other names considered were KYC Data and Know Your Customer (KYC) Data. Including KYB was also considered, but KYC was identified as the most broadly used terminology. It was noted that in the future there may be a broader user for this info, in which case referring to the user as a customer would no longer be correct, but it was agreed the title could easily be revisited at that time. Additionally, the use of “Standards” was questioned, but as these are in fact SDF’s requirements and not determined by the companies using them it was deemed valid to refer to them as standards.