### PR TITLE
Updating SEP-10 title for clarity and usability

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0010
-Title: Stellar Web Authentication
+Title: Stellar Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31


### PR DESCRIPTION
**Context**
As part of an ongoing effort to improve the usability of our protocols, in Q1 of 2021 SDF held an internal review of several SEP titles with the goal of choosing usable, descriptive names. 

Our protocols have developed over many years and as they and the ecosystem have grown, the names that they were originally given have sometimes become less meaningful. We’ve found ourselves often referring to a protocol by its number instead of its title, which can be confusing for new members as it abstracts the meaning of the SEP in discussion. While we’ll continue to use the SEP-# namespace in technical discussions and in order to maintain searchability, this step towards plain language names will hopefully encourage their usage in addition to the numeric shorthand.

**Before: Stellar Web Authentication
After: Stellar Authentication**
 This title would change only slightly, removing the “Web” as it’s superfluous since all authorization of this type occurs on the web. SEP-10 wasn’t in the original list of SEPs being considered until discussion moved towards supporting shorter titles that increased usability. 

Another name considered was StellarAuth. However, that’s also the name of a Stellar 2FA system, and the full “Authentication” was chosen in order to differentiate. However, it’s likely it will still be shortened colloquially in the same vein as OAuth.