### PR TITLE
SEP-38: add a GET /quote endpoint

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,8 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
+Updated: 2021-04-28
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.0.0
+Version 1.1.0
 ```
 
 ## Summary

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -213,7 +213,7 @@ Name | Type | Description
 
 ### GET Quote
 
-This endpoint can be used to fetch a previously-provided firm quote. Expired quotes should still be retrievable using this endpoint.
+This endpoint can be used to fetch a previously-provided firm quote. Quotes referenced in other protocols must be available at this endpoint past the `expires_at` expiration for the quote.
 
 #### Request
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -90,6 +90,7 @@ The [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-character
 * [`GET /prices`](#get-prices)
 * [`GET /price`](#get-price)
 * [`POST /quote`](#post-quote)
+* [`GET /quote/:id`](#get-quote)
 
 ### GET Info
 
@@ -208,3 +209,26 @@ Name | Type | Description
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
 `buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * sell_amount = buy_amount` must be true up to the number of decimals required for `buy_asset`.
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
+
+### GET Quote
+
+This endpoint can be used to fetch a previously-provided firm quote.
+
+#### Request
+
+Name | Type | Description
+-----|------|------------
+`id` | string | The unique identifier for the quote. Same as the `id` returned in the [`POST /quote`](#post-quote) response.
+
+#### Response
+
+This response body should match the response from [POST /quote](#post-quote).
+
+Name | Type | Description
+-----|------|------------
+`id` | string | The `id` specified in the request.
+`expires_at` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | The date and time by which the anchor must receive funds from the client.
+`price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
+`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * sell_amount = buy_amount` must be true up to the number of decimals required for `buy_asset`.
+`sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
+

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -213,7 +213,7 @@ Name | Type | Description
 
 ### GET Quote
 
-This endpoint can be used to fetch a previously-provided firm quote.
+This endpoint can be used to fetch a previously-provided firm quote. Expired quotes should still be retrievable using this endpoint.
 
 #### Request
 


### PR DESCRIPTION
In the original PR for creating this protocol, we opted to not add a `GET /quote/:id` endpoint with the rationale that the client could store previously provided quotes in their own persistent storage.

However, this assumption places an unnecessary requirement on client-side implementations. It also means that a user would only be able to fetch quote details from the application used to originally request the quote.