### PR TITLE
SEP-1: add ANCHOR_QUOTE_SERVER to specification

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -7,7 +7,7 @@ Author: stellar.org
 Status: Active
 Created: 2017-10-30
 Updated: 2021-04-29
-Version: 2.3.1
+Version: 2.4.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -6,8 +6,8 @@ Title: stellar.toml
 Author: stellar.org
 Status: Active
 Created: 2017-10-30
-Updated: 2021-04-20
-Version: 2.3.0
+Updated: 2021-04-29
+Version: 2.3.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -61,6 +61,7 @@ HORIZON_URL | url | Location of public-facing Horizon instance (if you offer one
 ACCOUNTS | list of `G...` strings | A list of Stellar accounts that are controlled by this domain 
 URI_REQUEST_SIGNING_KEY | Stellar public key | The signing key is used for [SEP-7](sep-0007.md) delegated signing
 DIRECT_PAYMENT_SERVER | uses `https://` |  The server used for receiving [SEP-31](sep-0031.md) direct fiat-to-fiat payments. Requires [SEP-12](sep-0012.md) and hence a `KYC_SERVER` TOML attribute.
+ANCHOR_QUOTE_SERVER | uses `https://` | The server used for receiving [SEP-38](sep-0038.md) requests.
 
 ### Organization Documentation
 


### PR DESCRIPTION
Adds a stellar.toml attribute for SEP-38. Another possible name is `ANCHOR_RFQ_SERVER`. `ANCHOR` is an important word to include because it differentiates the protocol from a potential future SEP that supports exchange of on-chain assets.