### PR TITLE
SEP-38: Add request examples

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,9 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-04-28
+Updated: 2021-04-30
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.1.0
+Version 1.1.1
 ```
 
 ## Summary

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -133,10 +133,11 @@ Name | Type | Description
 `name` | string | The value to use when making `POST /quote` requests.
 `description` | string | A human readable description of the method identified by `name`.
 
-##### Examples
+##### Example
 
-```
-GET /info
+`GET /info`
+
+```json
 
 {
   "assets":  [
@@ -193,9 +194,12 @@ Name | Type | Description
 
 ##### Examples
 
+
 ```
 GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+```
 
+```json
 {
   "buy_assets": [
     {
@@ -206,10 +210,12 @@ GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAP
   ]
 }
 ```
-
+---
 ```
 GET /prices?sell_asset=iso4217:BRL
+```
 
+```json
 {
   "buy_assets": [
     {
@@ -248,6 +254,9 @@ Name | Type | Description
 
 ```
 GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+```
+
+```json
 
 {
   "price": "5.42",
@@ -255,9 +264,12 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
   "buy_amount": "92.25"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+```
+
+```json
 
 {
   "price": "5.42",
@@ -265,9 +277,12 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
   "buy_amount": "100"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+```
+
+```json
 
 {
   "price": "0.18",
@@ -275,10 +290,12 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
   "buy_amount": "555.56"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+```
 
+```json
 {
   "price": "0.18",
   "sell_amount": "90",
@@ -355,7 +372,9 @@ Name | Type | Description
 
 ```
 GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+```
 
+```json
 {
   "id": "de762cda-a193-4961-861e-57b31fed6eb3",
   "expires_at": "2021-04-30T07:42:23",
@@ -364,9 +383,12 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
   "buy_amount": "92.25"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+```
+
+```json
 
 {
   "id": "de762cda-a193-4961-861e-57b31fed6eb3",
@@ -376,9 +398,12 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
   "buy_amount": "100"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+```
+
+```json
 
 {
   "id": "de762cda-a193-4961-861e-57b31fed6eb3",
@@ -388,9 +413,12 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
   "buy_amount": "555.56"
 }
 ```
-
+---
 ```
 GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+```
+
+```json
 
 {
   "id": "de762cda-a193-4961-861e-57b31fed6eb3",

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -85,6 +85,18 @@ The [SEP-11](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/s
 
 The [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) three-character currency code for the fiat currency.
 
+For example, Stellar USDC would be identified as:
+
+```
+stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+```
+
+Fiat USD would be identified as:
+
+```
+iso4217:USD
+```
+
 ### Endpoints
 
 * [`GET /info`](#get-info)
@@ -100,6 +112,12 @@ This endpoint describes the supported Stellar assets and off-chain assets availa
 #### Request
 
 No request arguments required.
+
+##### Examples
+
+```
+GET /info
+```
 
 #### Response
 
@@ -121,6 +139,38 @@ Name | Type | Description
 `name` | string | The value to use when making `POST /quote` requests.
 `description` | string | A human readable description of the method identified by `name`.
 
+##### Examples
+
+```json
+{
+  "assets":  [
+    {
+      "asset": "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+    },
+    {
+      "asset": "stellar:BRL:GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP"
+    },
+    {
+      "asset": "iso4217:BRL",
+      "delivery_methods": [
+        {
+          "name": "cash",
+          "description": "Pick up cash BRL at one of our payout locations."
+        },
+        {
+          "name": "ACH",
+          "description": "Have BRL sent directly to your bank account."
+        },
+        {
+          "name": "PIX",
+          "description": "Have BRL sent directly to the account of your choice."
+        }
+      ]
+    }
+  ]
+}
+```
+
 ### GET Prices
 
 This endpoint can be used to fetch the [indicative](https://www.investopedia.com/terms/i/indicativequote.asp) prices of available off-chain assets in exchange for a Stellar asset and vice versa.
@@ -130,6 +180,16 @@ This endpoint can be used to fetch the [indicative](https://www.investopedia.com
 Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
+
+##### Examples
+
+```
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+```
+
+```
+GET /prices?sell_asset=iso4217:BRL
+```
 
 #### Response
 
@@ -144,6 +204,32 @@ Name | Type | Description
 `asset` | string | The [Asset Identification Format](#asset-identification-format) value.
 `price` | string | The price offered by the anchor for one unit of `asset` in terms of `sell_asset`. In traditional finance, `asset` would be referred to as the base asset and `sell_asset` as the counter asset.
 `decimals` | integer | The number of decimals needed to represent `asset`.
+
+##### Examples
+
+```json
+{
+  "buy_assets": [
+    {
+      "asset": "iso4217:BRL",
+      "price": "0.18",
+      "decimals": 2
+    }
+  ]
+}
+```
+
+```json
+{
+  "buy_assets": [
+    {
+      "asset": "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      "price": "5.42",
+      "decimals": 7
+    }
+  ]
+}
+```
 
 ### GET Price
 
@@ -160,6 +246,24 @@ Name | Type | Description
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
 
+##### Examples
+
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+```
+
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+```
+
 #### Response
 
 Name | Type | Description
@@ -167,6 +271,24 @@ Name | Type | Description
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
 `sell_amount` | string | The amount of `sell_asset` the anchor would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the anchor would provide with `sell_asset`.
+
+##### Examples
+
+```json
+{
+  "price": "5.42",
+  "sell_amount": 542,
+  "buy_amount": 100
+}
+```
+
+```json
+{
+  "price": "0.18",
+  "sell_amount": 90,
+  "buy_amount": 500
+}
+```
 
 ### POST Quote
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -113,12 +113,6 @@ This endpoint describes the supported Stellar assets and off-chain assets availa
 
 No request arguments required.
 
-##### Examples
-
-```
-GET /info
-```
-
 #### Response
 
 Name | Type | Description
@@ -141,7 +135,9 @@ Name | Type | Description
 
 ##### Examples
 
-```json
+```
+GET /info
+
 {
   "assets":  [
     {
@@ -181,16 +177,6 @@ Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 
-##### Examples
-
-```
-GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
-```
-
-```
-GET /prices?sell_asset=iso4217:BRL
-```
-
 #### Response
 
 Name | Type | Description
@@ -207,7 +193,9 @@ Name | Type | Description
 
 ##### Examples
 
-```json
+```
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+
 {
   "buy_assets": [
     {
@@ -219,7 +207,9 @@ Name | Type | Description
 }
 ```
 
-```json
+```
+GET /prices?sell_asset=iso4217:BRL
+
 {
   "buy_assets": [
     {
@@ -246,24 +236,6 @@ Name | Type | Description
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
 
-##### Examples
-
-```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
-```
-
-```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
-```
-
-```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
-```
-
-```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
-```
-
 #### Response
 
 Name | Type | Description
@@ -274,19 +246,43 @@ Name | Type | Description
 
 ##### Examples
 
-```json
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+
 {
   "price": "5.42",
-  "sell_amount": 542,
-  "buy_amount": 100
+  "sell_amount": "500",
+  "buy_amount": "92.25"
 }
 ```
 
-```json
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+
+{
+  "price": "5.42",
+  "sell_amount": "542",
+  "buy_amount": "100"
+}
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+
 {
   "price": "0.18",
-  "sell_amount": 90,
-  "buy_amount": 500
+  "sell_amount": "100",
+  "buy_amount": "555.56"
+}
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+
+{
+  "price": "0.18",
+  "sell_amount": "90",
+  "buy_amount": "500"
 }
 ```
 
@@ -330,7 +326,7 @@ Name | Type | Description
 `id` | string | The unique identifier for the quote to be used in other Stellar Ecosystem Proposals (SEPs).
 `expires_at` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | The date and time by which the anchor must receive funds from the client.
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
-`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * sell_amount = buy_amount` must be true up to the number of decimals required for `buy_asset`.
+`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
 
 ### GET Quote
@@ -352,6 +348,55 @@ Name | Type | Description
 `id` | string | The `id` specified in the request.
 `expires_at` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | The date and time by which the anchor must receive funds from the client.
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
-`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * sell_amount = buy_amount` must be true up to the number of decimals required for `buy_asset`.
+`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
 
+##### Examples
+
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+
+{
+  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
+  "expires_at": "2021-04-30T07:42:23",
+  "price": "5.42",
+  "sell_amount": "500",
+  "buy_amount": "92.25"
+}
+```
+
+```
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+
+{
+  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
+  "expires_at": "2021-04-30T07:42:23",
+  "price": "5.42",
+  "sell_amount": "542",
+  "buy_amount": "100"
+}
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+
+{
+  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
+  "expires_at": "2021-04-30T07:42:23",
+  "price": "0.18",
+  "sell_amount": "100",
+  "buy_amount": "555.56"
+}
+```
+
+```
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+
+{
+  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
+  "expires_at": "2021-04-30T07:42:23",
+  "price": "0.18",
+  "sell_amount": "90",
+  "buy_amount": "500"
+}
+```


### PR DESCRIPTION
I thought it would be helpful to include examples of the requests and responses for each endpoint, similar to what we have in SEP-31. 

In the process of writing these, I realized that the formula described in the `buy_amount` attribute description was incorrect based on the definition of `price` we've defined. I updated the patch version, but I could see an argument for a minor version increment.