### PR TITLE
CAP-0038 - Auth related updates

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -56,11 +56,10 @@ exchanging assets with the order book and liquidity pools.
 ## Specification
 
 ### XDR changes
-This patch of XDR changes is based on the XDR files in commit (`8e3ee53ff07e7e02c0d82c5c731bbe37f0467268`) of stellar-core.
-
+This patch of XDR changes is based on the XDR files in commit (`afb2dca9e112c79547e5125c1e45a8e94c9b965b`) of stellar-core.
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 0e7bc842..73a17001 100644
+index 0e7bc842b..73a170019 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -25,7 +25,8 @@ enum AssetType
@@ -244,7 +243,7 @@ index 0e7bc842..73a17001 100644
  
  // list of all envelope types used in the application
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 75f39eb4..38453ae4 100644
+index 75f39eb4e..6c25f6fbe 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -49,7 +49,9 @@ enum OperationType
@@ -262,7 +261,7 @@ index 75f39eb4..38453ae4 100644
      Signer* signer;
  };
  
-+union ExpandedTrustLineAsset switch (AssetType type)
++union ChangeTrustAsset switch (AssetType type)
 +{
 +case ASSET_TYPE_NATIVE: // Not credit
 +    void;
@@ -287,7 +286,7 @@ index 75f39eb4..38453ae4 100644
  struct ChangeTrustOp
  {
 -    Asset line;
-+    ExpandedTrustLineAsset line;
++    ChangeTrustAsset line;
  
      // if limit is set to 0, deletes the trust line
      int64 limit;
@@ -296,7 +295,7 @@ index 75f39eb4..38453ae4 100644
  {
      AccountID trustor;
 -    Asset asset;
-+    ExpandedTrustLineAsset asset;
++    TrustLineAsset asset;
  
      uint32 clearFlags; // which flags to clear
      uint32 setFlags;   // which flags to set
@@ -428,7 +427,17 @@ index 75f39eb4..38453ae4 100644
          SimplePaymentResult last;
      } success;
  case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
-@@ -1229,6 +1330,61 @@ default:
+@@ -1218,7 +1319,8 @@ enum SetTrustLineFlagsResultCode
+     SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+     SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+     SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+-    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
++    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
++    SET_TRUST_LINE_FLAGS_NOT_ISSUER = -5
+ };
+ 
+ union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+@@ -1229,6 +1331,59 @@ default:
      void;
  };
  
@@ -470,11 +479,9 @@ index 75f39eb4..38453ae4 100644
 +    LIQUIDITY_POOL_WITHDRAW_MALFORMED = -1,      // bad input
 +    LIQUIDITY_POOL_WITHDRAW_NO_TRUST = -2,       // no trust line for one of the
 +                                                 // assets
-+    LIQUIDITY_POOL_WITHDRAW_NOT_AUTHORIZED = -3, // not authorized for one of
-+                                                 // the assets
-+    LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -4,    // not enough balance of the
++    LIQUIDITY_POOL_WITHDRAW_UNDERFUNDED = -3,    // not enough balance of the
 +                                                 // pool share
-+    LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -5       // would go above limit for one
++    LIQUIDITY_POOL_WITHDRAW_LINE_FULL = -4       // would go above limit for one
 +                                                 // of the assets
 +};
 +
@@ -490,7 +497,7 @@ index 75f39eb4..38453ae4 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1291,6 +1447,10 @@ case opINNER:
+@@ -1291,6 +1446,10 @@ case opINNER:
          ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
      case SET_TRUST_LINE_FLAGS:
          SetTrustLineFlagsResult setTrustLineFlagsResult;
@@ -536,6 +543,11 @@ if !authorized(tlA) || !authorized(tlB) || !authorized(tlPool)
 
 issuerA = loadAccount(cp.assetA.issuer)
 issuerB = loadAccount(cp.assetB.issuer)
+
+
+// bool poolEnabled(issuer):
+//     return issuer.flags & AUTH_LIQUIDITY_POOL_ENABLED_FLAG != 0
+
 if !issuerA || !poolEnabled(issuerA) || !issuerB || !poolEnabled(issuerB)
     Fail with LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED
 
@@ -608,8 +620,6 @@ tlA = loadTrustLine(sourceAccount, cp.assetA)
 tlB = loadTrustLine(sourceAccount, cp.assetB)
 if !exists(tlA) || !exists(tlB)
     Fail with LIQUIDITY_POOL_WITHDRAW_NO_TRUST
-if !authorized(tlA) || !authorized(tlB) || !authorized(tlPool)
-    Fail with LIQUIDITY_POOL_WITHDRAW_NOT_AUTHORIZED
 
 reserveA = lp.constantProduct().reserveA
 reserveB = lp.constantProduct().reserveB
@@ -661,9 +671,6 @@ decremented on the corresponding liquidity pool.
 liquidity pool is erased.
 
 #### SetTrustLineFlagsOp
-`SetTrustLineFlagsOp` is the only way for an issuer to redeem it's assets from a Liquidity
-Pool back to the owner, or a claimable balance for the owner to claim.
-
 The validity conditions for `SetTrustLineFlagsOp` are unchanged if
 `asset.type() != ASSET_TYPE_POOL_SHARE`. `SetTrustLineFlagsOp` is additionally invalid
 if `asset.type() == ASSET_TYPE_POOL_SHARE` and
@@ -679,20 +686,22 @@ The behavior of `SetTrustLineFlagsOp` is unchanged if
 `asset.type() == ASSET_TYPE_POOL_SHARE` then
 
 ```
-poolID = SHA256(asset.liquidityPool)
-tlPool = loadTrustLine(sourceAccount, poolID)
+tlPool = loadTrustLine(sourceAccount, asset.liquidityPoolID)
 if !exists(tlPool)
     Fail with SET_TRUST_LINE_FLAGS_NO_TRUST_LINE
 
 // Note that the issuer account must have AUTH_REVOCABLE set to get here
 if (tlPool.flag & AUTHORIZED_FLAG == AUTHORIZED_FLAG) && (clearFlags & AUTHORIZED_FLAG == AUTHORIZED_FLAG)
-    lp = loadLiquidityPool(poolID)
+    lp = loadLiquidityPool(asset.liquidityPoolID)
+
+    if sourceAccount != lp.constantProduct().assetA.issuer && sourceAccount != lp.constantProduct().assetB.issuer
+        Fail with SET_TRUST_LINE_FLAGS_NOT_ISSUER
 
     //redeem tlPool's pool shares from lp using the logic from LiquidityPoolWithdrawOp
     //the code below should run for each asset in the pool
     //lets say amountA is the amount that needs to be sent back
 
-    tlA = loadTrustLine(trustor, asset.liquidityPool().constantProduct().assetA)
+    tlA = loadTrustLine(trustor, lp.constantProduct().assetA)
     if !tlA || tlA.availableLimit < amountA
         ClaimableBalance cb
         cb.amount = amountA
@@ -702,7 +711,7 @@ if (tlPool.flag & AUTHORIZED_FLAG == AUTHORIZED_FLAG) && (clearFlags & AUTHORIZE
             if isClawbackEnabledOnTrustline(tl)
                 cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
         else
-            issuer = loadAccount(asset.liquidityPool().constantProduct().assetA.issuer)
+            issuer = loadAccount(lp.constantProduct().assetA.issuer)
             if issuer && isClawbackEnabledOnAccount(issuer)
                 cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
         
@@ -711,6 +720,11 @@ if (tlPool.flag & AUTHORIZED_FLAG == AUTHORIZED_FLAG) && (clearFlags & AUTHORIZE
         tlA.balance += amountA
 
 ```
+
+#### SetOptionsOp
+The new `AUTH_LIQUIDITY_POOL_ENABLED_FLAG` can be set and cleared using `SetOptionsOp`.
+If `AUTH_IMMUTABLE_FLAG` is already set on the account, then `SET_OPTIONS_CANT_CHANGE`
+will be returned if `AUTH_LIQUIDITY_POOL_ENABLED_FLAG` is set or cleared.
 
 #### PathPaymentStrictSendOp and PathPaymentStrictReceiveOp
 For each step in the path, the exchange will be routed to the order book or
@@ -890,11 +904,12 @@ by putting this flag in the trust line is that `LiquidityPoolDepositOp` will not
 dependency on the issuer account. This dependency isn't an issue, so we don't
 think it's necessary to add a new trust line flag.
 
-### AUTH_LIQUIDITY_POOL_ENABLED_FLAG only affects deposits
-`AUTH_LIQUIDITY_POOL_ENABLED_FLAG` will only prevent deposits, not withdrawals. Issuers
-can choose to stop allowing their assets into pools, but they may still want to allow
-trust lines to withdraw those assets. If the issuer wanted to lock the funds of a trust line
-in a pool, they could just deauthorize the asset trust line.
+### Pool withdrawals are not subject to authorization checks
+It would be unfair to lock an accounts funds in a Liquidity Pool when they no longer
+want to be a part of one. It's currently possible for an account to pull offers 
+regardless of their authorization state, so it makes sense to treat pool shares the same.
+A deauthorized account can withdraw from a pool, but will not be able to do anything else with
+those funds since operations like payments check authorization.
 
 ### Clawback assets from a pool
 There are no operations that clawback directly from a pool, but the same results can 


### PR DESCRIPTION
1. Removes auth check from `LiquidityPoolWithdrawOp`.
2. Use `TrustLineAsset` in `SetTrustlineFlagsOp.
3. Add some minor details.