### PR TITLE
CAP: Add examples of how to generate and apply diffs of xdr files

### DIFF
--- a/cap-template.md
+++ b/cap-template.md
@@ -76,7 +76,13 @@ The technical specification should describe the syntax and semantics of any new 
 ### XDR changes
 This section includes all changes to the XDR (`.x` files), presented as a "diff"
 against the latest version of the protocol (or in some rare exception,
-on top of a different CAP).
+on top of a different CAP). Diffs should be generated against on the XDR in the
+[stellar-core repository].
+
+To generate diffs, use the `git diff` command.
+
+To apply diffs, use the `git apply --reject --whitespace=fix` command.
+
 For large changes, it may be beneficial to link to actual XDR files copied
 in the relevant "contents" folder.
 
@@ -126,3 +132,5 @@ The implementation(s) must be completed before any CAP is given "Final" status, 
 completed before the CAP is accepted. While there is merit to the approach of reaching consensus on
 the specification and rationale before writing code, the principle of "rough consensus and running
 code" is still useful when it comes to resolving many discussions of API details.
+
+[stellar-core repository]: https://github.com/stellar/stellar-core


### PR DESCRIPTION
### What
Add examples of how to generate and apply diffs in XDR files in CAPs.

### Why
Generating a diff is relatively self-explanatory and simple, but it is worth calling out to people we expect them to just use a git diff and not to generate an entire patch containing commits.

Applying a diff is relatively painful, especially for diffs that have been pasted into markdown files. Diffs in markdown files will almost always have whitespace inconsistencies that will cause the naked git apply command to error. It is capable of overlooking or fixing most whitespace errors and for folks who are unfamiliar with git apply the reject command is more useful because if there are conflicts it will leave the local space in a state that can be manually repaired.

This might be too prescriptive for folks who have their own workflows, but anyone who has their own workflow that differs from this basic workflow probably doesn't need to reference these commands, as long as the diffs they generate can be applied in this manner.