### PR TITLE
CAP-21: Add seqSuccess

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -489,7 +489,7 @@ to correct an abnormal situation (e.g., one end of a payment channel
 failing, or an account owner losing the key) and so don't actually get
 submitted in the common case.
 
-An earlier version of the proposal did not contain the `seqSuccess
+An earlier version of the proposal did not contain the `seqSuccess`
 field either.  However, payment channels and contracts inadvertently
 need to handle transaction sequences where when transactions fail,
 only one path is possible ideally without executing another

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -92,6 +92,10 @@ struct AccountEntryExtensionV3
 
     // Time at which `seqNum` took on its present value.
     TimePoint seqTime;
+
+    // Result of transaction that caused `seqNum` to take on its present value.
+    // True if the transaction result was txSUCCESS or txFEE_BUMP_INNER_SUCCESS.
+    bool seqSuccess;
 };
 
 struct AccountEntry
@@ -136,10 +140,13 @@ after executing a transaction, `sourceAccount`'s sequence number is
 always set to the transaction's `seqNum`--like an implicit
 `BUMP_SEQUENCE` operation.  This guarantees transactions cannot be
 replayed, even when the previous account `seqNum` is well below the
-transaction's `seqNum`.  The final element of `Preconditions` is an
-array of extra signers required for the transaction.  This can be used
-with `SIGNER_KEY_TYPE_HASH_X` to sign a transaction that can only be
-executed in exchange for disclosing a hash preimage.
+transaction's `seqNum`.  The `seqSuccess` element preconditions the
+transaction on whether the `sourceAccount`'s sequence number was set
+from a successful or failed transaction. The final element of
+`Preconditions` is an array of extra signers required for the
+transaction.  This can be used with `SIGNER_KEY_TYPE_HASH_X` to sign a
+transaction that can only be executed in exchange for disclosing a
+hash preimage.
 
 ```c++
 typedef int64 TimePoint;
@@ -173,6 +180,10 @@ struct GeneralPreconditions {
     // must be at least minSeqLedgerGap greater than sourceAccount's
     // seqLedger.
     uint32 minSeqLedgerGap;
+
+    // For the transaction to be valid, must be NULL, or must be equal to
+    // sourceAccount's seqSuccess.
+    bool *seqSuccess;
 
     // For the transaction to be valid, there must be a signature
     // corresponding to every Signer in this array, even if the
@@ -289,7 +300,7 @@ the same block.
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 26ff33d43..d96f55ea6 100644
+index 0e7bc842..7046a264 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -12,7 +12,8 @@ typedef opaque Thresholds[4];
@@ -302,7 +313,7 @@ index 26ff33d43..d96f55ea6 100644
  typedef opaque DataValue<64>;
  
  // 1-4 alphanumeric characters right-padded with 0 bytes
-@@ -126,6 +127,24 @@ const MAX_SIGNERS = 20;
+@@ -126,6 +127,28 @@ const MAX_SIGNERS = 20;
  
  typedef AccountID* SponsorshipDescriptor;
  
@@ -322,12 +333,16 @@ index 26ff33d43..d96f55ea6 100644
 +
 +    // Time at which `seqNum` took on its present value.
 +    TimePoint seqTime;
++
++    // For the transaction to be valid, must be NULL, or must be equal to
++    // sourceAccount's seqSuccess.
++    bool *seqSuccess;
 +};
 +
  struct AccountEntryExtensionV2
  {
      uint32 numSponsored;
-@@ -187,6 +206,8 @@ struct AccountEntry
+@@ -187,6 +210,8 @@ struct AccountEntry
          void;
      case 1:
          AccountEntryExtensionV1 v1;
@@ -336,7 +351,7 @@ index 26ff33d43..d96f55ea6 100644
      }
      ext;
  };
-@@ -325,10 +346,10 @@ case CLAIM_PREDICATE_OR:
+@@ -325,10 +350,10 @@ case CLAIM_PREDICATE_OR:
  case CLAIM_PREDICATE_NOT:
      ClaimPredicate* notPredicate;
  case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
@@ -351,10 +366,10 @@ index 26ff33d43..d96f55ea6 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index b2a4f420b..ce933d909 100644
+index 75f39eb4..cb761552 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -507,6 +507,58 @@ struct TimeBounds
+@@ -507,6 +507,62 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -388,6 +403,10 @@ index b2a4f420b..ce933d909 100644
 +    // seqLedger.
 +    uint32 minSeqLedgerGap;
 +
++    // For the transaction to be valid, must be NULL, or must be equal to
++    // sourceAccount's seqSuccess.
++    bool *seqSuccess;
++
 +    // For the transaction to be valid, there must be a signature
 +    // corresponding to every Signer in this array, even if the
 +    // signature is not otherwise required by the sourceAccount or
@@ -413,7 +432,7 @@ index b2a4f420b..ce933d909 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -558,8 +610,8 @@ struct Transaction
+@@ -558,8 +614,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  
@@ -470,6 +489,12 @@ to correct an abnormal situation (e.g., one end of a payment channel
 failing, or an account owner losing the key) and so don't actually get
 submitted in the common case.
 
+An earlier version of the proposal did not contain the `seqSuccess
+field either.  However, payment channels and contracts inadvertently
+need to handle transaction sequences where when transactions fail,
+only one path is possible ideally without executing another
+transaction on-chain.
+
 ### Two-way payment channel
 
 The proposed mechanism can be used to implement a payment channel
@@ -521,11 +546,14 @@ constructed as follows:
 
 For R to top-up or withdraw excess funds from the escrow account E,
 the participants skip a generation.  They set s = 2(i+1), and i = i+2.
-They then exchange C_i and D_i (which unlike the update case, can be
-exchanged in a single phase of communication because D_i is not yet
-executable while E's sequence number is below the new s).  Finally,
-they create a top-up transaction that atomically adjusts E's balance
-and uses `BUMP_SEQUENCE` to increase E's sequence number to s.
+They then exchange two sets of C_i and D_i (which unlike the update
+case, can be exchanged in a single phase of communication because D_i
+is not yet executable while E's sequence number is below the new s).
+One set preserves the existing channel state and is preconditioned on
+`seqSuccess` false. The other preserves the new channel state and is
+preconditioned on `seqSuccess` true.  Finally, they create a top-up
+transaction that atomically adjusts E's balance and uses
+`BUMP_SEQUENCE` to increase E's sequence number to s.
 
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -300,7 +300,7 @@ the same block.
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 0e7bc842..7046a264 100644
+index 0e7bc842..d02b76be 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -12,7 +12,8 @@ typedef opaque Thresholds[4];
@@ -334,8 +334,8 @@ index 0e7bc842..7046a264 100644
 +    // Time at which `seqNum` took on its present value.
 +    TimePoint seqTime;
 +
-+    // For the transaction to be valid, must be NULL, or must be equal to
-+    // sourceAccount's seqSuccess.
++    // Result of transaction that caused `seqNum` to take on its present value.
++    // True if the transaction result was txSUCCESS or txFEE_BUMP_INNER_SUCCESS.
 +    bool *seqSuccess;
 +};
 +


### PR DESCRIPTION
### What
Add a seqSuccess to the account entry extension v3, and corresponding precondition to transaction general preconditions.

### Why
The top-up flow described for two-way payment channels does not handle the case where a top-up fails. In that case the channel will have progressed past the sequence number of the last agreed C/D, but won't progress forward. There needs to be a second set of C/D that preserves the existing state but that would be bumped past if the top-up is successful. Even with this the channel still needs repair at some point if it is to stay open, with a third set of C/D. We can avoid the need to rely on the bump sequences and a third set if we introduce `seqSuccess` since the fork is completely finalized in the top-up's success or failure without need for tidy up on-chain.