### PR TITLE
CAP-21: Add clarification about how deposit failure is handled

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -532,7 +532,8 @@ E.
 If a top-up transaction by R fails, the state of E is unchanged. The
 participants can choose to close the channel with the previous D_i and
 C_i. If they wish to keep the channel open they discard the change to
-s, increment i, and exchange C_i and D_i containing the agreed state.
+s, increment i again, and exchange C_i and D_i containing the agreed
+state.
 
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -525,7 +525,14 @@ They then exchange C_i and D_i (which unlike the update case, can be
 exchanged in a single phase of communication because D_i is not yet
 executable while E's sequence number is below the new s).  Finally,
 they create a top-up transaction that atomically adjusts E's balance
-and uses `BUMP_SEQUENCE` to increase E's sequence number to s.
+and uses `BUMP_SEQUENCE` to increase E's sequence number to s. The
+top-up transaction has a source account set to any account other than
+E.
+
+If a top-up transaction by R fails, the state of E is unchanged. The
+participants can choose to close the channel with the previous D_i and
+C_i. If they wish to keep the channel open they discard the change to
+s, increment i, and exchange C_i and D_i containing the agreed state.
 
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.


### PR DESCRIPTION
### What
Add a note to the two-way payment channel specifically noting that top-up's by the responder must not use the escrow account's source account. Also add notes about how participants can close or progress a channel if a deposit fails.

### Why
The failure case is not discussed. Specifically the source account of the top-up transaction has an impact on the safety of the channel.