### PR TITLE
CAP-21: Add another type of two-way payment channel that uses two escrow accounts

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -567,7 +567,7 @@ constructed as follows:
 * D_i, the _declaration transaction_, declares an intent to execute
   the corresponding closing transaction C_i.  D_i has source account
   EI, sequence number 2i, and `minSeqNum` set to s.  Hence, D_i can
-  execute at any time, so long as E's sequence number n satisfies s <=
+  execute at any time, so long as EI's sequence number n satisfies s <=
   n < 2i.  D_i always leaves EI's sequence number at 2i after
   executing.  Because C_i has source account E and sequence number
   2i+1, D_i leaves EI in a state where C_i can execute.  Note that D_i
@@ -594,7 +594,7 @@ payment into them directly.
 I and R may withdraw excess funds from the escrow accounts by skipping
 a generation. They set s = 2(i+1), and i = i+2. They then exchange C_i
 and D_i (which unlike the update case, can be exchanged in a single
-phase of communication because D_i is not yet executable while E's
+phase of communication because D_i is not yet executable while EI's
 sequence number is below the new s).  Finally, they create a withdraw
 transaction that atomically adjusts EI's and/or ER's balance, as
 required, and uses `BUMP_SEQUENCE` to increase EI's sequence number to

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -569,7 +569,7 @@ constructed as follows:
   EI, sequence number 2i, and `minSeqNum` set to s.  Hence, D_i can
   execute at any time, so long as EI's sequence number n satisfies s <=
   n < 2i.  D_i always leaves EI's sequence number at 2i after
-  executing.  Because C_i has source account E and sequence number
+  executing.  Because C_i has source account EI and sequence number
   2i+1, D_i leaves EI in a state where C_i can execute.  Note that D_i
   does not require any operations, but since Stellar disallows empty
   transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -530,6 +530,79 @@ and uses `BUMP_SEQUENCE` to increase E's sequence number to s.
 To close the channel cooperatively, the parties re-sign C_i with a
 `minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.
 
+### Two-way payment channel supporting uncoordinated deposits
+
+The proposed mechanism can be used to implement a payment channel
+between two parties, an initiator I and a responder R.  The protocol
+assumes some _synchrony period_, S, such that both parties are
+guaranteed to be able to observe the blockchain state and submit
+transactions within any period of length S.
+
+The payment channel consists of two 2-of-2 multisig escrow accounts:
+
+* EI - created and configured by I, holding all amounts contributed by
+  I.
+
+* ER - created and configured by R, holding all amounts contributed by
+  R.
+
+The payment channel updates state using a series of _declaration_ and
+_closing_ transactions with EI as the source account. The two parties
+maintain the following two variables during the lifetime of the
+channel:
+
+* s - the _starting sequence number_, is initialized to one greater
+  than the sequence number of the escrow account EI after EI has been
+  created and configured.  It is increased only when withdrawing.
+
+* i - the _iteration number_ of the payment channel, is initialized to
+  (s/2)+1.  It is incremented with every off-chain update of the
+  payment channel state.
+
+To update the payment channel state, the parties 1) increment i, 2)
+sign and exchange a closing transaction C_i, and finally 3) sign and
+exchange a declaration transaction D_i.  The transactions are
+constructed as follows:
+
+* D_i, the _declaration transaction_, declares an intent to execute
+  the corresponding closing transaction C_i.  D_i has source account
+  EI, sequence number 2i, and `minSeqNum` set to s.  Hence, D_i can
+  execute at any time, so long as E's sequence number n satisfies s <=
+  n < 2i.  D_i always leaves E's sequence number at 2i after
+  executing.  Because C_i has source account E and sequence number
+  2i+1, D_i leaves E in a state where C_i can execute.  Note that D_i
+  does not require any operations, but since Stellar disallows empty
+  transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.
+
+* C_i, the _closing transaction_, disburses funds from EI to ER,
+  and/or from ER to EI such that the balances of the escrow accounts
+  match the final agreed state of the channel at the time C_i is
+  generated. C_i also changes the signing weights on EI and ER such
+  that I unilaterally controls EI and R unilaterally controls ER.  C_i
+  has source account EI, sequence number 2i+1, and a `minSeqAge` of S
+  (the synchrony period).  The `minSeqAge` prevents a misbehaving
+  party from executing C_i when the channel state has already
+  progressed to a later iteration number, as the other party can
+  always invalidate C_i by submitting D_i' for some i' > i.  C_i
+  contains one or more `PAYMENT` operations disbursing funds between
+  escrow accounts, plus `SET_OPTIONS` operations adjusting signing
+  weights of each escrow account.
+
+I and R may top-up their respective escrow accounts by making a
+payment into them directly.
+
+I and R may withdraw excess funds from the escrow accounts by skipping
+a generation. They set s = 2(i+1), and i = i+2. They then exchange C_i
+and D_i (which unlike the update case, can be exchanged in a single
+phase of communication because D_i is not yet executable while E's
+sequence number is below the new s).  Finally, they create a withdraw
+transaction that atomically adjusts EI's and/or ER's balance, as
+required, and uses `BUMP_SEQUENCE` to increase E's sequence number to
+s.
+
+To close the channel cooperatively, the parties re-sign C_i with a
+`minSeqNum` of s and a `minSeqAge` of 0, then submit this transaction.
+
 ### One-way payment channel
 
 A one-way payment channel enables an initiator I to make repeated

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -568,9 +568,9 @@ constructed as follows:
   the corresponding closing transaction C_i.  D_i has source account
   EI, sequence number 2i, and `minSeqNum` set to s.  Hence, D_i can
   execute at any time, so long as E's sequence number n satisfies s <=
-  n < 2i.  D_i always leaves E's sequence number at 2i after
+  n < 2i.  D_i always leaves EI's sequence number at 2i after
   executing.  Because C_i has source account E and sequence number
-  2i+1, D_i leaves E in a state where C_i can execute.  Note that D_i
+  2i+1, D_i leaves EI in a state where C_i can execute.  Note that D_i
   does not require any operations, but since Stellar disallows empty
   transactions, it contains a `BUMP_SEQUENCE` operation as a no-op.
 
@@ -597,7 +597,7 @@ and D_i (which unlike the update case, can be exchanged in a single
 phase of communication because D_i is not yet executable while E's
 sequence number is below the new s).  Finally, they create a withdraw
 transaction that atomically adjusts EI's and/or ER's balance, as
-required, and uses `BUMP_SEQUENCE` to increase E's sequence number to
+required, and uses `BUMP_SEQUENCE` to increase EI's sequence number to
 s.
 
 To close the channel cooperatively, the parties re-sign C_i with a


### PR DESCRIPTION
### What
Add another type of two-way payment channel design to the rationale that uses two escrow accounts and does not use claimable balances.

### Why
I've been expanding on the definition of the existing two-way payment channel in CAP-21, writing out all of the different steps, how fees would work, etc. The full write up I've done is here:
https://github.com/stellar/experimental-payment-channels/pull/3

After doing the write up I'm reasonably certain that even though on the surface it appears that a single escrow account is required, two 2-of-2 multisig accounts would likely be necessary in a real product. I think it will be required because claimable balances require a sponsor, and the sponsor is bound to them and can't be merged until they are claimed. To keep claimable balance sponsorship from binding the initiator and responder together after the channel closes a second reserve account would be required to sponsor the claimable balances safely. See the full write up in the PR above for how it would work and why.

If a two-way payment channel is likely to have two 2-of-2 multisig accounts, then we may as well construct the channel to make the most of those two accounts. If we use two accounts to hold I and R's contributions both parties can deposit without coordination. The channel is still not symmetric because I's escrow account EI is the account providing sequence numbers, but I don't think this is a big deal.

As an extra bonus, channel close does not create any ledger entries, which means the channel never has to deal with the oddities of claimable balances and the oddities of ledger entry creation which can fail because of sponsorship low reserve errors. These things are not insurmountable in the existing two-way payment channel design, but the design is simpler without them.