### PR TITLE
SEP-0012: make payload of POST callback_url clear

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -421,7 +421,7 @@ Anchor has no information on the customer | `404 Not Found`
 
 Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
-Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as [`GET /customer`](#customer-get).
+Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get).
 
 It's the wallet's responsibility to send a working callback URL to the anchor.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: Anchor/Client customer info transfer
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-04-13
-Version 1.6.0
+Updated: 2021-05-18
+Version 1.6.1
 ```
 
 ## Abstract


### PR DESCRIPTION
When I read the description of the payload POST callback_url, it wasn't clear to me whether it should be the same as the GET /customer request or response although the GET request body should not have any meaning.