### PR TITLE
CAP-21: Add comment about unit of duration

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -143,7 +143,7 @@ executed in exchange for disclosing a hash preimage.
 
 ```c++
 typedef int64 TimePoint;
-typedef int64 Duration;
+typedef int64 Duration; // duration in seconds
 
 struct LedgerBounds {
     uint32 minLedger;
@@ -289,7 +289,7 @@ the same block.
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 26ff33d43..d96f55ea6 100644
+index 0e7bc842..490d9a8f 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -12,7 +12,8 @@ typedef opaque Thresholds[4];
@@ -298,11 +298,11 @@ index 26ff33d43..d96f55ea6 100644
  typedef int64 SequenceNumber;
 -typedef uint64 TimePoint;
 +typedef int64 TimePoint;
-+typedef int64 Duration;
++typedef int64 Duration; // duration in seconds
  typedef opaque DataValue<64>;
  
  // 1-4 alphanumeric characters right-padded with 0 bytes
-@@ -126,6 +127,24 @@ const MAX_SIGNERS = 20;
+@@ -126,6 +127,28 @@ const MAX_SIGNERS = 20;
  
  typedef AccountID* SponsorshipDescriptor;
  
@@ -322,12 +322,16 @@ index 26ff33d43..d96f55ea6 100644
 +
 +    // Time at which `seqNum` took on its present value.
 +    TimePoint seqTime;
++
++    // Result of transaction that caused `seqNum` to take on its present value.
++    // True if the transaction result was txSUCCESS or txFEE_BUMP_INNER_SUCCESS.
++    bool *seqSuccess;
 +};
 +
  struct AccountEntryExtensionV2
  {
      uint32 numSponsored;
-@@ -187,6 +206,8 @@ struct AccountEntry
+@@ -187,6 +210,8 @@ struct AccountEntry
          void;
      case 1:
          AccountEntryExtensionV1 v1;
@@ -336,7 +340,7 @@ index 26ff33d43..d96f55ea6 100644
      }
      ext;
  };
-@@ -325,10 +346,10 @@ case CLAIM_PREDICATE_OR:
+@@ -325,10 +350,10 @@ case CLAIM_PREDICATE_OR:
  case CLAIM_PREDICATE_NOT:
      ClaimPredicate* notPredicate;
  case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
@@ -351,10 +355,10 @@ index 26ff33d43..d96f55ea6 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index b2a4f420b..ce933d909 100644
+index 75f39eb4..cb761552 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -507,6 +507,58 @@ struct TimeBounds
+@@ -507,6 +507,62 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -388,6 +392,10 @@ index b2a4f420b..ce933d909 100644
 +    // seqLedger.
 +    uint32 minSeqLedgerGap;
 +
++    // For the transaction to be valid, must be NULL, or must be equal to
++    // sourceAccount's seqSuccess.
++    bool *seqSuccess;
++
 +    // For the transaction to be valid, there must be a signature
 +    // corresponding to every Signer in this array, even if the
 +    // signature is not otherwise required by the sourceAccount or
@@ -413,7 +421,7 @@ index b2a4f420b..ce933d909 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -558,8 +610,8 @@ struct Transaction
+@@ -558,8 +614,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -423,7 +423,7 @@ index 75f39eb4..fefd6d94 100644
 +    Preconditions cond;
  
      Memo memo;
-
+ 
 ```
 
 ## Design Rationale

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -289,7 +289,7 @@ the same block.
 
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 0e7bc842..490d9a8f 100644
+index 0e7bc842..9a283e7f 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -12,7 +12,8 @@ typedef opaque Thresholds[4];
@@ -302,7 +302,7 @@ index 0e7bc842..490d9a8f 100644
  typedef opaque DataValue<64>;
  
  // 1-4 alphanumeric characters right-padded with 0 bytes
-@@ -126,6 +127,28 @@ const MAX_SIGNERS = 20;
+@@ -126,6 +127,24 @@ const MAX_SIGNERS = 20;
  
  typedef AccountID* SponsorshipDescriptor;
  
@@ -322,16 +322,12 @@ index 0e7bc842..490d9a8f 100644
 +
 +    // Time at which `seqNum` took on its present value.
 +    TimePoint seqTime;
-+
-+    // Result of transaction that caused `seqNum` to take on its present value.
-+    // True if the transaction result was txSUCCESS or txFEE_BUMP_INNER_SUCCESS.
-+    bool *seqSuccess;
 +};
 +
  struct AccountEntryExtensionV2
  {
      uint32 numSponsored;
-@@ -187,6 +210,8 @@ struct AccountEntry
+@@ -187,6 +206,8 @@ struct AccountEntry
          void;
      case 1:
          AccountEntryExtensionV1 v1;
@@ -340,7 +336,7 @@ index 0e7bc842..490d9a8f 100644
      }
      ext;
  };
-@@ -325,10 +350,10 @@ case CLAIM_PREDICATE_OR:
+@@ -325,10 +346,10 @@ case CLAIM_PREDICATE_OR:
  case CLAIM_PREDICATE_NOT:
      ClaimPredicate* notPredicate;
  case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
@@ -355,10 +351,10 @@ index 0e7bc842..490d9a8f 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 75f39eb4..cb761552 100644
+index 75f39eb4..fefd6d94 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -507,6 +507,62 @@ struct TimeBounds
+@@ -507,6 +507,58 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -392,10 +388,6 @@ index 75f39eb4..cb761552 100644
 +    // seqLedger.
 +    uint32 minSeqLedgerGap;
 +
-+    // For the transaction to be valid, must be NULL, or must be equal to
-+    // sourceAccount's seqSuccess.
-+    bool *seqSuccess;
-+
 +    // For the transaction to be valid, there must be a signature
 +    // corresponding to every Signer in this array, even if the
 +    // signature is not otherwise required by the sourceAccount or
@@ -421,7 +413,7 @@ index 75f39eb4..cb761552 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -558,8 +614,8 @@ struct Transaction
+@@ -558,8 +610,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  
@@ -431,7 +423,7 @@ index 75f39eb4..cb761552 100644
 +    Preconditions cond;
  
      Memo memo;
- 
+
 ```
 
 ## Design Rationale


### PR DESCRIPTION
### What
Add a comment stating that the unit of time the `Duration` type is expressed in is in seconds.

### Why
It is unclear looking at the XDR what unit of time the new `Duration` type is expressed in. Seconds is mentioned at one location it will be used, in claimable balances, and it would be helpful if this is defined on the type too.