### PR TITLE
CAP-0038 - update auth revoke logic

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -716,6 +716,7 @@ return `CHANGE_TRUST_TRUSTLINE_MISSING`.
 also be set according to existing logic).
 - If no liquidity pool with `liquidityPoolID == SHA256(line.liquidityPool())`
 exists, then that liquidity pool is created.
+- If a trust line is created, it should count as two subentries (and therefore require two base reserves)
 - If a trust line is created, then `numTrustLines` is incremented on the
 corresponding liquidity pool and `numPoolsInvolved` is incremented
 on each asset trust line. If a trust line is erased, then `numTrustLines` is
@@ -748,21 +749,27 @@ if isAuthorizedToMaintainLiabilities(tl) && !isAuthorizedToMaintainLiabilities(e
 
         //redeem lp's pool shares using the logic from LiquidityPoolWithdrawOp
         assetsAndAmounts = redeem(poolTL)
+        
+        //free up reserves from poolTL for the claimable balances below
+        cbSponsoringAcc = poolTL.sponsoringID ? poolTL.sponsoringID : trustor
+        delete(poolTL)
 
-        foreach (assetAndAmount in assetsAndAmounts)
-            tlA = loadTrustLine(trustor, assetAndAmount.asset)
-            if tlA.availableLimit < amountA
-                ClaimableBalance cb
-                cb.amount = assetAndAmount.amount
-                cb.asset = assetAndAmount.asset
-                cb.claimant = trustor
+        foreach (assetAndAmount in assetAndAmounts)
+            tlA = loadTrustLine(trustor, assetsAndAmount.asset)
+            
+            LedgerEntry le;
+            le.sponsoringID = cbSponsoringAcc
+            le.type(CLAIMABLE_BALANCE)
 
-                if isClawbackEnabledOnTrustline(tl)
-                    cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
-                
-                create(cb)
-            else
-                tlA.balance += assetAndAmount.amount
+            ClaimableBalance& cb = le.claimableBalance()
+            cb.amount = assetAndAmount.amount
+            cb.asset = assetAndAmount.asset
+            cb.claimant = trustor
+
+            if isClawbackEnabledOnTrustline(tl)
+                cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
+            
+            create(cb)
 
 ```
 
@@ -817,8 +824,8 @@ the liquidity pool, in order to avoid destroying assets.
 This proposal does not require a reserve for a `LiquidityPoolEntry`. This is
 justified by the fact that a `LiquidityPoolEntry` cannot exist without the
 existence of a `TrustLineEntry` which can hold the pool share. The
-`TrustLineEntry` does require a reserve. This choice provides the cleanest user
-experience for `LiquidityPoolDepositOp` because any account can create the
+`TrustLineEntry` for pool shares require two base reserves. This choice provides the 
+cleanest user experience for `LiquidityPoolDepositOp` because any account can create the
 `LiquidityPoolEntry`, avoiding a race condition where accounts cannot predict
 whether they will need a reserve.
 
@@ -826,6 +833,25 @@ An alternative approach is to treat a `LiquidityPoolEntry` like a
 `ClaimableBalanceEntry`, so it is always sponsored. This would still allow the
 account that creates a pool to be merged if it can find another account to
 assume the sponsorship.
+
+### TrustLineEntry with asset of type ASSET_TYPE_POOL_SHARE takes two base reserves
+This proposal uses Claimable Balances to send back an asset when a redeem is forced due to 
+auth revocation. Instead of making the issuer put up the reserve, we would like to have 
+the owner of the asset put up the reserve. This is ideal for a few reasons. First, the claimant of the 
+claimable balance now has an additional incentive to claim the balance, and second, the issuer
+will not have to worry about potentially putting up many reserves in the case where many pool 
+trust lines need to be redeemed on a revoke.
+
+So how do we make the owner of the asset put up the reserve for the Claimable Balance? We
+require pool trust lines to require the same number of reserves as the number of Claimable Balances
+that need to be created (so two). When authorization is revoked, the pool shares in the pool 
+trust line are redeemed, the trust line is deleted (freeing up two reserves), and then two sponsored Claimable
+Balances are created. 
+
+But what if the owner account is already sponsoring at least `UINT32_MAX - 1` entries? They won't
+be able to sponsor those claimable balances and the revoke would fail. For this reason, we should
+limit `numSponsoring + numSubentries` to `UINT32_MAX`, guaranteeing that an account can always
+sponsor a claimable balance for every subentry that gets removed.
 
 ### Liquidity Pools Support Arbitrary Asset Pairs
 Some implementations of liquidity pools, such as Uniswap V1, enforced the

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -974,20 +974,16 @@ an asset trust line, which will redeem the all pool trust lines involving that a
 back to the owner account if possible, and if not, into a claimable balance. The issuer can
 then use `ClawbackOp` or `ClawbackClaimableBalanceOp` to clawback the assets.
 
-### Pool Shares are not Subject to Clawback
-This proposal does not permit clawback of pool shares. If the issuer for one of
-the constituent assets executed a clawback, this may infringe on the rights and
-obligations of the issuer of the other constituent asset. This complicates the
-clawback model and raises questions about what it means to execute a clawback of
-a pool share.
+### Alternative authorization revoke solution
+The current proposal forces a redeem of all involved pool trust lines when 
+an asset trust line has its authorization revoked. There is an alternative to this solution.
+We could instead require the issuer to revoke authorization on individual pool trust lines to force a redeem.
+This approach will require the issuer to look up all pool trust lines for an asset trust line to perform the revoke.
+It would also add an additional step when regulating assets for the issuer, so we would need to add an opt in flag 
+for liquidity pools so issuers are aware of this. 
 
-One possible model would be that clawback is equivalent to withdrawing from the
-liquidity pool, then executing clawback on the withdrawn asset that the issuer
-controls. Although this has behavior that seems reasonable, it creates new
-technical problems. What happens if the account does not currently have a trust
-line for the other underlying asset? What happens if the account does have a
-trust line for the underlying asset but it has insufficient limit or is not
-authorized?
+This approach would be simpler to implement, and we wouldn't need to tie the lifetime of an asset trust
+line to a pool trust line like in this proposal, but it is not as user-friendly as the current proposal.   
 
 ### Why is the asset trust line required to exist for the lifetime of corresponding pool trust lines
 This proposal introduces `TrustLineEntryExtensionV2`, which keeps track of the number of pool trust lines

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -59,7 +59,7 @@ exchanging assets with the order book and liquidity pools.
 This patch of XDR changes is based on the XDR files in commit (`afb2dca9e112c79547e5125c1e45a8e94c9b965b`) of stellar-core.
 ```diff
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 0e7bc842..73a17001 100644
+index 0e7bc842..a57b1c46 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -25,7 +25,8 @@ enum AssetType
@@ -121,24 +121,7 @@ index 0e7bc842..73a17001 100644
  };
  
  struct Signer
-@@ -114,12 +120,15 @@ enum AccountFlags
-     // Trustlines are created with clawback enabled set to "true",
-     // and claimable balances created from those trustlines are created
-     // with clawback enabled set to "true"
--    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
-+    AUTH_CLAWBACK_ENABLED_FLAG = 0x8,
-+    // If set, TrustLines can deposit into LiquidityPools
-+    AUTH_LIQUIDITY_POOL_ENABLED_FLAG = 0x10
- };
- 
- // mask for all valid flags
- const MASK_ACCOUNT_FLAGS = 0x7;
- const MASK_ACCOUNT_FLAGS_V17 = 0xF;
-+const MASK_ACCOUNT_FLAGS_V18 = 0x1F;
- 
- // maximum number of signers
- const MAX_SIGNERS = 20;
-@@ -214,12 +223,45 @@ const MASK_TRUSTLINE_FLAGS = 1;
+@@ -214,12 +220,57 @@ const MASK_TRUSTLINE_FLAGS = 1;
  const MASK_TRUSTLINE_FLAGS_V13 = 3;
  const MASK_TRUSTLINE_FLAGS_V17 = 7;
  
@@ -175,6 +158,18 @@ index 0e7bc842..73a17001 100644
 +    // add other asset types here in the future
 +};
 +
++struct TrustLineEntryExtensionV2
++{
++    uint32_t numPoolsInvolved;
++
++    union switch (int v)
++    {
++    case 0:
++        void;
++    }
++    ext;
++};
++
  struct TrustLineEntry
  {
 -    AccountID accountID; // account this trustline belongs to
@@ -188,7 +183,16 @@ index 0e7bc842..73a17001 100644
  
      int64 limit;  // balance cannot be above this
      uint32 flags; // see TrustLineFlags
-@@ -403,6 +445,25 @@ struct ClaimableBalanceEntry
+@@ -238,6 +289,8 @@ struct TrustLineEntry
+             {
+             case 0:
+                 void;
++            case 2:
++                TrustLineEntryExtensionV2 v2;
+             }
+             ext;
+         } v1;
+@@ -403,6 +456,25 @@ struct ClaimableBalanceEntry
      ext;
  };
  
@@ -214,7 +218,7 @@ index 0e7bc842..73a17001 100644
  struct LedgerEntryExtensionV1
  {
      SponsorshipDescriptor sponsoringID;
-@@ -431,6 +492,8 @@ struct LedgerEntry
+@@ -431,6 +503,8 @@ struct LedgerEntry
          DataEntry data;
      case CLAIMABLE_BALANCE:
          ClaimableBalanceEntry claimableBalance;
@@ -223,7 +227,7 @@ index 0e7bc842..73a17001 100644
      }
      data;
  
-@@ -457,7 +520,7 @@ case TRUSTLINE:
+@@ -457,7 +531,7 @@ case TRUSTLINE:
      struct
      {
          AccountID accountID;
@@ -232,7 +236,7 @@ index 0e7bc842..73a17001 100644
      } trustLine;
  
  case OFFER:
-@@ -479,6 +542,9 @@ case CLAIMABLE_BALANCE:
+@@ -479,6 +553,9 @@ case CLAIMABLE_BALANCE:
      {
          ClaimableBalanceID balanceID;
      } claimableBalance;
@@ -302,7 +306,7 @@ index a21c577a..02f08da4 100644
  
  /* Entries used to define the bucket list */
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 75f39eb4..6c25f6fb 100644
+index 75f39eb4..b07487c6 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -49,7 +49,9 @@ enum OperationType
@@ -349,14 +353,7 @@ index 75f39eb4..6c25f6fb 100644
  
      // if limit is set to 0, deletes the trust line
      int64 limit;
-@@ -403,12 +422,43 @@ struct ClawbackClaimableBalanceOp
- struct SetTrustLineFlagsOp
- {
-     AccountID trustor;
--    Asset asset;
-+    TrustLineAsset asset;
- 
-     uint32 clearFlags; // which flags to clear
+@@ -409,6 +428,37 @@ struct SetTrustLineFlagsOp
      uint32 setFlags;   // which flags to set
  };
  
@@ -486,17 +483,18 @@ index 75f39eb4..6c25f6fb 100644
          SimplePaymentResult last;
      } success;
  case PATH_PAYMENT_STRICT_SEND_NO_ISSUER:
-@@ -1218,7 +1319,8 @@ enum SetTrustLineFlagsResultCode
-     SET_TRUST_LINE_FLAGS_MALFORMED = -1,
-     SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
-     SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
--    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
-+    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
-+    SET_TRUST_LINE_FLAGS_NOT_ISSUER = -5
+@@ -933,7 +1034,9 @@ enum ChangeTrustResultCode
+                                      // cannot create with a limit of 0
+     CHANGE_TRUST_LOW_RESERVE =
+         -4, // not enough funds to create a new trust line,
+-    CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
++    CHANGE_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
++    CHANGE_TRUST_TRUSTLINE_MISSING = -6, // Asset trustline is missing for pool
++    CHANGE_TRUST_CANNOT_DELETE = 7 // Asset trustline is still involved with a pool
  };
  
- union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
-@@ -1229,6 +1331,59 @@ default:
+ union ChangeTrustResult switch (ChangeTrustResultCode code)
+@@ -1229,6 +1332,59 @@ default:
      void;
  };
  
@@ -556,7 +554,7 @@ index 75f39eb4..6c25f6fb 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1291,6 +1446,10 @@ case opINNER:
+@@ -1291,6 +1447,10 @@ case opINNER:
          ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
      case SET_TRUST_LINE_FLAGS:
          SetTrustLineFlagsResult setTrustLineFlagsResult;
@@ -598,16 +596,6 @@ tlB = loadTrustLine(sourceAccount, cp.assetB)
 if !exists(tlA) || !exists(tlB)
     Fail with LIQUIDITY_POOL_DEPOSIT_NO_TRUST
 if !authorized(tlA) || !authorized(tlB) || !authorized(tlPool)
-    Fail with LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED
-
-issuerA = loadAccount(cp.assetA.issuer)
-issuerB = loadAccount(cp.assetB.issuer)
-
-
-// bool poolEnabled(issuer):
-//     return issuer.flags & AUTH_LIQUIDITY_POOL_ENABLED_FLAG != 0
-
-if !issuerA || !poolEnabled(issuerA) || !issuerB || !poolEnabled(issuerB)
     Fail with LIQUIDITY_POOL_DEPOSIT_NOT_AUTHORIZED
 
 if cp.totalPoolShares != 0
@@ -713,10 +701,15 @@ if `line.type() == ASSET_TYPE_POOL_SHARE` and
 - `line.liquidityPool().constantProduct().fee != 12884902` (this very closely
 approximates 0.3%)
 
-The behavior of `ChangeTrustOp` is unchanged if
-`line.type() != ASSET_TYPE_POOL_SHARE`. If
-`line.type() == ASSET_TYPE_POOL_SHARE` then
+The behavior of `ChangeTrustOp` is changed for all trust line types  
 
+If `line.type() != ASSET_TYPE_POOL_SHARE` then
+- If trust line is being deleted but `numPoolsInvolved != 0`, 
+return `CHANGE_TRUST_CANNOT_DELETE`.
+
+If `line.type() == ASSET_TYPE_POOL_SHARE` then
+- If any of the trust lines for an asset in the pool are missing,
+return `CHANGE_TRUST_TRUSTLINE_MISSING`.
 - The referenced trust line `tl` has
 `tl.asset.liquidityPoolID() == SHA256(line.liquidityPool())`
 - If a trust line is created, then `AUTHORIZED_FLAG` is set (other flags may
@@ -724,66 +717,54 @@ also be set according to existing logic).
 - If no liquidity pool with `liquidityPoolID == SHA256(line.liquidityPool())`
 exists, then that liquidity pool is created.
 - If a trust line is created, then `numTrustLines` is incremented on the
-corresponding liquidity pool. If a trust line is erased, then `numTrustLines` is
-decremented on the corresponding liquidity pool.
+corresponding liquidity pool and `numPoolsInvolved` is incremented
+on each asset trust line. If a trust line is erased, then `numTrustLines` is
+decremented on the corresponding liquidity pool, and `numPoolsInvolved` is decremented
+on each asset trust line.
 - If `numTrustLines` on the corresponding liquidity pool becomes 0, then that
 liquidity pool is erased.
 
-#### SetTrustLineFlagsOp
-The validity conditions for `SetTrustLineFlagsOp` are unchanged if
-`asset.type() != ASSET_TYPE_POOL_SHARE`. `SetTrustLineFlagsOp` is additionally invalid
-if `asset.type() == ASSET_TYPE_POOL_SHARE` and
+#### SetTrustLineFlagsOp and AllowTrustOp
+The validity conditions for `SetTrustLineFlagsOp` and `AllowTrustOp` are unchanged.
 
-- `asset.liquidityPool().constantProduct().assetA >= asset.liquidityPool().constantProduct().assetB`
-- `asset.liquidityPool().constantProduct().fee != 12884902` (this very closely
-approximates 0.3%)
-- `sourceAccount != asset.liquidityPool().constantProduct().assetA.issuer && sourceAccount != asset.liquidityPool().constantProduct().assetB.issuer`
-- `setFlags != AUTHORIZED_FLAG && setFlags != 0` 
-
-The behavior of `SetTrustLineFlagsOp` is unchanged if
-`asset.type() != ASSET_TYPE_POOL_SHARE`. If
-`asset.type() == ASSET_TYPE_POOL_SHARE` then
+The authorization revocation behavior of `SetTrustLineFlagsOp` and `AllowTrustOp`
+are extended to force a redeem of pool shares if any of the involved asset trust lines
+get their authorization revoked -
 
 ```
-tlPool = loadTrustLine(sourceAccount, asset.liquidityPoolID)
-if !exists(tlPool)
-    Fail with SET_TRUST_LINE_FLAGS_NO_TRUST_LINE
+tl = loadTrustLine(trustor, asset)
 
-// Note that the issuer account must have AUTH_REVOCABLE set to get here
-if isAuthorizedToMaintainLiabilities(tlPool) && !isAuthorizedToMaintainLiabilities(expectedFlag)
-    lp = loadLiquidityPool(asset.liquidityPoolID)
+if isAuthorizedToMaintainLiabilities(tl) && !isAuthorizedToMaintainLiabilities(expectedFlag)
+    // ... existing code to remove offers when auth is revoked
 
-    if sourceAccount != lp.constantProduct().assetA.issuer && sourceAccount != lp.constantProduct().assetB.issuer
-        Fail with SET_TRUST_LINE_FLAGS_NOT_ISSUER
+    // gets all pool trust lines that involve this asset and sourceAccount 
+    poolTLs = getPoolTrustlines(asset, sourceAccount)
 
-    //redeem tlPool's pool shares from lp using the logic from LiquidityPoolWithdrawOp
-    //the code below should run for each asset in the pool
-    //lets say amountA is the amount that needs to be sent back
+    // prefetches all pools for the poolTLs just loaded
+    loadPools(poolTLs)
 
-    tlA = loadTrustLine(trustor, lp.constantProduct().assetA)
-    if !tlA || tlA.availableLimit < amountA
-        ClaimableBalance cb
-        cb.amount = amountA
-        cb.claimant = trustor
+    foreach (poolTL in poolTLs)
+        lp = loadLiquidityPool(poolTL.liquidityPoolID)
 
-        if tl 
-            if isClawbackEnabledOnTrustline(tl)
-                cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
-        else
-            issuer = loadAccount(lp.constantProduct().assetA.issuer)
-            if issuer && isClawbackEnabledOnAccount(issuer)
-                cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
-        
-        create(cb)
-    else
-        tlA.balance += amountA
+        //redeem lp's pool shares using the logic from LiquidityPoolWithdrawOp
+        assetsAndAmounts = redeem(poolTL)
+
+        foreach (assetAndAmount in assetsAndAmounts)
+            tlA = loadTrustLine(trustor, assetAndAmount.asset)
+            if tlA.availableLimit < amountA
+                ClaimableBalance cb
+                cb.amount = assetAndAmount.amount
+                cb.asset = assetAndAmount.asset
+                cb.claimant = trustor
+
+                if isClawbackEnabledOnTrustline(tl)
+                    cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
+                
+                create(cb)
+            else
+                tlA.balance += assetAndAmount.amount
 
 ```
-
-#### SetOptionsOp
-The new `AUTH_LIQUIDITY_POOL_ENABLED_FLAG` can be set and cleared using `SetOptionsOp`.
-If `AUTH_IMMUTABLE_FLAG` is already set on the account, then `SET_OPTIONS_CANT_CHANGE`
-will be returned if `AUTH_LIQUIDITY_POOL_ENABLED_FLAG` is set or cleared.
 
 #### PathPaymentStrictSendOp and PathPaymentStrictReceiveOp
 For each step in the path, the exchange will be routed to the order book or
@@ -953,26 +934,6 @@ work if either of the constituent trust lines are unauthorized. Therefore this
 produces reasonable authorization semantics analogous to shared control by the
 issuers of the constituent assets.
 
-### SetTrustlineFlagsOp can Deauthorize Pool Trust Lines, but AllowTrust cannot
-`AllowTrustOp` is not changed in this proposal to use `ExpandedTrustLineAsset`,
-and therefore cannot load pool trust lines. This was done because `AllowTrustOp`
-was deprecated for `SetTrustlineFlags`.
-
-### New account flag AUTH_LIQUIDITY_POOL_ENABLED_FLAG
-This new flag serves two purposes - 
-1. It allows issuers to keep their assets out of Liquidity Pools if they wish.
-2. An issuer should only enable this flag if they are aware of Liquidity Pools
-and therefore should be aware of how to regulate their assets. More specifically,
-they should be aware that to remove their assets from a pool, they need to revoke
-authorization on the pool trust lines, not the asset trust line.
-
-### AUTH_LIQUIDITY_POOL_ENABLED_FLAG account flag is not propagated to trust line flags
-The granularity offered by controlling Liquidity Pool access per trust line is unnecessary
-because issuers already have strict control over trust lines. The one advantage offered 
-by putting this flag in the trust line is that `LiquidityPoolDepositOp` will not need a 
-dependency on the issuer account. This dependency isn't an issue, so we don't
-think it's necessary to add a new trust line flag.
-
 ### Pool withdrawals are not subject to authorization checks
 It would be unfair to lock an accounts funds in a Liquidity Pool when they no longer
 want to be a part of one. It's currently possible for an account to pull offers 
@@ -982,10 +943,10 @@ those funds since operations like payments check authorization.
 
 ### Clawback assets from a pool
 There are no operations that clawback directly from a pool, but the same results can 
-be achieved by using `SetTrustlineFlagsOp`. The issuer can deauthorize a pool trust line
-using `SetTrustlineFlagsOp`, which will redeem the assets back to the owner account if possible,
-and if not, into a claimable balance. The issuer can then use `ClawbackOp` or `ClawbackClaimableBalanceOp`
-to clawback the assets.
+be achieved by using `SetTrustlineFlagsOp` or `AllowTrustOp`. The issuer can deauthorize 
+an asset trust line, which will redeem the all pool trust lines involving that asset and account
+back to the owner account if possible, and if not, into a claimable balance. The issuer can
+then use `ClawbackOp` or `ClawbackClaimableBalanceOp` to clawback the assets.
 
 ### Pool Shares are not Subject to Clawback
 This proposal does not permit clawback of pool shares. If the issuer for one of
@@ -1001,6 +962,12 @@ technical problems. What happens if the account does not currently have a trust
 line for the other underlying asset? What happens if the account does have a
 trust line for the underlying asset but it has insufficient limit or is not
 authorized?
+
+### Why is the asset trust line required to exist for the lifetime of corresponding pool trust lines
+This proposal introduces `TrustLineEntryExtensionV2`, which keeps track of the number of pool trust lines
+an asset trust line is involved in. The extension is used to make sure the trust line is not deleted while 
+corresponding pool trust lines exist. This is required because without the asset trust line, there is no way
+to deauthorize the trust line and force a redeem of the related pool shares.
 
 ### No Interleaved Execution
 This proposal uses `PathPaymentStrictSendOp` and `PathPaymentStrictReceiveOp` as


### PR DESCRIPTION
1. Use a revocation strategy that follows how offers work today by redeeming all relevant pool shares when an asset trust line has its authorization revoked.
2. Make the trustor sponsor the claimable balances on revoke instead of the issuer.
3. Add a section for the previously proposed revoke strategy.