### PR TITLE
SEP-0009: update "birth_place" field type from date to string

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -59,7 +59,7 @@ Name | Type | Description
 `mobile_number` | phone number | Mobile phone number with country code, in E.164 format
 `email_address` | string | Email address
 `birth_date` | date | Date of birth, e.g. `1976-07-04`
-`birth_place` | date | Place of birth (city, state, country; as on passport)
+`birth_place` | string | Place of birth (city, state, country; as on passport)
 `birth_country_code` | country code | ISO Code of country of birth
 `bank_account_number` | string | Number identifying bank account
 `bank_number` | string | Number identifying bank in national banking system (routing number in US)

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC / AML fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2021-02-10
-Version 1.3.1
+Updated: 2021-05-19
+Version 1.3.2
 ```
 
 ## Simple Summary


### PR DESCRIPTION
### What

Update SEP-9 `birth_place` field type from "date" to "string".

### Why

The field description says _"Place of birth (city, state, country; as on passport)"_ so I'm assuming its type should actually be "string".

