### PR TITLE
ecosystem/sep-0024.md: Claimable balance flow where stellar account doesn't exist

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -263,9 +263,10 @@ const result = await this.server.submitTransaction(transaction)
 1. Wallets make a request to `/transactions/deposit/interactive` providing the `claimable_balance_supported` request parameter.
 2. Anchors update their internal database record of the transaction to indicate the wallet supports receiving a claimable balance.
 3. Users send the external asset to the anchor's off-chain account.
-4. Anchors detect that the user's Stellar account doesn't have a trustline.
-5. Anchors submits a Stellar transaction containing a claimable balance operation.
-6. Anchors update the `/transaction(s)` attriutes `status` to `completed` and `claimable_balance_id` to the ID returned in the Horizon response.
+4. If anchors detect that the user's Stellar account doesn't exist then the anchor should [create the Stellar account](#stellar-account-does-not-exist) but skip the step where the anchor should listen for the user to establish their trust line(skip to step 6).
+5. If anchors detect that the user's Stellar account exists then anchors must check if the user's Stellar account doesn't have a trust line(if trust line exists then proceed with the traditional [deposit flow](#deposit) where anchors then proceed to send payment to the user's Stellar account; skips "Anchor Claimable Balance Flow" steps 6 and 7).
+6. Anchors submits a Stellar transaction containing a claimable balance operation.
+7. Anchors update the `/transaction(s)` attributes `status` to `completed` and `claimable_balance_id` to the ID returned in the Horizon response.
 
 ##### Claimable Balance Claimants and Predicates
 
@@ -394,7 +395,7 @@ The URL supplied by both callback parameters should receive the full transaction
 
 **`callback` details**
 
-If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. 
+If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body.
 
 **`postMessage` deprecation**
 


### PR DESCRIPTION
### What 
Adds clarity to the `Anchor Claimable Balance Flow` section to describe what to do when a user makes a deposit to an anchor and doesn't have a created Stellar account.

### Why
To decrease the _"trust line must be established first"_ blockers that exist in the traditional SEP24 deposit flow we leverage the claimable balance operation and detail the deposit flow that anchors and wallets should follow.
However the scenario where a wallet user attempts a deposit without having a stellar account created needs to be detailed to remove ambiguity of this edge case.