### PR TITLE
meta: add cap diff check

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: go get github.com/stellar/mddiffcheck@latest
+    - run: go get github.com/stellar/mddiffcheck
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -15,5 +15,5 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1
-    - run: go get github.com/stellar/mddiffcheck@latest
+    - run: GOPROXY=direct go get github.com/stellar/mddiffcheck@latest
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -11,5 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.16
     - run: go get github.com/stellar/mddiffcheck
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -11,9 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1
     - run: go get github.com/stellar/mddiffcheck@latest
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -1,0 +1,19 @@
+name: 'Check CAP Diffs'
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  mddiffcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1
+    - run: go get github.com/stellar/mddiffcheck@latest
+    - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -15,5 +15,5 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1
-    - run: GOPROXY=direct go get github.com/stellar/mddiffcheck@latest
+    - run: go get github.com/stellar/mddiffcheck@latest
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -287,7 +287,7 @@ the same block.
 
 ### XDR diff
 
-```diff
+```diff check.base=v16.0.0
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 26ff33d43..d96f55ea6 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -287,7 +287,7 @@ the same block.
 
 ### XDR diff
 
-```diff check.base=v16.0.0
+```diff mddiffcheck.base=v16.0.0
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 26ff33d43..d96f55ea6 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -97,7 +97,7 @@ flags. This operation can be used to unset `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
 
 This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90b2780584c6390207bf09291212d606896ce9f8`) of [stellar-core].
 
-```diff
+```diff check.ignore=true
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 8d7463915..26ff33d43 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0035.md
+++ b/core/cap-0035.md
@@ -97,7 +97,7 @@ flags. This operation can be used to unset `TRUSTLINE_CLAWBACK_ENABLED_FLAG`.
 
 This patch of XDR changes is based on the XDR files in tag/commit `v15.1.0` (`90b2780584c6390207bf09291212d606896ce9f8`) of [stellar-core].
 
-```diff check.ignore=true
+```diff mddiffcheck.ignore=true
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 8d7463915..26ff33d43 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0036.md
+++ b/core/cap-0036.md
@@ -69,7 +69,7 @@ destroyed as if it had been claimed by a claimaint.
 
 This patch of XDR changes is based on the XDR files as they are after the XDR changes from CAP-35 are applied.
 
-```diff
+```diff check.ignore=true
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -47,7 +47,8 @@ enum OperationType

--- a/core/cap-0036.md
+++ b/core/cap-0036.md
@@ -69,7 +69,7 @@ destroyed as if it had been claimed by a claimaint.
 
 This patch of XDR changes is based on the XDR files as they are after the XDR changes from CAP-35 are applied.
 
-```diff check.ignore=true
+```diff mddiffcheck.ignore=true
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -47,7 +47,8 @@ enum OperationType

--- a/core/cap-0037.md
+++ b/core/cap-0037.md
@@ -85,7 +85,7 @@ their funds to the pool, participating in the collective liquidity allocation.
 
 ### XDR changes
 
-```diff
+```diff check.ignore=true
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -403,6 +403,43 @@ struct ClaimableBalanceEntry
@@ -165,7 +165,7 @@ their funds to the pool, participating in the collective liquidity allocation.
  };
 ```
 
-```diff
+```diff check.ignore=true
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -48,7 +48,9 @@ enum OperationType

--- a/core/cap-0037.md
+++ b/core/cap-0037.md
@@ -85,7 +85,7 @@ their funds to the pool, participating in the collective liquidity allocation.
 
 ### XDR changes
 
-```diff check.ignore=true
+```diff mddiffcheck.ignore=true
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -403,6 +403,43 @@ struct ClaimableBalanceEntry
@@ -165,7 +165,7 @@ their funds to the pool, participating in the collective liquidity allocation.
  };
 ```
 
-```diff check.ignore=true
+```diff mddiffcheck.ignore=true
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -48,7 +48,9 @@ enum OperationType

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -57,7 +57,7 @@ exchanging assets with the order book and liquidity pools.
 
 ### XDR changes
 This patch of XDR changes is based on the XDR files in commit (`afb2dca9e112c79547e5125c1e45a8e94c9b965b`) of stellar-core.
-```diff check.base=afb2dca9e112c79547e5125c1e45a8e94c9b965b
+```diff mddiffcheck.base=afb2dca9e112c79547e5125c1e45a8e94c9b965b
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842b..73a170019 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -57,7 +57,7 @@ exchanging assets with the order book and liquidity pools.
 
 ### XDR changes
 This patch of XDR changes is based on the XDR files in commit (`afb2dca9e112c79547e5125c1e45a8e94c9b965b`) of stellar-core.
-```diff
+```diff check.base=afb2dca9e112c79547e5125c1e45a8e94c9b965b
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842b..73a170019 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0039.md
+++ b/core/cap-0039.md
@@ -61,7 +61,7 @@ accounts for contracts, such as payment channels.
 This patch of XDR changes is based on the XDR files in commit
 `b9e10051eafa1125e8d238a47e5915dad30c2640` of stellar-core.
 
-```diff check.base=b9e10051eafa1125e8d238a47e5915dad30c2640
+```diff mddiffcheck.base=b9e10051eafa1125e8d238a47e5915dad30c2640
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842..68c52758 100644
 --- a/src/xdr/Stellar-ledger-entries.x

--- a/core/cap-0039.md
+++ b/core/cap-0039.md
@@ -61,7 +61,7 @@ accounts for contracts, such as payment channels.
 This patch of XDR changes is based on the XDR files in commit
 `b9e10051eafa1125e8d238a47e5915dad30c2640` of stellar-core.
 
-```diff
+```diff check.base=b9e10051eafa1125e8d238a47e5915dad30c2640
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
 index 0e7bc842..68c52758 100644
 --- a/src/xdr/Stellar-ledger-entries.x


### PR DESCRIPTION
### What
Add a GitHub Action that check the diffs in CAPs are valid.

### Why
On a few occasions diffs have been committed that are corrupt. This is usually discovered by someone consuming the diff, and not by the person publishing the diff. This consumes that other persons time, as they need to debug the diff. Diffs are fiddly and it's easy for copy paste errors to occur, or stray characters, or missing new lines at the end to result in a corrupt diff. Instructions introduced in 9b0d752c7ac4d42c9735789cb190479ee8744a33 should help us generate good diffs, but this check will catch the corrupt diffs when the author is submitting them, before someone else is consuming them.

Some of the existing CAPs were easy to update to pass the check. Others not, some just don't seem to apply cleanly to any version as far as I could see, which is the type of situation this check will prevent. For those cases I added a parameter to ignore them for the moment until their authors can fix them.

This GitHub Action uses a tool that I wrote, `mddiffcheck`, which lives at https://github.com/stellar/mddiffcheck. It took more effort than I expected or planned to give to it to write the tool, but it is done now.

Close #893 