### PR TITLE
SEP-8: Be clear about the action_required step being interactive

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -226,7 +226,7 @@ Name | Type | Description
 
 This response means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
 
-The action the user must complete is intended to be displayed in a browser. The client may be able to skip the need to display the URL in the browser if it can supply the requested details.
+The action the user must complete is intended to be displayed in a browser. The client may be able to skip displaying the URL in the browser if the server supports the `POST` `action_method`, the client can supply the requested details, and the server's final response to the `POST` indicates no further action is required.
 
 An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-03-26
-Version 1.7.0
+Updated: 2021-05-26
+Version 1.7.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -226,6 +226,8 @@ Name | Type | Description
 
 This response means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
 
+The action the user must complete is interactive, and is intended to be displayed in a browser. The client may be able to skip the need to display the URL in the browser if it can supply the requested details.
+
 An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
 
 Parameters:

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -226,7 +226,7 @@ Name | Type | Description
 
 This response means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
 
-The action the user must complete is interactive, and is intended to be displayed in a browser. The client may be able to skip the need to display the URL in the browser if it can supply the requested details.
+The action the user must complete is intended to be displayed in a browser. The client may be able to skip the need to display the URL in the browser if it can supply the requested details.
 
 An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
 


### PR DESCRIPTION
### What
Make the action_required text clearer upfront that this state is intended to require user interaction with a browser, however that there are capabilities to allow a client to skip it if it has the necessary information.

### Why
It has been surprising to a few folks that user interaction with a browser is required because one of the two options for replying is a POST request.