### PR TITLE
SEP-24: improved memo description, removed successful response

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-05-17
-Version 1.3.2
+Updated: 2021-05-26
+Version 1.3.3
 ```
 
 ## Simple Summary
@@ -159,8 +159,8 @@ Name | Type | Description
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
-`memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
-`memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
+`memo` | string | (optional) Value of memo to attach to transaction, if `memo_type` is `hash`, this must be the base64-encoded hash. A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
+`memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
@@ -180,8 +180,6 @@ asset_code=USD&email_address=myaccount@gmail.com&account=GACW7NONV43MZIFHCOKCQJA
 ```
 
 ### Response
-
-There are several possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
 
 Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section below.
 
@@ -295,7 +293,7 @@ Name | Type | Description
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
-`memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
+`memo` | string | (optional) Value of memo to attach to transaction, if `memo_type` is `hash`, this must be the base64-encoded hash. A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
@@ -316,48 +314,15 @@ When uploading data for fields specificed in [SEP-9](sep-0009.md), `binary` type
 
 ### Response
 
-There are several possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
-
-The first response, the success response, is explained below. The other possible responses are shared with the deposit endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section directly below.
-
-#### 1. Success: no additional information needed
-
-Response code: `200 OK`
-
-This is the correct response if the anchor is able to execute the withdrawal and needs no additional information about the user. It should also be used if the anchor requires information about the user, but the information has previously been submitted and accepted.
-
-The response body should be a JSON object with the following fields:
-
-Name | Type | Description
------|------|------------
-`account_id` | `G...` string | The account the user should send its token back to.
-`memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
-`memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
-`eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
-`min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
-`max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
-`fee_fixed` | float | (optional)  Fixed (Base) fee, in units of withdrawn asset.  This is in addition to any `fee_percent`.
-`fee_percent` | float | (optional) Percentage fee in units of percent.  This is in addition to any `fee_fixed`.
-`fee_minimum` | float | (optional) Minimum fee in units of withdrawn asset.
-`extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name.
-
-Example:
-
-```json
-{
-  "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
-  "memo_type": "id",
-  "memo": "123"
-}
-```
+Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section below.
 
 ## Deposit and Withdraw shared responses
 
-### 2. Interactive customer information needed
+### Interactive customer information needed
 
 Response code: `200 OK`
 
-An anchor that requires the user to fill out information on a webpage hosted by the anchor should use this response. This can happen in situations where the anchor needs KYC information about a user, or when the anchor needs the user to perform a custom step for each transaction like entering an SMS code to confirm a withdrawal or selecting a bank account. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
+The anchor must respond with a webpage URL to its interactive flow. In the interactive flow, the anchor may collect KYC information from the user, or request the user to perform a custom step for each transaction like entering a SMS code to confirm a withdrawal or selecting a bank account. A wallet that receives this response should open a popup browser window or embedded webview to the specified URL. The anchor must take care that the popup page displays well on a mobile device, as many wallets are phone apps.
 
 As the user is interacting with the anchor popup, they will make progress on their deposit or withdrawal and cause updates to the transaction status. The wallet must either listen for a callback or poll the [`/transaction`](#single-historical-transaction) endpoint for updates about the transaction from the anchor. This allows the wallet to show the user status information and confirm if the deposit attempt initiated successfully or failed. For withdrawals, the wallet must get information on where to send the withdrawal payment to the anchor.
 
@@ -474,7 +439,7 @@ After that, the wallet displays the anchor's interactive URL in a popup, and eve
 
 If the wallet displays information to the user, it can display any of the fields that may be useful to the user, such as `more_info_url`, `status`, and `amount_in`.
 
-### 5. Authentication required
+### Authentication required
 
 Response code: `403 Forbidden`
 
@@ -486,7 +451,7 @@ This endpoint requires [authentication](#authentication).
 }
 ```
 
-### 6. Error
+### Error
 
 Every other HTTP status code will be considered an error. The body should contain a string indicating the error details.  This error is in a human readable format in the language indicated in the request and is intended to be displayed by the wallet.
 For example:
@@ -829,6 +794,6 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 ## Implementations
 
 * iOS and macOS SDK: https://github.com/Soneso/stellar-ios-mac-sdk/blob/master/README.md#6-anchor-client-interoperability
-* Demo wallet client for development of an anchor server: https://sep24.stellar.org
+* Demo wallet client for development of an anchor server: https://demo-wallet.stellar.org/
 * Anchor server implementation example and reuseable app in Python: https://github.com/stellar/django-polaris
 * Solar wallet: https://solarwallet.io


### PR DESCRIPTION
- Improved `memo` and `memo_type` descriptions about their use cases
- Removed successful response since SEP-6 must be used for non-interactive transactions
- Interactive response documentation now doesn't account for other types of responses. It focuses on explaning the interactive URL response.
- Updated link to Demo Wallet