### PR TITLE
SEP-8: remove requirement where incoming transactions needed to be signed by the wallet

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -31,7 +31,7 @@ Implementing a regulated asset requires these parts:
 
 ## Regulated Assets Approval Flow
 
-1. Wallet creates and signs a transaction.
+1. Wallet creates a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
 	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
 3. Wallet sends the transaction to the approval server.
@@ -97,7 +97,7 @@ Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X
 
 ## Approval Server
 
-Approval server is a single endpoint that receives a signed transaction, checks for compliance, and signs it on success.
+Approval server is a single endpoint that receives a transaction, checks for compliance, and signs it on success.
 
 The specification of an approval server is defined as follows:
 
@@ -128,7 +128,7 @@ This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 
 Name | Type | Description
 -----|------|------------
-`tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+`tx` | string | A base64 encoded transaction envelope XDR. This is the transaction that will be tested for compliance and signed by the issuer on success.
 
 ###### Example (JSON)
 
@@ -159,7 +159,7 @@ Parameters:
 Name | Type | Description
 -----|------|------------
 `status` | string | `"success"`
-`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as one or multiple additional signatures from the issuer.
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request if any, as well as one or multiple additional signatures from the issuer.
 `message` | string | (optional) A human readable string containing information to pass on to the user.
 
 ###### Example
@@ -179,7 +179,7 @@ A revised transaction should only add operations to the transaction to make it c
 
 A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
 
-It is important for the user to examine the revised transaction before re-signing it. More specifically, the user should make sure that the revised transaction does not contain any additional operations whose source account matches the source account of the original operation(s).
+It is important for the user to examine the revised transaction before signing it. More specifically, the user should make sure that the revised transaction does not contain any additional operations whose source account matches the source account of the original operation(s).
 
 Parameters:
 


### PR DESCRIPTION
### What

Remove SEP-8 requirement where incoming transactions needed to be signed by the wallet.

### Why

I don't really see any benefit of enforcing that rule.