### PR TITLE
SEP-12: clarify the need for 'type' parameters in GET and PUT requests

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-05-19
-Version 1.6.2
+Updated: 2021-05-28
+Version 1.6.3
 ```
 
 ## Abstract
@@ -105,7 +105,9 @@ The client can always use the `account`, `memo`, and `memo_type` parameters to u
 
 Different types of customers may have different KYC requirements depending on the action a given customer wants to take. The `type` parameter is used to specify the action a customer wants to make so the server can identify what information must be collected. SEP-12 does not define what `type` values are accepted and instead leaves that to the other protocols, such as [SEP-6](sep-0006.md) and [SEP-31](sep-0031.md), that use SEP-12 for the actions associated with those protocols.
 
-For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31 receiver would require banking information in order to receive a direct deposit. The `type` parameter could also be used to indicate that a customer is an organization instead of a person. 
+For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31 receiver would require banking information in order to receive a direct deposit. The `type` parameter could also be used to indicate that a customer is an organization instead of a person.
+
+Note that it is possible for the same customer to have different `status` values for different `type` parameters. For example, a customer could have an `ACCEPTED` status for the `small-transaction-amount` `type` parameter but have a `NEEDS_INFO` status for the `large-transaction-amount` type. Therefore it is recommended to always pass the `type` parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accomodate for implementations without more than one `type`.
 
 If the implementor requires the same set of fields for all customers, there is no need for the `type` parameter.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -107,7 +107,7 @@ Different types of customers may have different KYC requirements depending on th
 
 For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31 receiver would require banking information in order to receive a direct deposit. The `type` parameter could also be used to indicate that a customer is an organization instead of a person.
 
-Note that it is possible for the same customer to have different `status` values for different `type` parameters. For example, a customer could have an `ACCEPTED` status for the `small-transaction-amount` `type` parameter but have a `NEEDS_INFO` status for the `large-transaction-amount` type. Therefore it is recommended to always pass the `type` parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accomodate for implementations without more than one `type`.
+Note that it is possible for the same customer to have different `status` values for different `type` parameters. For example, a customer could have an `ACCEPTED` status for the `small-transaction-amount` `type` parameter but have a `NEEDS_INFO` status for the `large-transaction-amount` type. Therefore it is recommended to always pass the `type` parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accomodate for implementations that do not require `type`.
 
 If the implementor requires the same set of fields for all customers, there is no need for the `type` parameter.
 


### PR DESCRIPTION
Recommends clients always pass the customer `type` in `GET` & `PUT` requests.

### Context

I discovered that our `testanchor.stellar.org` SEP-12 implementation was returning `NEEDS_INFO` status values for customers who had passed all required fields for a SEP-6 deposit and received a customer `id`.

Upon further inspection I realized that this was because our `sep6-withdraw` customer `type` requires additional fields that the `sep6-deposit` `type` value does not, and the server was being conservative by assuming the request was for the `type` that required the most information.

Therefore, in order to ensure the correct `status` is returned for a customer in `GET /customer`, `type` should always be passed unless no types are specified in the SEP-31 or SEP-6 implementation.