### PR TITLE
SEP-31: include some details about the Sending and Receiving Anchors to make the SEP clearer

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -351,7 +351,7 @@ Name | Type | Description
 `stellar_memo` | string | The memo to attach to the Stellar payment.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
-`stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment from the Sending Anchor to the Receiving Anchor.
+`stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
 `refunded` | boolean | (optional) Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -346,12 +346,12 @@ Name | Type | Description
 `amount_in` | string | (optional) The amount received or to be received by the Receiving Anchor. Up to 7 decimals are permitted. Excludes any fees charged after Receiving Anchor receives the funds.
 `amount_out` | string | (optional) The amount sent by the Rending Anchor to Receiving Client. Up to 7 decimals are permitted.
 `amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor.
-`stellar_account_id` | string | The Stellar account to send the payment to.
+`stellar_account_id` | string | The Receiving Anchor's Stellar account the Sending Anchor will be making the payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
-`stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
+`stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment from the Sending Anchor to the Receiving Anchor.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
 `refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2021-05-17
-Version 1.2.2
+Updated: 2021-06-02
+Version 1.2.3
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -86,7 +86,7 @@ All endpoints respond with content type:
 1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected information for each client.
 1. On successful registration (`202` HTTP status), the Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction amount and asset information. The response will include a `id` that will be used to check the status of the transaction.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`. 
-1. The Sending Anchor submits the payment transaction to Stellar using the memo and memo_type specified by the Receiving Anchor `GET /transactions/:id` response fields `stellar_memo` and `stellar_memo_type`.
+1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `POST /transactions` response.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
 1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -353,7 +353,7 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment from the Sending Anchor to the Receiving Anchor.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (optional) Should be true if the transaction was refunded, and accompanied by the status `"error"` to make sure the Sending Anchor won't try to handle this transaction in any way. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (optional) Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -257,7 +257,7 @@ Content-Type: application/json
 }
 ```
 
-This request initiates a payment. The Sending and Receiving Client must be registered via [SEP-12](sep-0012.md) if required by the Receiving Anchor.
+This request initiates a payment. The Sending and Receiving Clients must be registered via [SEP-12](sep-0012.md) if required by the Receiving Anchor.
 
 ##### Request Parameters
 
@@ -279,7 +279,7 @@ This is the successful case where a Receiving Anchor confirms that they can fulf
 
 Name | Type | Description
 -----|------|------------
-`id` | string | The persistent identifier to check the status of this payment.
+`id` | string | The persistent identifier to check the status of this payment transaction.
 `stellar_account_id` | string | The Stellar account to send payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment (`text`, `hash`, or `id`).
 `stellar_memo` | string | The memo to attach to the Stellar payment.
@@ -362,7 +362,7 @@ Name | Type | Description
 * `pending_sender` -- awaiting payment to be sent by Sending Anchor.
 * `pending_stellar` -- transaction has been submitted to Stellar network, but is not yet confirmed.
 * `pending_customer_info_update` -- certain pieces of information need to be updated by the Sending Anchor. See the [Pending Customer Info Update](#pending-customer-info-update) section for more information.
-* `pending_transaction_info_update` -- certain pieces of information need to be updated by the sending anchor. See the [Pending Transaction Info Update](#pending-transaction-info-update) section for more information.
+* `pending_transaction_info_update` -- certain pieces of information need to be updated by the Sending Anchor. See the [Pending Transaction Info Update](#pending-transaction-info-update) section for more information.
 * `pending_receiver` -- payment is being processed by the Receiving Anchor.
 * `pending_external` -- payment has been submitted to external network, but is not yet confirmed.
 * `completed` -- funds have been delivered to the Receiving Client.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -86,7 +86,7 @@ All endpoints respond with content type:
 1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected information for each client.
 1. On successful registration (`202` HTTP status), the Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction amount and asset information. The response will include a `id` that will be used to check the status of the transaction.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`. 
-1. The Sending Anchor submits the payment transaction to Stellar.
+1. The Sending Anchor submits the payment transaction to Stellar using the memo and memo_type specified by the Receiving Anchor `GET /transactions/:id` response fields `stellar_memo` and `stellar_memo_type`.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
 1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -353,7 +353,7 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment from the Sending Anchor to the Receiving Anchor.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (optional) Should be true if the transaction was refunded, and accompanied by the status `"error"` to make sure the Sending Anchor won't try to handle this transaction in any way. Not including this field means the transaction was not refunded.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -346,7 +346,7 @@ Name | Type | Description
 `amount_in` | string | (optional) The amount received or to be received by the Receiving Anchor. Up to 7 decimals are permitted. Excludes any fees charged after Receiving Anchor receives the funds.
 `amount_out` | string | (optional) The amount sent by the Rending Anchor to Receiving Client. Up to 7 decimals are permitted.
 `amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor.
-`stellar_account_id` | string | The Receiving Anchor's Stellar account the Sending Anchor will be making the payment to.
+`stellar_account_id` | string | The Receiving Anchor's Stellar account that the Sending Anchor will be making the payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.


### PR DESCRIPTION
### What

Disambiguate parts of the SEP and add further recommendation about refunded transactions.

### Why

When reading the SEP, some details and interactions between Sending and Receiving Anchors were not very clear.
