### PR TITLE
SEP-23: Update status to Active

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -44,7 +44,7 @@
 | [SEP-0012](sep-0012.md) | KYC API | Interstellar | Standard | Active |
 | [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Active |
 | [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Active |
-| [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières and Tomer Weller | Standard | Active |
+| [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Standard | Active |
 | [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal | SDF | Standard | Active |
 | [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
 | [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Active |

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -44,6 +44,7 @@
 | [SEP-0012](sep-0012.md) | KYC API | Interstellar | Standard | Active |
 | [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Active |
 | [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Active |
+| [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières and Tomer Weller | Standard | Active |
 | [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal | SDF | Standard | Active |
 | [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
 | [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Active |
@@ -61,7 +62,6 @@
 | [SEP-0019](sep-0019.md) | Bootstrapping Multisig Transaction Submission | Paul Selden, Nikhil Saraf | Standard | Draft |
 | [SEP-0021](sep-0021.md) | On-chain signature & transaction sharing | Mister.Ticot | Informational | Draft |
 | [SEP-0022](sep-0022.md) | IPFS Support | Samuel B. Sendelbach | Informational | Draft |
-| [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières and Tomer Weller | Standard | Draft |
 | [SEP-0030](sep-0030.md) | Recoverysigner: multi-party key management of Stellar accounts | Leigh McCulloch, Lindsay Lin | Standard | Draft |
 | [SEP-0032](sep-0032.md) | Asset Address | Leigh McCulloch | Standard | Draft |
 | [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Final Comment Period |

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -44,7 +44,7 @@
 | [SEP-0012](sep-0012.md) | KYC API | Interstellar | Standard | Active |
 | [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Active |
 | [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Active |
-| [SEP-0023](sep-0023.md) | Augmented strkey format for multiplexed addresses | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Standard | Active |
+| [SEP-0023](sep-0023.md) | Muxed Account Strkeys | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Standard | Active |
 | [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal | SDF | Standard | Active |
 | [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
 | [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Active |

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -5,9 +5,9 @@ SEP: 0023
 Title: Augmented strkey format for multiplexed accounts
 Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Alfonso Acosta <@2opremio>
 Track: Standard
-Status: Draft
+Status: Active
 Created: 2019-09-16
-Updated: 2021-03-25
+Updated: 2021-06-02
 Version: 0.0.2
 Discussion: https://groups.google.com/forum/#!forum/stellar-dev
 ```

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0023
-Title: Augmented strkey format for multiplexed accounts
+Title: Muxed Account Strkeys
 Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Alfonso Acosta <@2opremio>
 Track: Standard
 Status: Active

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -8,7 +8,7 @@ Track: Standard
 Status: Active
 Created: 2019-09-16
 Updated: 2021-06-02
-Version: 0.0.2
+Version: 1.0.0
 Discussion: https://groups.google.com/forum/#!forum/stellar-dev
 ```
 


### PR DESCRIPTION
### What
Update the status of SEP-23 to Active, set version to v1.0.0.

### Why
The SEP is implemented in Horizon, the Go SDK, the JS SDK, stc, and more. At this point the inertia that would be required to change SEP-23 is significantly high because changing it would require breaking changes to all these things. Even though in some of these things the functionality SEP-23 defines is specified as opt-in the implementation carries weight that'll be difficult to coordinate in changing. Therefore I think this SEP should be considered in active status, and not draft. It has moved past being a draft because we would not make arbitrary changes to it at this point.

cc @stanford-scs @tomerweller @ire-and-curses @shanzzam @2opremio 