### PR TITLE
Change operationID to use an AccountID instead of MuxedAccount

### DIFF
--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -224,7 +224,7 @@ union OperationID switch (EnvelopeType type)
 case ENVELOPE_TYPE_OP_ID:
     struct
     {
-        MuxedAccount sourceAccount;
+        AccountID sourceAccount;
         SequenceNumber seqNum;
         uint32 opNum;
     } id;


### PR DESCRIPTION
The implementation (unfortunately) ended up using the `AccountID` and converting it into the `MuxedAccount`. This PR updates the XDR to make it clear that the transaction source `MuxedAccount` is not used in `OperationID`.