### PR TITLE
CAP-0038 - Remove liquidityPoolID from union in LedgerPoolEntry

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -59,7 +59,7 @@ exchanging assets with the order book and liquidity pools.
 This patch of XDR changes is based on the XDR files in commit (`a5e7028c04305c7b6f7d08c981e87bb9891b7364`) of stellar-core.
 ```diff mddiffcheck.base=a5e7028c04305c7b6f7d08c981e87bb9891b7364
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 0e7bc842..c04995ce 100644
+index 0e7bc842..92dbcd92 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -14,6 +14,7 @@ typedef string string64<64>;
@@ -207,7 +207,7 @@ index 0e7bc842..c04995ce 100644
  };
  
  enum ClaimableBalanceFlags
-@@ -403,6 +449,29 @@ struct ClaimableBalanceEntry
+@@ -403,6 +449,33 @@ struct ClaimableBalanceEntry
      ext;
  };
  
@@ -218,26 +218,30 @@ index 0e7bc842..c04995ce 100644
 +    int32 fee;    // Fee is in basis points, so the actual rate is (fee/100)%
 +};
 +
-+union LiquidityPoolEntry switch (LiquidityPoolType type)
++struct LiquidityPoolEntry
 +{
-+case LIQUIDITY_POOL_CONSTANT_PRODUCT:
-+    struct
-+    {
-+        PoolID liquidityPoolID;
-+        LiquidityPoolConstantProductParameters params;
++    PoolID liquidityPoolID;
 +
-+        int64 reserveA;        // amount of A in the pool
-+        int64 reserveB;        // amount of B in the pool
-+        int64 totalPoolShares; // total number of pool shares issued
-+        int64 poolSharesTrustLineCount; // number of trust lines
-+                                        // for the associated pool shares
-+    } constantProduct;
++    union switch (LiquidityPoolType type)
++    {
++    case LIQUIDITY_POOL_CONSTANT_PRODUCT:
++        struct
++        {
++            LiquidityPoolConstantProductParameters params;
++
++            int64 reserveA;        // amount of A in the pool
++            int64 reserveB;        // amount of B in the pool
++            int64 totalPoolShares; // total number of pool shares issued
++            int64 poolSharesTrustLineCount; // number of trust lines for the associated pool shares
++        } constantProduct;
++    }
++    body;
 +};
 +
  struct LedgerEntryExtensionV1
  {
      SponsorshipDescriptor sponsoringID;
-@@ -431,6 +500,8 @@ struct LedgerEntry
+@@ -431,6 +504,8 @@ struct LedgerEntry
          DataEntry data;
      case CLAIMABLE_BALANCE:
          ClaimableBalanceEntry claimableBalance;
@@ -246,7 +250,7 @@ index 0e7bc842..c04995ce 100644
      }
      data;
  
-@@ -457,7 +528,7 @@ case TRUSTLINE:
+@@ -457,7 +532,7 @@ case TRUSTLINE:
      struct
      {
          AccountID accountID;
@@ -255,17 +259,20 @@ index 0e7bc842..c04995ce 100644
      } trustLine;
  
  case OFFER:
-@@ -479,6 +550,9 @@ case CLAIMABLE_BALANCE:
+@@ -479,6 +554,12 @@ case CLAIMABLE_BALANCE:
      {
          ClaimableBalanceID balanceID;
      } claimableBalance;
 +
 +case LIQUIDITY_POOL:
-+    PoolID liquidityPoolID;
++    struct
++    {
++        PoolID liquidityPoolID;
++    } liquidityPool;
  };
  
  // list of all envelope types used in the application
-@@ -492,6 +566,7 @@ enum EnvelopeType
+@@ -492,6 +573,7 @@ enum EnvelopeType
      ENVELOPE_TYPE_AUTH = 3,
      ENVELOPE_TYPE_SCPVALUE = 4,
      ENVELOPE_TYPE_TX_FEE_BUMP = 5,
@@ -336,7 +343,7 @@ index a21c577a..d56c7e9f 100644
  
  /* Entries used to define the bucket list */
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index e7b4218f..83c83804 100644
+index 75f39eb4..5caddd9a 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -7,6 +7,12 @@


### PR DESCRIPTION
The current proposal stores `liquidityPoolID` under a union in `LedgerPoolEntry`, while the `LIQUIDITY_POOL` `LedgerKey` does not use a union for its `liquidityPoolID`. This doesn't make much sense because every pool type will need a `liquidityPoolID`, so this PR pulls the `liquidityPoolID` from the union in LedgerPoolEntry.