### PR TITLE
SEP-9: add 'sex' field

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -81,6 +81,9 @@ Name | Type | Description
 `notary_approval_of_photo_id` | binary | Image of notary's approval of photo ID or passport
 `ip_address` | string | IP address of customer's computer
 `photo_proof_residence` | binary | Image of a utility bill, bank statement or similar with the user's name and address
+`sex` | string | `male`, `female`, or `other`
+
+```
 
 ### Organization KYC fields
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -82,7 +82,6 @@ Name | Type | Description
 `ip_address` | string | IP address of customer's computer
 `photo_proof_residence` | binary | Image of a utility bill, bank statement or similar with the user's name and address
 `sex` | string | `male`, `female`, or `other`
-
 ```
 
 ### Organization KYC fields

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -82,7 +82,6 @@ Name | Type | Description
 `ip_address` | string | IP address of customer's computer
 `photo_proof_residence` | binary | Image of a utility bill, bank statement or similar with the user's name and address
 `sex` | string | `male`, `female`, or `other`
-```
 
 ### Organization KYC fields
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2021-05-19
-Version 1.3.2
+Updated: 2021-06-22
+Version 1.4.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
resolves stellar/stellar-protocol#915 

Uses `other` instead of the suggested `undefined` since `undefined` could be interpreted to mean `null` or simply omitted.

@ymatienzo