### PR TITLE
SEP-12: fix PUT /customer response example

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-05-28
-Version 1.6.3
+Updated: 2021-06-24
+Version 1.6.4
 ```
 
 ## Abstract

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -319,13 +319,6 @@ Name | Type | Description
 ```json
 {
    "id": "391fb415-c223-4608-b2f5-dd1e91e3a986",
-   "fields": {
-      "photo_id_front": {
-         "description": "Email address of the customer",
-         "type": "binary",
-         "status": "PROCESSING"
-      }
-   }
 }
 ```
 


### PR DESCRIPTION
I made a mistake when making the changes for #812. I suspect I thought I was altering a `GET /customer` or `PUT /customer/verification` response, but `id` is the only property allowed for `PUT /customer` responses.