### PR TITLE
Update cap-0038.md

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -722,7 +722,7 @@ Succeed with LIQUIDITY_POOL_DEPOSIT_SUCCESS
 #### LiquidityPoolWithdrawOp
 `LiquidityPoolWithdrawOp` is the only way for an account to withdraw funds from
 a liquidity pool. The operation specifies an amount of pool shares to withdraw.
-Using that number of pool shares, it calculates amounts of each asset to deposit
+Using that number of pool shares, it calculates amounts of each asset to withdraw
 with a maximum error (rounded against the depositor) of 1 stroop in each asset.
 Finally, it checks that the withdrawn amounts are at least those specified by
 minAmountA and minAmountB.
@@ -992,13 +992,13 @@ account that creates a pool to be merged if it can find another account to
 assume the sponsorship.
 
 ### TrustLineEntry with asset of type ASSET_TYPE_POOL_SHARE takes two base reserves
-This proposal uses Claimable Balances to send back an asset when a redeem is
+This proposal uses Claimable Balances to send back an asset when a redemption is
 forced due to auth revocation. Instead of making the issuer put up the reserve,
 we would like to have the owner of the asset put up the reserve. This is ideal
 for a few reasons. First, the claimant of the claimable balance now has an
 additional incentive to claim the balance, and second, the issuer will not have
 to worry about potentially putting up many reserves in the case where many pool
-trust lines need to be redeemed on a revoke.
+trust lines need to be redeemed on a revocation.
 
 So how do we make the owner of the asset put up the reserve for the Claimable
 Balance? We require pool trust lines to require the same number of reserves as
@@ -1008,7 +1008,7 @@ the trust line is deleted (freeing up two reserves), and then two sponsored
 Claimable Balances are created.
 
 But what if the owner account is already sponsoring at least `UINT32_MAX - 1`
-entries? They won't be able to sponsor those claimable balances and the revoke
+entries? They won't be able to sponsor those claimable balances and the revocation
 would fail. For this reason, we should limit `numSponsoring + numSubentries` to
 `UINT32_MAX`, guaranteeing that an account can always sponsor a claimable
 balance for every subentry that gets removed.
@@ -1021,7 +1021,7 @@ implementations, such as Uniswap V2, have generally removed this constraint.
 This proposal allows complete flexibility in the constituent assets of a
 liquidity pool. We believe that this enables liquidity to be provided in the
 manner that is most efficient. For example, providing liquidity between two
-stablecoins with the same underlying can be relatively low risk (assuming both
+stablecoins with the same underlying asset can be relatively low risk (assuming both
 are creditable). But if instead liquidity had to be provided against some fixed
 third asset, then the liquidity provider would be subject to impermanent loss in
 both liquidity pools.
@@ -1107,9 +1107,9 @@ effort of supporting transferability at this point. This proposal is designed
 such that transferability could easily be added in a future protocol version.
 
 One of the decisions that will need to be made is what should happen to the
-authorization state of a pool trustline if one of it's corresponding asset
+authorization state of a pool trustline if one of its corresponding asset
 trustlines has authorization downgraded. We could either always check the
-asset trustlines authorization when checking the pool trustlines authorization,
+asset trustline's authorization when checking the pool trustline's authorization,
 or automatically update pool trustlines when the asset trustline changes. We need
 to make sure a pool trustline cannot be transferred to and redeemed by an account
 that has a deauthorized trustline to one of the assets in the pool.
@@ -1126,7 +1126,7 @@ If pool shares become transferable in future protocol versions, we can derive th
 actual authorization state of the pool trust line from the asset trust lines.
 
 ### Pool withdrawals are allowed when asset trust lines have AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG set
-It would be unfair to lock an accounts funds in a Liquidity Pool when they no
+It would be unfair to lock an account's funds in a Liquidity Pool when they no
 longer want to be a part of one. It's currently possible for an account to pull
 offers in the `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` state, so it makes sense
 to treat pool shares the same. An account in this state can withdraw from a pool,
@@ -1141,11 +1141,11 @@ trust lines using that asset and account back to the owner account if
 possible, and if not, into a claimable balance. The issuer can then use
 `ClawbackOp` or `ClawbackClaimableBalanceOp` to clawback the assets.
 
-### Alternative authorization revoke solution
-The current proposal forces a redeem of all referenced pool trust lines when an
+### Alternative authorization revocation solution
+The current proposal forces a redemption of all referenced pool trust lines when an
 asset trust line has its authorization revoked. There is an alternative to this
 solution.  We could instead require the issuer to revoke authorization on
-individual pool trust lines to force a redeem.  This approach will require the
+individual pool trust lines to force a redemption.  This approach will require the
 issuer to look up all pool trust lines for an asset trust line to perform the
 revoke.  It would also add an additional step when regulating assets for the
 issuer, so we would need to add an opt in flag for liquidity pools so issuers
@@ -1155,20 +1155,20 @@ This approach would be simpler to implement, and we wouldn't need to tie the
 lifetime of an asset trust line to a pool trust line like in this proposal, but
 it is not as user-friendly as the current proposal.
 
-### Why is the asset trust line required to exist for the lifetime of corresponding pool trust lines
+### Why the asset trust line is required to exist for the lifetime of corresponding pool trust lines
 This proposal introduces `TrustLineEntryExtensionV2.liquidityPoolUseCount`, which
 keeps track of the number of pool trust lines an asset trust line is used
 in. The extension is used to make sure the trust line is not deleted while
 corresponding pool trust lines exist. This is required because without the
 asset trust line, there is no way to deauthorize the trust line and force a
-redeem of the related pool shares.
+redemption of the related pool shares.
 
 This mechanism is not required for the native asset since a trust line is not
 required to hold the native asset, and the native asset is trustless.
 
 ### No Interleaved Execution
 This proposal uses `PathPaymentStrictSendOp` and `PathPaymentStrictReceiveOp` as
-a opaque interfaces to exchange on the Stellar network. These operations are
+opaque interfaces to exchange on the Stellar network. These operations are
 referred to as opaque interfaces because there is no way to specify how you want
 the exchange to execute. This approach is favorable because it requires no
 changes to clients that depend on exchange.


### PR DESCRIPTION
Some minor things I noticed when re-reading this CAP. 

Note: I suggested changing `revoke` to `revocation` and `redeem` to `redemption` when used as nouns, but if using `revoke` and `redeem` as nouns is a term of art, please ignore.