### PR TITLE
SEP-10: Add requirement that server should return only one JWT token for a challenge

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2021-03-04
-Version 3.2.0
+Version 3.3.0
 ```
 
 ## Simple Summary
@@ -199,6 +199,8 @@ Upon successful verification, **Server** responds with a session JWT, containing
 * `client_domain` - (optional) a nonstandard JWT claim containing the client home domain, included if the challenge transaction contained a `client_domain` (see [Verifying Client Application Identity](#verifying-client-application-identity))
 
 The JWT may contain other claims specific to your application, see [RFC7519].
+
+The **Server** should provide only a single session JWT for a specific challenge transaction.
 
 [Uniform Resource Identifier (URI)]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 [RFC7519]: https://tools.ietf.org/html/rfc7519

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2021-03-04
-Version 3.3.0
+Version 3.2.1
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,7 +6,7 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2021-03-04
+Updated: 2021-06-24
 Version 3.2.1
 ```
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -200,7 +200,7 @@ Upon successful verification, **Server** responds with a session JWT, containing
 
 The JWT may contain other claims specific to your application, see [RFC7519].
 
-The **Server** should provide only a single session JWT for a specific challenge transaction.
+The **Server** should not provide more than one JWT for a specific challenge transaction.
 
 [Uniform Resource Identifier (URI)]: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 [RFC7519]: https://tools.ietf.org/html/rfc7519


### PR DESCRIPTION
### What
Add a requirement to SEP-10 that the server should return only one JWT token for a given challenge, without prescribing exactly how that is achieved.

### Why
It is a best practice to not allow multiple authentication tokens be collected through a handshake process. While this SEP does not attempt to mention all best practices relating to JWTs and other things, I think it could be worth mentioning this one.

Realistically there is probably little someone could do with an average SEP-10 server, but it may be confusing if there are multiple JWTs that were all related to one challenge.

The change doesn't prescribe how to implement this because I don't think it is particularly important, at least not yet to force a particular implementation on an implementation. A server may implement this by making the JWT deterministic, such that subsequent requests for a token with a valid not-expired challenge return the exact same JWT. Or, a server may implement this by caching or storing challenges for which tokens have been issued and refusing to supply a token more than once. There are trade-offs with different approaches. The former doesn't prevent recollection but scales well, the latter requires storage and is harder to scale and operate.

The change is backwards compatible for any sensible client.