### PR TITLE
SEP-12: Clarify existing vs. provided fields

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -117,7 +117,8 @@ Name | Type | Description
 -----|------|------------
 `id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
 `status` | string | Status of the customers KYC process.
-`fields` | object | (optional) An object containing the fields for the given KYC type. See [fields](#fields) for more detailed information.
+`fields` | object | (optional) An object containing the fields the anchor has not yet received for the given customer of the `type` provided in the request. Required for customers in the `NEEDS_INFO` status. See [Fields](#fields) for more detailed information.
+`provided_fields` | object | (optional) An object containing the fields the anchor has received for the given customer. See [Provided Fields](#provided-fields) for more detailed information. Required for customers whose information needs verification via [`PUT /customer/verification`](#customer-put-verification).
 `message` | string | (optional) Human readable message describing the current state of customer's KYC process.
 
 ```js
@@ -125,7 +126,7 @@ Name | Type | Description
 {
    "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",
    "status": "ACCEPTED",
-   "fields": {
+   "provided_fields": {
       "first_name": {
          "description": "The customer's first name",
          "type": "string",
@@ -146,6 +147,37 @@ Name | Type | Description
 ```
 
 ```js
+// The case when a customer has provided some but not all required information
+{
+   "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",
+   "status": "NEEDS_INFO",
+   "fields": {
+      "mobile_number": {
+         "description": "phone number of the customer",
+         "type": "string"
+      },
+      "email_address": {
+         "description": "email address of the customer",
+         "type": "string",
+         "optional": true
+      }
+   },
+   "provided_fields": {
+      "first_name": {
+         "description": "The customer's first name",
+         "type": "string",
+         "status": "ACCEPTED"
+      },
+      "last_name": {
+         "description": "The customer's last name",
+         "type": "string",
+         "status": "ACCEPTED"
+      },
+   }
+}
+```
+
+```js
 // The case when an anchor requires info about an unknown customer 
 {
    "status": "NEEDS_INFO",
@@ -154,7 +186,6 @@ Name | Type | Description
          "description": "Email address of the customer",
          "type": "string"
          "optional": true,
-         "status": "NOT_PROVIDED"
       },
       "id_type": {
          "description": "Government issued ID",
@@ -164,14 +195,12 @@ Name | Type | Description
             "Drivers License",
             "State ID"
          ],
-         "status": "NOT_PROVIDED"
       },
       "photo_id_front": {
          "description": "A clear photo of the front of the government issued ID",
          "type": "binary",
-         "status": "NOT_PROVIDED"
       }
-   }
+   },
 }
 ```
 
@@ -181,7 +210,7 @@ Name | Type | Description
     "id": "46116754-695e-43f6-84c4-8c05e50a7b12",
     "status": "PROCESSING",
     "message": "Photo ID requires manual review. This process typically takes 1-2 business days.",
-    "fields": {
+    "provided_fields": {
       "photo_id_front": {
          "description": "A clear photo of the front of the government issued ID",
          "type": "binary",
@@ -200,18 +229,35 @@ Name | Type | Description
 }
 ```
 
+```js
+// the case when the anchor requires a verification code to be sent to the server
+{
+   "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",
+   "status": "NEEDS_INFO",
+   "provided_fields": {
+      "mobile_number": {
+         "description": "phone number of the customer",
+         "type": "string",
+         "status": "VERIFICATION_REQUIRED",
+      },
+   }
+}
+```
+
 #### Customer Statuses
 
 Status | Description
 -------|------------
-ACCEPTED | All required KYC fields have been accepted. It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list.
+ACCEPTED | All required KYC fields have been accepted and the customer has been validated for the `type` passed. It is possible for an accepted customer to move back to another status if the KYC provider determines it needs more info at a later date, or if the customer shows up on a sanctions list.
 PROCESSING | KYC process is in flight and client can check again in the future to see if any further info is needed.
 NEEDS_INFO | More info needs to be provided to finish KYC for this customer.  The `fields` entry is required in this case.
 REJECTED | This customer's KYC has failed and will never succeed.  The `message` must be supplied in this case.
 
 #### Fields
 
-The fields entry is required for the `NEEDS_INFO` status but may be included with any status. Fields should be specified as an object with keys representing the [SEP-9](sep-0009.md) field names required.
+The fields object defines the pieces of information the anchor has not yet received for the customer. It is required for the `NEEDS_INFO` status but may be included with any status. Fields should be specified as an object with keys representing the [SEP-9](sep-0009.md) field names required.
+
+Customers in the `ACCEPTED` status should not have any required fields present in the object, since all required fields should have already been provided.
 
 Property | Type | Description
 -----|------|------------
@@ -219,7 +265,18 @@ Property | Type | Description
 `description` | string | A human-readable description of this field, especially important if this is not a SEP-9 field.
 `choices` | array | (optional) An array of valid values for this field.
 `optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
-`status` | string | (optional) One of the values described in [Field Statuses](#field-statuses). If the server does not wish to expose which field(s) were accepted or rejected, this property can be omitted.
+
+#### Provided Fields
+
+The provided fields object defines the pieces of information the anchor has received for the customer. It is not required unless one or more of provided fields require verification via [`PUT /customer/verification`](#customer-put-verification).
+
+Property | Type | Description
+-----|------|------------
+`type` | enum | The data type of the field value. Can be `string`, `binary`, `number`, or `date`
+`description` | string | A human-readable description of this field, especially important if this is not a SEP-9 field.
+`choices` | array | (optional) An array of valid values for this field.
+`optional` | boolean | (optional) A boolean whether this field is required to proceed or not. Defaults to false.
+`status` | string | (optional) One of the values described in [Provided Field Statuses](#provided-field-statuses). If the server does not wish to expose which field(s) were accepted or rejected, this property can be omitted.
 `error` | string | (optional) The human readable description of why the field is `REJECTED`.
 
 #### Field Statuses
@@ -228,10 +285,8 @@ Status | Description
 -------|------------
 ACCEPTED | The field has been validated. When all required fields are accepted, the [Customer Status](#customer-statuses) should also be accepted.
 PROCESSING | The field is being validated. The client can make [GET /customer](#customer-get) requests to check on the result of this validation in the future.
-NOT_PROVIDED | The field has not been sent by the client. The field is required unless the `optional` property is `true`. The [Customer Status](#customer-statuses) should be `NEEDS_INFO` if a field is required but has not been provided.
 REJECTED | The field was in the `PROCESSING` status but did not pass validation. If the client may resubmit this field, the [Customer Status](#customer-statuses) should be `NEEDS_INFO`, otherwise it should be `REJECTED`.
 VERIFICATION_REQUIRED | The field must be verified using the [PUT /customer/verification](#customer-put-verification) endpoint. For example, the `mobile_number` field could be placed in this status until a confirmation code is sent to the customer and passed back to the this endpoint.
-
 
 #### Errors
 
@@ -352,19 +407,7 @@ For example:
 This endpoint allows servers to accept data values, usually confirmation codes, that verify a previously provided field via `PUT /customer`, such as `mobile_number` or `email_address`. Note that while fields such as `photo_proof_residence` or `notary_approval_of_photo_id` are verifications of other fields described in [SEP-9](#sep-0009.md), the server does not require the associated fields _before_ verification can be accomplished, so this endpoint would not be useful for such fields.
 
 Fields in the `VERIFICATION_REQUIRED` status require a request to this endpoint.
-```js
-{
-   "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",
-   "status": "NEEDS_INFO",
-   "fields": {
-      "mobile_number": {
-         "description": "phone number of the customer",
-         "type": "string",
-         "status": "VERIFICATION_REQUIRED",
-      },
-   }
-}
-```
+
 
 ### Request
 
@@ -389,6 +432,20 @@ Name | Type | Description
 Success responses should return a `200 Success` status as well as a body matching the [GET /customer](#customer-get) response schema. The field statuses for which verifications were sent must be updated to either `PROCESSING` or `ACCEPTED`.
 
 All error responses should contain details under the `error` key. If the `id` provide is not known, a `404` status should be returned. On any other client error, use a `400` status.
+
+```js
+{
+   "id": "d1ce2f48-3ff1-495d-9240-7a50d806cfed",
+   "status": "ACCEPTED",
+   "provided_fields": {
+      "mobile_number": {
+         "description": "phone number of the customer",
+         "type": "string",
+         "status": "ACCEPTED",
+      },
+   }
+}
+```
 
 ```json
 {

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-05-28
-Version 1.6.3
+Updated: 2021-06-24
+Version 1.7.0
 ```
 
 ## Abstract


### PR DESCRIPTION
resolves stellar/stellar-protocol#981

Changes:
- Clarifies `fields` to be an object containing SEP-9 fields that have not yet been collected by the anchor
- Adds `provided_fields` for SEP-9 fields that have been collected
- Moves field `status` and `error` properties from `fields` to `provided_fields`
- Removes `NOT_PROVIDED` as a value for field `status`

Open questions:

- Do we want to add a new `VERIFICATION_REQUIRED` customer-level status to better indicate what the anchor is waiting on?

`NEEDS_INFO` is primarily for indicating that the customer must provide more information detailed in `fields`. However, anchors that require verification of provided fields are instructed to use `NEEDS_INFO` as well. If all fields have been provided it may be confusing for the client to still see `NEEDS_INFO`. 

- What should the customer `status` be when multiple statuses apply to the customer's state? 

For example, an anchor could be `PROCESSING` a provided field but still need others (`NEEDS_INFO`) or needs a verification of another provided field `VERIFICATION_REQUIRED`.