### PR TITLE
SEP-38: fixes and improvements

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -174,7 +174,7 @@ This endpoint can be used to fetch the [indicative](https://www.investopedia.com
 
 These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-It is expected that the prices returned include a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds.
+The prices returned include any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, or other factors.
 
 #### Request
 
@@ -239,7 +239,7 @@ The client must provide either `sell_amount` or `buy_amount`, but not both.
 
 These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-It is expected that the price returned includes a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds.
+The price returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, or other factors.
 
 #### Request
 
@@ -325,7 +325,7 @@ Servers may deny access to the API if misuse is detected.
 
 #### Transaction Fees
 
-It is expected for the quote returned to include a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds and the delivery method.
+The quote returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, the delivery method, amount, or other factors.
 
 If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network. 
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -9,7 +9,7 @@ Status: Draft
 Created: 2021-04-09
 Updated: 2021-06-28
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.1.3
+Version 1.2.0
 ```
 
 ## Summary
@@ -172,9 +172,9 @@ Name | Type | Description
 
 This endpoint can be used to fetch the [indicative](https://www.investopedia.com/terms/i/indicativequote.asp) prices of available off-chain assets in exchange for a Stellar asset and vice versa.
 
-These prices are just indicatives provided at a given time, the actual price will be calculated according with the market price at conversion time, after the Anchor receives the funds from a User.
+These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-It is expected that the prices returned **include a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
+It is expected that the prices returned include a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds.
 
 #### Request
 
@@ -237,9 +237,9 @@ This endpoint can be used to fetch the indicative price for a given asset pair.
 
 The client must provide either `sell_amount` or `buy_amount`, but not both.
 
-These prices are just indicatives provided at a given time, the actual price will be calculated according with the market price at conversion time, after the Anchor receives the funds from a User.
+These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-It is expected that the price returned **includes a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
+It is expected that the price returned includes a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds.
 
 #### Request
 
@@ -325,7 +325,7 @@ Servers may deny access to the API if misuse is detected.
 
 #### Transaction Fees
 
-It is expected for the quote returned to **include a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds and the delivery method.
+It is expected for the quote returned to include a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds and the delivery method.
 
 If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network. 
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -368,10 +368,10 @@ Name | Type | Description
 `buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
 
-##### Examples
+##### Example
 
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+GET /quote?id=de762cda-a193-4961-861e-57b31fed6eb3
 ```
 
 ```json
@@ -381,50 +381,5 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
   "price": "5.42",
   "sell_amount": "500",
   "buy_amount": "92.25"
-}
-```
----
-```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
-```
-
-```json
-
-{
-  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
-  "expires_at": "2021-04-30T07:42:23",
-  "price": "5.42",
-  "sell_amount": "542",
-  "buy_amount": "100"
-}
-```
----
-```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
-```
-
-```json
-
-{
-  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
-  "expires_at": "2021-04-30T07:42:23",
-  "price": "0.18",
-  "sell_amount": "100",
-  "buy_amount": "555.56"
-}
-```
----
-```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
-```
-
-```json
-
-{
-  "id": "de762cda-a193-4961-861e-57b31fed6eb3",
-  "expires_at": "2021-04-30T07:42:23",
-  "price": "0.18",
-  "sell_amount": "90",
-  "buy_amount": "500"
 }
 ```

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -152,7 +152,7 @@ Name | Type | Description
       "delivery_methods": [
         {
           "name": "cash",
-          "description": "Deposit cash BRL to one of our payout locations."
+          "description": "Deposit cash BRL at one of our agent locations."
         },
         {
           "name": "ACH",

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -152,15 +152,15 @@ Name | Type | Description
       "delivery_methods": [
         {
           "name": "cash",
-          "description": "Pick up cash BRL at one of our payout locations."
+          "description": "Deposit cash BRL to one of our payout locations."
         },
         {
           "name": "ACH",
-          "description": "Have BRL sent directly to your bank account."
+          "description": "Send BRL directly to the Anchor's bank account."
         },
         {
           "name": "PIX",
-          "description": "Have BRL sent directly to the account of your choice."
+          "description": "Send BRL directly to the Anchor's bank account."
         }
       ]
     }

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -172,6 +172,8 @@ Name | Type | Description
 
 This endpoint can be used to fetch the [indicative](https://www.investopedia.com/terms/i/indicativequote.asp) prices of available off-chain assets in exchange for a Stellar asset and vice versa.
 
+These prices are just indicatives provided at a given time, the actual price will be calculated according with the market price at conversion time, after the Anchor receives the funds from a User.
+
 It is expected that the prices returned **include a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
 
 #### Request
@@ -234,6 +236,8 @@ GET /prices?sell_asset=iso4217:BRL
 This endpoint can be used to fetch the indicative price for a given asset pair.
 
 The client must provide either `sell_amount` or `buy_amount`, but not both.
+
+These prices are just indicatives provided at a given time, the actual price will be calculated according with the market price at conversion time, after the Anchor receives the funds from a User.
 
 It is expected that the price returned **includes a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -343,8 +343,10 @@ Name | Type | Description
 `id` | string | The unique identifier for the quote to be used in other Stellar Ecosystem Proposals (SEPs).
 `expires_at` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | The date and time by which the anchor must receive funds from the client.
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
-`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
+`sell_asset` | string | The asset the client would like to sell. Ex. `USDC:G...`, `iso4217:ARS`
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
+`buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
+`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
 
 ### GET Quote
 
@@ -365,8 +367,10 @@ Name | Type | Description
 `id` | string | The `id` specified in the request.
 `expires_at` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | The date and time by which the anchor must receive funds from the client.
 `price` | string | The price offered by the anchor for one unit of `buy_asset` in terms of `sell_asset`. In traditional finance, `buy_asset` would be referred to as the base asset and `sell_asset` as the counter asset.
-`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
+`sell_asset` | string | The asset the client would like to sell. Ex. `USDC:G...`, `iso4217:ARS`
 `sell_amount` | string | The amount of `sell_asset` to be exchanged for `buy_asset`.
+`buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
+`buy_amount` | string | The amount of `buy_asset` to be exchanged for `sell_asset`. `price * buy_amount = sell_amount` must be true up to the number of decimals required for `buy_asset`.
 
 ##### Example
 
@@ -379,7 +383,9 @@ GET /quote?id=de762cda-a193-4961-861e-57b31fed6eb3
   "id": "de762cda-a193-4961-861e-57b31fed6eb3",
   "expires_at": "2021-04-30T07:42:23",
   "price": "5.42",
+  "sell_asset": "iso4217:BRL",
   "sell_amount": "500",
+  "buy_asset": "stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&",
   "buy_amount": "92.25"
 }
 ```

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,14 +7,14 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-05-03
+Updated: 2021-06-28
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.1.2
+Version 1.1.3
 ```
 
 ## Summary
 
-This protocol enables anchors to accept off-chain assets in exchange for different on-chain assets, and vice versa. Specifically, it enables anchors to provide quotes that can referenced within the context of existing Stellar Ecosystem Proposals. How the exchange of assets is facilitated is outside the scope of this document.
+This protocol enables anchors to accept off-chain assets in exchange for different on-chain assets, and vice versa. Specifically, it enables anchors to provide quotes that can be referenced within the context of existing Stellar Ecosystem Proposals. How the exchange of assets is facilitated is outside the scope of this document.
 
 ## Motivation
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -172,6 +172,8 @@ Name | Type | Description
 
 This endpoint can be used to fetch the [indicative](https://www.investopedia.com/terms/i/indicativequote.asp) prices of available off-chain assets in exchange for a Stellar asset and vice versa.
 
+It is expected that the prices returned **include a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
+
 #### Request
 
 Name | Type | Description
@@ -232,6 +234,8 @@ GET /prices?sell_asset=iso4217:BRL
 This endpoint can be used to fetch the indicative price for a given asset pair.
 
 The client must provide either `sell_amount` or `buy_amount`, but not both.
+
+It is expected that the price returned **includes a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds.
 
 #### Request
 
@@ -317,7 +321,7 @@ Servers may deny access to the API if misuse is detected.
 
 #### Transaction Fees
 
-It should be expected that the provided quote includes a margin for the provider as a service fee, and this margin will vary depending on the directional flow of funds.
+It is expected for the quote returned to **include a margin for the provider as a service fee**, and this margin will vary depending on the directional flow of funds and the delivery method.
 
 If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network. 
 


### PR DESCRIPTION
### What

Make a few updates to SEP-38 for improved clarity and usability:
* Fix example response from the `GET /quote` request.
* Add parameters `sell_asset` and `buy_asset` to the responses from `GET /quote/{id}` because without these fields the request won't provide much valuable information
* Update the response from `POST /quote` to be consistent with the changes added to `GET /quote`
* Make it clear that fees are included in the prices from `GET /prices` and `GET /price`
* Add a statement about the indicative price being an estimate, so the actual price will be calculated at conversion time.
* Fix inconsistency between `delivery_methods` field description and examples.