### PR TITLE
SEP-38: distinguish sell/buy delivery methods for fee calculation

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -176,13 +176,18 @@ This endpoint can be used to fetch the [indicative](https://www.investopedia.com
 
 These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-The prices returned include any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, or other factors.
+The prices returned include any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, delivery method, country code, or other factors.
 
 #### Request
 
 Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
+`sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
+`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
+`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
+
 
 #### Response
 
@@ -202,7 +207,7 @@ Name | Type | Description
 
 
 ```
-GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sep=SEP-6&sell_amount=100
 ```
 
 ```json
@@ -218,7 +223,7 @@ GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAP
 ```
 ---
 ```
-GET /prices?sell_asset=iso4217:BRL
+GET /prices?sell_asset=iso4217:BRL&sep=SEP-6&sell_amount=500&country_code=BRA&delivery_method=PIX
 ```
 
 ```json

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -355,7 +355,7 @@ Name | Type | Description
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
 `sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
 `delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
-`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -24,6 +24,10 @@ Removing this requirement for anchors also provides downstream benefits to ecosy
 
 ## Specification
 
+## stellar.toml
+
+An anchor must define the location of their `ANCHOR_QUOTE_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
+
 ### Authentication
 
 All endpoints require authentication in the form of a [SEP-10](sep-0010.md) JSON Web Token (JWT) in the `Authorization` header of the request. 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,9 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-06-28
+Updated: 2021-06-30
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.2.0
+Version 1.3.0
 ```
 
 ## Summary

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -124,10 +124,11 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `asset` | string | The [Asset Identification Format](#asset-identification-format) value.
-`delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`client_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`anchor_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods an anchor can use to deliver funds to the client. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
 `country_codes` | array | (optional) Only for fiat assets. A list of [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes of the countries where the Anchor operates for fiat transactions.
 
-`delivery_methods` Object Schema
+`delivery_methods` Object Schema, used for both parameters `client_delivery_methods` and `anchor_delivery_methods`.
 
 Name | Type | Description
 -----|------|------------
@@ -151,7 +152,7 @@ Name | Type | Description
     {
       "asset": "iso4217:BRL",
       "country_codes": ["BRA"],
-      "delivery_methods": [
+      "client_delivery_methods": [
         {
           "name": "cash",
           "description": "Deposit cash BRL at one of our agent locations."
@@ -163,6 +164,20 @@ Name | Type | Description
         {
           "name": "PIX",
           "description": "Send BRL directly to the Anchor's bank account."
+        }
+      ],
+      "anchor_delivery_methods": [
+        {
+          "name": "cash",
+          "description": "Pick up cash BRL at one of our payout locations."
+        },
+        {
+          "name": "ACH",
+          "description": "Have BRL sent directly to your bank account."
+        },
+        {
+          "name": "PIX",
+          "description": "Have BRL sent directly to the account of your choice."
         }
       ]
     }
@@ -185,7 +200,8 @@ Name | Type | Description
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
 `sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
-`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -207,7 +223,7 @@ Name | Type | Description
 
 
 ```
-GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sep=SEP-6&sell_amount=100
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sep=SEP-6&sell_amount=100&country_code=BRA&anchor_delivery_method=ACH
 ```
 
 ```json
@@ -223,7 +239,7 @@ GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAP
 ```
 ---
 ```
-GET /prices?sell_asset=iso4217:BRL&sep=SEP-6&sell_amount=500&country_code=BRA&delivery_method=PIX
+GET /prices?sell_asset=iso4217:BRL&sep=SEP-6&sell_amount=500&country_code=BRA&client_delivery_method=PIX
 ```
 
 ```json
@@ -257,7 +273,8 @@ Name | Type | Description
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
 `sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
-`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -272,7 +289,7 @@ Name | Type | Description
 ##### Examples
 
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&sep=SEP-6&delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&sep=SEP-6&client_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -285,7 +302,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&sep=SEP-6&delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&sep=SEP-6&client_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -298,7 +315,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&sep=SEP-6&delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&sep=SEP-6&anchor_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -311,7 +328,7 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&sep=SEP-6&delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&sep=SEP-6&anchor_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -354,7 +371,8 @@ Name | Type | Description
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
 `sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
-`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -124,11 +124,11 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `asset` | string | The [Asset Identification Format](#asset-identification-format) value.
-`client_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
-`anchor_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods an anchor can use to deliver funds to the client. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`sell_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to sell/deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`buy_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to buy/retrieve funds from the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
 `country_codes` | array | (optional) Only for fiat assets. A list of [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes of the countries where the Anchor operates for fiat transactions.
 
-`delivery_methods` Object Schema, used for both parameters `client_delivery_methods` and `anchor_delivery_methods`.
+`delivery_methods` Object Schema, used for both parameters `sell_delivery_methods` and `buy_delivery_methods`.
 
 Name | Type | Description
 -----|------|------------
@@ -152,7 +152,7 @@ Name | Type | Description
     {
       "asset": "iso4217:BRL",
       "country_codes": ["BRA"],
-      "client_delivery_methods": [
+      "sell_delivery_methods": [
         {
           "name": "cash",
           "description": "Deposit cash BRL at one of our agent locations."
@@ -166,7 +166,7 @@ Name | Type | Description
           "description": "Send BRL directly to the Anchor's bank account."
         }
       ],
-      "anchor_delivery_methods": [
+      "buy_delivery_methods": [
         {
           "name": "cash",
           "description": "Pick up cash BRL at one of our payout locations."
@@ -199,8 +199,8 @@ Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
-`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -222,7 +222,7 @@ Name | Type | Description
 
 
 ```
-GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=100&country_code=BRA&anchor_delivery_method=ACH
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=100&country_code=BRA&buy_delivery_method=ACH
 ```
 
 ```json
@@ -238,7 +238,7 @@ GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAP
 ```
 ---
 ```
-GET /prices?sell_asset=iso4217:BRL&sell_amount=500&country_code=BRA&client_delivery_method=PIX
+GET /prices?sell_asset=iso4217:BRL&sell_amount=500&country_code=BRA&sell_delivery_method=PIX
 ```
 
 ```json
@@ -271,8 +271,8 @@ Name | Type | Description
 `buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
-`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -287,7 +287,7 @@ Name | Type | Description
 ##### Examples
 
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&client_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&sell_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -300,7 +300,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&client_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&sell_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -313,7 +313,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&anchor_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&buy_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -326,7 +326,7 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&anchor_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&buy_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -368,8 +368,8 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,7 +7,7 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-07-06
+Updated: 2021-07-08
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
 Version 1.3.0
 ```
@@ -24,7 +24,7 @@ Removing this requirement for anchors also provides downstream benefits to ecosy
 
 ## Specification
 
-## stellar.toml
+### stellar.toml
 
 An anchor must define the location of their `ANCHOR_QUOTE_SERVER` in their [`stellar.toml`](sep-0001.md). This is how a wallet knows where to find the anchor's server.
 
@@ -204,7 +204,7 @@ Name | Type | Description
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
 `sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -276,7 +276,7 @@ Name | Type | Description
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
 `sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -373,7 +373,7 @@ Name | Type | Description
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
 `sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,7 +7,7 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-07-08
+Updated: 2021-07-21
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
 Version 1.3.0
 ```

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -128,7 +128,7 @@ Name | Type | Description
 `buy_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to buy/retrieve funds from the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
 `country_codes` | array | (optional) Only for fiat assets. A list of [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes of the countries where the Anchor operates for fiat transactions.
 
-`delivery_methods` Object Schema, used for both parameters `sell_delivery_methods` and `buy_delivery_methods`.
+Object Schema for `sell_delivery_methods` and `buy_delivery_methods`.
 
 Name | Type | Description
 -----|------|------------

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -246,7 +246,7 @@ The client must provide either `sell_amount` or `buy_amount`, but not both.
 
 These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
-The price returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, or other factors.
+The price returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, delivery method, country code, or other factors.
 
 #### Request
 
@@ -256,6 +256,10 @@ Name | Type | Description
 `buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
+`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
+`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
+
 
 #### Response
 
@@ -268,7 +272,7 @@ Name | Type | Description
 ##### Examples
 
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&sep=SEP-6&delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -281,7 +285,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&sep=SEP-6&delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -294,7 +298,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&sep=SEP-6&delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -307,7 +311,7 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&sep=SEP-6&delivery_method=PIX&country_code=BRA
 ```
 
 ```json

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -324,9 +324,9 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
 
 ### POST Quote
 
-This endpoint can be used to request a [firm](https://www.investopedia.com/terms/f/firmquote.asp) quote for a Stellar asset and off-chain asset pair. 
+This endpoint can be used to request a [firm](https://www.investopedia.com/terms/f/firmquote.asp) quote for a Stellar asset and off-chain asset pair.
 
-In contrast with the `GET price(s)` endpoints, the amount requested must be held in reserve and not used in calculations of subsequent quotes until the expiration provided in the response.
+In contrast with the `GET /price` and `GET /prices` endpoints, the amount requested must be held in reserve and not used in calculations of subsequent quotes until the expiration provided in the response.
 
 #### Protecting Against Bad Actors
 
@@ -338,7 +338,7 @@ Servers may deny access to the API if misuse is detected.
 
 The quote returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, the delivery method, amount, or other factors.
 
-If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network. 
+If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network.
 
 In the reverse scenario, the anchor will submit a Stellar transaction to deliver funds to the client as long as the client delivered off-chain funds to the anchor before the expiration. In this case, the anchor will likely increase their margin to cover the cost of submitting the transaction.
 
@@ -394,7 +394,7 @@ Name | Type | Description
 ##### Example
 
 ```
-GET /quote?id=de762cda-a193-4961-861e-57b31fed6eb3
+GET /quote/de762cda-a193-4961-861e-57b31fed6eb3
 ```
 
 ```json

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -203,8 +203,8 @@ Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -275,8 +275,8 @@ Name | Type | Description
 `buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 
@@ -372,8 +372,8 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain deposit from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,7 +7,7 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-06-30
+Updated: 2021-07-06
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
 Version 1.3.0
 ```
@@ -199,7 +199,6 @@ Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
-`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
 `client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
 `anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
@@ -223,7 +222,7 @@ Name | Type | Description
 
 
 ```
-GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sep=SEP-6&sell_amount=100&country_code=BRA&anchor_delivery_method=ACH
+GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=100&country_code=BRA&anchor_delivery_method=ACH
 ```
 
 ```json
@@ -239,7 +238,7 @@ GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAP
 ```
 ---
 ```
-GET /prices?sell_asset=iso4217:BRL&sep=SEP-6&sell_amount=500&country_code=BRA&client_delivery_method=PIX
+GET /prices?sell_asset=iso4217:BRL&sell_amount=500&country_code=BRA&client_delivery_method=PIX
 ```
 
 ```json
@@ -272,7 +271,6 @@ Name | Type | Description
 `buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
-`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
 `client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
 `anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
@@ -289,7 +287,7 @@ Name | Type | Description
 ##### Examples
 
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&sep=SEP-6&client_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=500&client_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -302,7 +300,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&sep=SEP-6&client_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_amount=100&client_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -315,7 +313,7 @@ GET /price?sell_asset=iso4217:BRL&buy_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MO
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&sep=SEP-6&anchor_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&sell_amount=100&anchor_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -328,7 +326,7 @@ GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP
 ```
 ---
 ```
-GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&sep=SEP-6&anchor_delivery_method=PIX&country_code=BRA
+GET /price?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&buy_asset=iso4217:BRL&buy_amount=500&anchor_delivery_method=PIX&country_code=BRA
 ```
 
 ```json
@@ -370,7 +368,6 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
 `client_delivery_method` | string | (optional) One of the `name` values specified by the `client_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is making an off-chain deposit to the anchor.
 `anchor_delivery_method` | string | (optional) One of the `name` values specified by the `anchor_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an an off-chain deposit from the anchor.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -336,7 +336,7 @@ Servers may deny access to the API if misuse is detected.
 
 #### Transaction Fees
 
-The quote returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, the delivery method, amount, or other factors.
+The quote returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, the delivery method, amount, country code, or other factors.
 
 If the client requests some amount of an off-chain asset for providing some amount of a Stellar asset, the client will submit a Stellar transaction delievering funds to the anchor before the expiration included in the response, paying a fee as determined by state of the Stellar network.
 
@@ -353,7 +353,9 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from `GET /info`. If the array is not provided, this parameter is not required.
+`sep` | string | The name of the SEP that will be executing the quoted exchange. As of now, the ones that can make use of RFQ are `SEP-6` or `SEP-31`.
+`delivery_method` | string | (optional) One of the `name` values specified by the `delivery_methods` array for the associated asset returned from [`GET /info`](#info). If the array is not provided, this parameter is not required.
+`country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address.
 
 #### Response
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -125,6 +125,7 @@ Name | Type | Description
 -----|------|------------
 `asset` | string | The [Asset Identification Format](#asset-identification-format) value.
 `delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`country_codes` | array | (optional) Only for fiat assets. A list of [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes of the countries where the Anchor operates for fiat transactions.
 
 `delivery_methods` Object Schema
 
@@ -149,6 +150,7 @@ Name | Type | Description
     },
     {
       "asset": "iso4217:BRL",
+      "country_codes": ["BRA"],
       "delivery_methods": [
         {
           "name": "cash",


### PR DESCRIPTION
### What

1. Replace `delivery_methods` with `buy_delivery_methods` and `sell_delivery_methods`.
2. Update request parameters of `GET /price`, `GET /prices` and `POST /quote` endpoints so the fee can be accurately calculated with the new parameters provided:
    * `sell_delivery_method`
    * `buy_delivery_method`
    * `country_code`
2. Add `country_codes` parameter to the `GET /info` endpoint
4. Fix request example for `GET /quote`.