### PR TITLE
SEP: Update Team

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -175,7 +175,7 @@ From there, the following process will happen:
 
 ## SEP Team Members
 
-**SEP Team**: Tomer (SDF), Nikhil (SDF) Tom Q. (SDF), Michael (SDF), Alex (SDF), orbitlens, David (SDF), Jed
+**SEP Team**: Tomer (SDF), Nikhil (SDF), Leigh (SDF), Jake (SDF), Alex (SDF), orbitlens, David (SDF), Jed
 (SDF)
 
 [ietf]: https://ietf.org/

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -175,7 +175,13 @@ From there, the following process will happen:
 
 ## SEP Team Members
 
-**SEP Team**: Tomer (SDF), Nikhil (SDF), Leigh (SDF), Jake (SDF), Alex (SDF), orbitlens, David (SDF), Jed
-(SDF)
+- Tomer Weller <@tomerweller> (SDF)
+- Nikhil Saraf<@nikhilsaraf> (SDF)
+- Leigh McCulloch <@leighmcculloch> (SDF)
+- Jake Urban <@JakeUrban> (SDF)
+- Alex Cordeiro <@accordeiro> (SDF)
+- Orbit Lens <@orbitlens>
+- David Mazières <@stanford-scs> (SDF)
+- Jed McCaleb <@jedmccaleb> (SDF)
 
 [ietf]: https://ietf.org/


### PR DESCRIPTION
### What
Remove Tom Q from the SEP team, and add Leigh and Jake.

### Why
I'm not really sure the SEP team definition is as distinct or important as the CAP team is, but it looks out of date, and myself and Jake make decisions about state transitions of SEPs. It's possible we should remove this list of people all together, but that seems like a larger conversation to have and once updated the list does seem somewhat accurate indication of the people who will typically approve SEPs.