### PR TITLE
CAP-38: Use REVOKE_SPONSORSHIP_MALFORMED in more cases

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -986,7 +986,9 @@ In this proposal, `F = 0.003` which corresponds to 0.3% (this is encoded by
 #### RevokeSponsorshipOp
 This proposal adds a new result code `REVOKE_SPONSORSHIP_MALFORMED` for
 `RevokeSponsorshipOp`. This result code will be returned on validation if
-`RevokeSponsorshipOp.ledgerKey().type() == LIQUIDITY_POOL`.
+`RevokeSponsorshipOp.ledgerKey().type() == LIQUIDITY_POOL`. Additionally, all
+existing validation failures will now return `REVOKE_SPONSORSHIP_MALFORMED` for
+consistency.
 
 #### Ledger Header Flags
 This proposal also adds a `LedgerHeaderExtensionV1` that contains flags for


### PR DESCRIPTION
Improves the consistency of validation results for `RevokeSponsorshipOp`.