### PR TITLE
SEP: Add details about SEP versioning

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -139,6 +139,7 @@ From there, the following process will happen:
 * You should continue the discussion of the draft SEP on the mailing list to gather additional
   feedback. We welcome any additional PRs that iterate on the draft.
 * Keep the version of the SEP as a v0 version while in draft.
+* Increment the minor or patch versions on each change while in draft. See [SEP Versioning].
 
 ### Draft -> Awaiting Decision -> Final Comment Period (FCP)
 * When you're ready, you should submit a PR changing the status in the draft to `Awaiting Decision`.
@@ -164,6 +165,7 @@ From there, the following process will happen:
 * Ideally there will be a reference implementation exhibiting the behavior and value of the SEP before moving to active state.
 * Active SEPs should be brought into production by ecosystem members.
 * Minor changes may be made as more implementations are brought online highlighting any edge cases.
+* Increment the major, minor, or patch versions on each change. See [SEP Versioning].
 
 ### Active -> Final
 * Once the SEP team determines that an active SEP is complete, proven, and won't be extended, the SEP can move to `Final` status.
@@ -188,3 +190,4 @@ During draft a SEP should have a major version of `0` to indicate that anything 
 
 [ietf]: https://ietf.org/
 [semantic versioning]: https://semver.org/
+[SEP Versioning: #sep-versioning

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -164,8 +164,10 @@ From there, the following process will happen:
 * If no major concerns are brought up, the SEP is marked as `Active` and updated to version `v1.0.0` by your SEP buddy.
 * Ideally there will be a reference implementation exhibiting the behavior and value of the SEP before moving to active state.
 * Active SEPs should be brought into production by ecosystem members.
-* Minor changes may be made as more implementations are brought online highlighting any edge cases.
 * Increment the major, minor, or patch versions on each change. See [SEP Versioning].
+* Patch changes may be made to address bugs, errors, clarifications, or to fix errata.
+* Minor changes may be made as more implementations are brought online highlighting any edge cases.
+* Major changes, and breaking changes, should be considered with care as they may reduce interoperability.
 
 ### Active -> Final
 * Once the SEP team determines that an active SEP is complete, proven, and won't be extended, the SEP can move to `Final` status.

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -190,4 +190,4 @@ During draft a SEP should have a major version of `0` to indicate that anything 
 
 [ietf]: https://ietf.org/
 [semantic versioning]: https://semver.org/
-[SEP Versioning: #sep-versioning
+[SEP Versioning]: #sep-versioning

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -172,7 +172,8 @@ From there, the following process will happen:
 ### Active -> Final
 * Once the SEP team determines that an active SEP is complete, proven, and won't be extended, the SEP can move to `Final` status.
 * This promotion can only occur once there are multiple live implementations being used in production to ensure any edge cases or incompatibilities are found.
-* No changes will be made to a finalized SEP aside from fixing minor errata.
+* No changes will be made to a finalized SEP aside from fixing errata.
+* Changes should increment the the patch version number only.
 * Much consideration should be given before moving to Final status, it is OK for SEPs to live in Active status for a long time.
   
 ### Regression

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -120,6 +120,7 @@ repository. You should make sure to adhere to the following:
   `sep_{shorttitle}.md`, for example `sep_newaccountdeposit.md`
 * Make sure to place your SEP in the `ecosystem/` folder.
 * Include GitHub handles or emails for all authors listed.  GitHub handles are preferred.
+* Set the version to `v0.0.1`.
 
 Finally, submit a PR of your draft via your fork of this repository.
 
@@ -137,6 +138,7 @@ From there, the following process will happen:
     pushing the SEP towards a final disposition.
 * You should continue the discussion of the draft SEP on the mailing list to gather additional
   feedback. We welcome any additional PRs that iterate on the draft.
+* Keep the version of the SEP as a v0 version while in draft.
 
 ### Draft -> Awaiting Decision -> Final Comment Period (FCP)
 * When you're ready, you should submit a PR changing the status in the draft to `Awaiting Decision`.
@@ -158,7 +160,7 @@ From there, the following process will happen:
   along with the mailing list.
 
 ### FCP -> Active
-* If no major concerns are brought up, the SEP is marked as `Active` by your SEP buddy.
+* If no major concerns are brought up, the SEP is marked as `Active` and updated to version `v1.0.0` by your SEP buddy.
 * Ideally there will be a reference implementation exhibiting the behavior and value of the SEP before moving to active state.
 * Active SEPs should be brought into production by ecosystem members.
 * Minor changes may be made as more implementations are brought online highlighting any edge cases.
@@ -173,9 +175,16 @@ From there, the following process will happen:
 * It is possible for a SEP to move from `Active` to `Draft` or `Deprecated` if it is never adopted, or is abandoned by the community.
 * Regression of an active SEP occurs via the same process as a proposal (`Draft` -> `Awaiting Decision` -> `FCP` -> `Deprecated`)
 
+## SEP Versioning
+
+Unlike CAPs, SEPs are assigned versions because they are dynamic and change over time. SEPs use [semantic versioning] in the form `vMAJOR.MINOR.PATCH` to determine an appropriate version for each change.
+
+During draft a SEP should have a major version of `0` to indicate that anything in the SEP may change at anytime. Once a SEP moves to Active it should be changed to `v1.0.0` and the rules of semantic versioning apply.
+
 ## SEP Team Members
 
 **SEP Team**: Tomer (SDF), Nikhil (SDF) Tom Q. (SDF), Michael (SDF), Alex (SDF), orbitlens, David (SDF), Jed
 (SDF)
 
 [ietf]: https://ietf.org/
+[semantic versioning]: https://semver.org/

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -173,7 +173,7 @@ From there, the following process will happen:
 * Once the SEP team determines that an active SEP is complete, proven, and won't be extended, the SEP can move to `Final` status.
 * This promotion can only occur once there are multiple live implementations being used in production to ensure any edge cases or incompatibilities are found.
 * No changes will be made to a finalized SEP aside from fixing errata.
-* Changes should increment the the patch version number only.
+* Changes should increment the patch version number only.
 * Much consideration should be given before moving to Final status, it is OK for SEPs to live in Active status for a long time.
   
 ### Regression


### PR DESCRIPTION
### What
Add instructions about how to set the version number in SEPs.

### Why
We have no instructions for how to use versions, and that leads to some unfortunate situations during the draft state of a SEP. It's happened where we start a draft of a new SEP, start with v1, and then a little while later while it is still in draft we want to make a breaking change and need to change to v2. Drafts are intended to be a work-in-progress where unrestrained iteration is occurring, anything can change, and in semantic versioning that's what the v0 major version is intended for.