### PR TITLE
CAP-21: Update discussion URL

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -7,7 +7,7 @@ Author: David Mazières
 Status: Draft
 Created: 2019-05-24
 Updated: 2021-03-04
-Discussion: https://groups.google.com/forum/#!topic/stellar-dev/NtCwqWwAxRA
+Discussion: https://groups.google.com/g/stellar-dev/c/N8vzP2Mi89U
 Protocol version: TBD
 ```
 


### PR DESCRIPTION
### What
Update the discussion URL to the new mailing list thread.

### Why
The discussion URL is pointing to the old thread. The new mailing list thread is where all discussion is happening now.