### PR TITLE
CAP-40: Add proposal to add a ed25519 signed payload signer

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -68,7 +68,7 @@
 | [CAP-0032](cap-0032.md) | Trustline Preauthorization | Jonathan Jove | Draft |
 | [CAP-0037](cap-0037.md) | Automated Market Makers | OrbitLens | Draft |
 | [CAP-0039](cap-0039.md) | Not Auth Revocable Trustlines | Leigh McCulloch | Draft |
-| [CAP-0040](cap-0040.md) | Ed25519 Signed Hash Signer | Leigh McCulloch | Draft |
+| [CAP-0040](cap-0040.md) | Ed25519 Signed Payload Signer for Transaction Signature Disclosure | Leigh McCulloch | Draft |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/README.md
+++ b/core/README.md
@@ -68,6 +68,7 @@
 | [CAP-0032](cap-0032.md) | Trustline Preauthorization | Jonathan Jove | Draft |
 | [CAP-0037](cap-0037.md) | Automated Market Makers | OrbitLens | Draft |
 | [CAP-0039](cap-0039.md) | Not Auth Revocable Trustlines | Leigh McCulloch | Draft |
+| [CAP-0040](cap-0040.md) | Ed25519 Signed Hash Signer | Leigh McCulloch | Draft |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -138,9 +138,9 @@ signatures.
 Signature checking is changed to include verifying that any ed25519 signed hash
 signer's have matching signatures.
 
-Ed25519 signatures are verified by performing ed25519 signature verification
-using the signature, the hash from the signer, and the ed25519 public key from
-the signer.
+Ed25519 signed hash signer signatures are verified by performing ed25519
+signature verification using the signature, the hash from the signer, and the
+ed25519 public key from the signer.
 
 ## Design Rationale
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -215,7 +215,7 @@ The effort to verify the signature is equivalent to the effort to verify an
 ed25519 signature.
 
 The size of signers stored in the ledger would be twice the size, at 64 bytes,
-for ed25519 signed hash signers compared to 32bytes for all other signers.
+for ed25519 signed hash signers compared to 32 bytes for all other signers.
 
 ## Test Cases
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -71,7 +71,7 @@ This patch of XDR changes is based on the XDR files in tag `v17.2.0` of
 
 ```diff mddiffcheck.base=v17.2.0
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c20..77e72fc8 100644
+index 8f7d5c20..d4722ad1 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -19,6 +19,7 @@ enum CryptoKeyType
@@ -97,10 +97,10 @@ index 8f7d5c20..77e72fc8 100644
      /* Hash of random 256 bit preimage X */
      uint256 hashX;
 +case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
-+    /* Payload to be raw signed by ed25519. */
-+    opaque<32> payload;
 +    /* Public key that must sign the payload. */
 +    uint256 ed25519;
++    /* Payload to be raw signed by ed25519. */
++    opaque<32> payload;
  };
  
  // variable size as the size depends on the signature scheme used
@@ -118,14 +118,22 @@ used, including in `extraSigners<1>` added in [CAP-21].
 
 #### Signature
 
-The signature of a ed25519 signed payload signer is a raw ed25519 signature of
+The signature of a ed25519 signed payload signer is the raw ed25519 signature of
 the signer's payload using the private key that derives the signer's ed25519
 public key.
 
+The payload is signed raw. The payload is not hashed during signing, and the
+Stellar network ID is not incorporated into the payload during signing, so the
+signature is independent of the Stellar network ID.
+
+When the payload is a Stellar transaction hash, the network ID must already be
+hashed into the payload in the same way the network ID is hashed into Stellar
+transaction hashes for ed25519 signers.
+
 #### Signature Hint
 
-The signature hint of an ed25519 signed payload signer is the last 2 bytes of
-the payload concatenated with the last 2 bytes of the ed25519 public key.
+The signature hint of an ed25519 signed payload signer is the XOR of the last 4
+bytes of the payload and the last 4 bytes of the ed25519 public key.
 
 #### Transaction Envelopes
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -186,7 +186,7 @@ key is the public key of the receiving participant that must sign D_i and C_i.
 
 The effect of this change is the receiving participant must sign the hash of C_i
 to authorize D_i, embedding their signature for C_i into D_i. If the receiving
-participant neferaiously authorizes and submits D_i without sharing a signature
+participant nefariously authorizes and submits D_i without sharing a signature
 for C_i, the sender may extra the signature for C_i from the signatures on D_i
 and submit C_i.
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -187,8 +187,9 @@ key is the public key of the receiving participant that must sign D_i and C_i.
 The effect of this change is the receiving participant must sign the hash of C_i
 to authorize D_i, embedding their signature for C_i into D_i. If the receiving
 participant nefariously authorizes and submits D_i without sharing a signature
-for C_i, the sender may extract the signature for C_i from the signatures on D_i
-and submit C_i.
+for C_i, the sender who is watching the network may see D_i be submitted,
+extract the signature for C_i from the signatures on D_i, attach the signature
+to C_i, and submit C_i.
 
 ### Other Uses
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -9,7 +9,7 @@ Working Group:
     Consulted: Jon Jove <@jonjove>, David Mazières <@stanford-scs>
 Status: Draft
 Created: 2021-07-14
-Discussion: https://groups.google.com/g/stellar-dev/c/N8vzP2Mi89U
+Discussion: TBD
 Protocol version: TBD
 ```
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -2,7 +2,7 @@
 
 ```
 CAP: 0040
-Title: Ed25519 Signed Hash Signer
+Title: Ed25519 Signed Payload Signer for Transaction Signature Disclosure
 Working Group:
     Owner: Leigh McCulloch <@leighmcculloch>
     Authors: Leigh McCulloch <@leighmcculloch>
@@ -71,14 +71,14 @@ This patch of XDR changes is based on the XDR files in tag `v17.2.0` of
 
 ```diff mddiffcheck.base=v17.2.0
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c20..820d67ff 100644
+index 8f7d5c20..77e72fc8 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -19,6 +19,7 @@ enum CryptoKeyType
      KEY_TYPE_ED25519 = 0,
      KEY_TYPE_PRE_AUTH_TX = 1,
      KEY_TYPE_HASH_X = 2,
-+    KEY_TYPE_ED25519_SIGNED_HASH = 4,
++    KEY_TYPE_ED25519_SIGNED_PAYLOAD = 3,
      // MUXED enum values for supported type are derived from the enum values
      // above by ORing them with 0x100
      KEY_TYPE_MUXED_ED25519 = 0x100
@@ -88,7 +88,7 @@ index 8f7d5c20..820d67ff 100644
      SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
 -    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X
 +    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
-+    SIGNER_KEY_TYPE_ED25519_SIGNED_HASH = KEY_TYPE_ED25519_SIGNED_HASH
++    SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
  };
  
  union PublicKey switch (PublicKeyType type)
@@ -96,10 +96,10 @@ index 8f7d5c20..820d67ff 100644
  case SIGNER_KEY_TYPE_HASH_X:
      /* Hash of random 256 bit preimage X */
      uint256 hashX;
-+case SIGNER_KEY_TYPE_ED25519_SIGNED_HASH:
-+    /* Hash to be signed by ed25519. */
-+    uint256 hash;
-+    /* Public key that must sign data. */
++case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
++    /* Payload to be raw signed by ed25519. */
++    opaque<32> payload;
++    /* Public key that must sign the payload. */
 +    uint256 ed25519;
  };
  
@@ -108,38 +108,38 @@ index 8f7d5c20..820d67ff 100644
 
 ### Semantics
 
-This proposal introduces one new type of signer, the ed25519 signed hash signer,
-that is defined as a 32-byte hash and a ed25519 public key. A signature for the
-signer is the result of signing the hash with the private key that the public
-key is derived.
+This proposal introduces one new type of signer, the ed25519 signed payload
+signer, that is defined as a variable length opaque payload with a maximum size
+of 32 bytes and an ed25519 public key. A signature for the signer is the result
+of signing the payload with the private key that the public key is derived.
 
-The ed25519 signed hash signer is usable everywhere existing signers may be
+The ed25519 signed payload signer is usable everywhere existing signers may be
 used, including in `extraSigners<1>` added in [CAP-21].
 
 #### Signature
 
-The ed25519 signed hash signer signature is created by ed25519 signing the hash
-using the private key that derives the ed25519 public key in the signer.
+The signature of a ed25519 signed payload signer is a raw ed25519 signature of
+the signer's payload using the private key that derives the signer's ed25519
+public key.
 
 #### Signature Hint
 
-The signature hint of an ed25519 signed hash signer is the last 4 bytes of the
-sha256 hash of the concatenated bytes of the signers hash and ed25519 public
-key.
+The signature hint of an ed25519 signed payload signer is the last 2 bytes of
+the payload concatenated with the last 2 bytes of the ed25519 public key.
 
 #### Transaction Envelopes
 
 This proposal makes no structural changes to transaction envelopes other than
-the signature of an ed25519 hash signer may be included in the list of decorated
-signatures.
+the signature of an ed25519 signed payload signer may be included in the list of
+decorated signatures.
 
 #### Signature Checking
 
-Signature checking is changed to include verifying that any ed25519 signed hash
-signer's have matching signatures.
+Signature checking is changed to include verifying that any ed25519 signed
+payload signer's have matching signatures.
 
-Ed25519 signed hash signer signatures are verified by performing ed25519
-signature verification using the signature, the hash from the signer, and the
+Ed25519 signed payload signer signatures are verified by performing ed25519
+signature verification using the signature, the payload from the signer, and the
 ed25519 public key from the signer.
 
 ## Design Rationale
@@ -181,23 +181,25 @@ May be changed to:
 
 This simplified exchange would be implemented by requiring the sender of a
 payment to include in D_i the `extraSigners` precondition with an ed25519 signed
-hash signer where the hash is the transaction hash of C_i and the ed25519 public
-key is the public key of the receiving participant that must sign D_i and C_i.
+payload signer where the payload is the transaction hash of C_i and the ed25519
+public key is the public key of the receiving participant that must sign D_i and
+C_i.
 
-The effect of this change is the receiving participant must sign the hash of C_i
-to authorize D_i, embedding their signature for C_i into D_i. If the receiving
-participant nefariously authorizes and submits D_i without sharing a signature
-for C_i, the sender who is watching the network may see D_i be submitted,
-extract the signature for C_i from the signatures on D_i, attach the signature
-to C_i, and submit C_i.
+The effect of this change is the receiving participant must sign the transaction
+hash of C_i to authorize D_i, embedding their signature for C_i into D_i. If the
+receiving participant nefariously authorizes and submits D_i without sharing a
+signature for C_i, the sender who is watching the network may see D_i be
+submitted, extract the signature for C_i from the signatures on D_i, attach the
+signature to C_i, and submit C_i.
 
 ### Other Uses
 
 This new signer is likely to have other applications in scenarios similar to
 where HASH_X signers are currently used, except that the data revealed would not
 only be a hash shared by multiple transactions across multiple chains, but could
-be a signature for a transaction on another chain. However, this has limited use
-to only signatures of ed25519 keys.
+be a signature for a transaction on another chain, or a siganture for any other
+use. However, this has limited use to only signatures of ed25519 keys as
+specified.
 
 ## Protocol Upgrade Transition
 
@@ -215,7 +217,7 @@ The effort to verify the signature is equivalent to the effort to verify an
 ed25519 signature.
 
 The size of signers stored in the ledger would be twice the size, at 64 bytes,
-for ed25519 signed hash signers compared to 32 bytes for all other signers.
+for ed25519 signed payload signers compared to 32 bytes for all other signers.
 
 ## Test Cases
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -158,8 +158,8 @@ first transaction is authorized and submitted.
 
 This proposal makes this possible when the signer is used with the
 `extraSigners` precondition introduced in [CAP-21], and does so without
-introducing any state new state to be stored on the ledger, allowing the signing
-dependency to exist without any new ledger state.
+introducing any new state to be stored on the ledger, allowing the signing
+dependency to exist without creating ledger entries.
 
 While it is possible to achieve a similar effect of this proposal with the
 existing protocol by using the preauth transaction signer, use of that signer

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -211,7 +211,7 @@ No substantial changes to resource utilization.
 
 The size of signatures, and therefore transactions, remain the same.
 
-The effort to verify the signature is equivalen to the effort to verify an
+The effort to verify the signature is equivalent to the effort to verify an
 ed25519 signature.
 
 The size of signers stored in the ledger would be twice the size, at 64 bytes,

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -209,7 +209,7 @@ This proposal is backwards compatible.
 
 No substantial changes to resource utilization.
 
-The size of signatures remains the same.
+The size of signatures, and therefore transactions, remain the same.
 
 The effort to verify the signature is equivalen to the effort to verify an
 ed25519 signature.

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -123,8 +123,9 @@ using the private key that derives the ed25519 public key in the signer.
 
 #### Signature Hint
 
-The signature hint of an ed25519 signed hash signer is a sha256 hash of the
-signers hash and ed25519 public key bytes concatenated.
+The signature hint of an ed25519 signed hash signer is the last 4 bytes of the
+sha256 hash of the concatenated bytes of the signers hash and ed25519 public
+key.
 
 #### Transaction Envelopes
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -34,7 +34,10 @@ multi-party contracts, such as payment channels, to be implemented where a
 relative time delay must occur between two transactions that have been mutually
 agreed by all parties to the contract.
 
-Signing a batch of transactions in contracts that have a time delay as specified in [CAP-21] requires participants to exchange signatures for each transaction across multiple-steps, exchanging the signatures for the transactions in reverse order that they can be executed.
+Signing a batch of transactions in contracts that have a time delay as specified
+in [CAP-21] requires participants to exchange signatures for each transaction
+across multiple-steps, exchanging the signatures for the transactions in reverse
+order that they can be executed.
 
 A party must not share their signature for an earlier transaction before
 receiving all signatures for lattertransactions otherwise another party may be
@@ -48,7 +51,9 @@ increases significantly for payment channel implementations that are
 asynchronous or payment channels where receiving participants are allowed to
 fall behind confirming payments from a sending participant.
 
-Making it safe for parties of a contract to exchange all signatures for a batch of transactions in a single message without risk that only a subset of the transactions could be authorized simplifies payment channel implementations.
+Making it safe for parties of a contract to exchange all signatures for a batch
+of transactions in a single message without risk that only a subset of the
+transactions could be authorized simplifies payment channel implementations.
 
 ### Goals Alignment
 
@@ -140,7 +145,9 @@ the signer.
 
 ## Design Rationale
 
-This proposal provides a primitive that makes it possible to construct a batch of transactions where all transactions can be authorized and submitted if the first transaction is authorized and submitted.
+This proposal provides a primitive that makes it possible to construct a batch
+of transactions where all transactions can be authorized and submitted if the
+first transaction is authorized and submitted.
 
 This proposal makes this possible when the signer is used with the
 `extraSigners` precondition introduced in [CAP-21], and does so without

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -1,0 +1,225 @@
+## Preamble
+
+```
+CAP: 0040
+Title: Ed25519 Signed Hash Signer
+Working Group:
+    Owner: Leigh McCulloch <@leighmcculloch>
+    Authors: Leigh McCulloch <@leighmcculloch>
+    Consulted: Jon Jove <@jonjove>, David Mazières <@stanford-scs>
+Status: Draft
+Created: 2021-07-14
+Discussion: https://groups.google.com/g/stellar-dev/c/N8vzP2Mi89U
+Protocol version: TBD
+```
+
+## Simple Summary
+
+This proposal adds a new signer type that simplifies the signing process that
+multiple parties must use in some contracts, such as payment channels, by
+allowing all parties to share a batch of transactions for signing and
+guaranteeing that if one transaction is signed, authorized, and submitted that
+information is revealed that allows all other transactions in the batch to be
+authorized.
+
+## Working Group
+
+This protocol change was authored by Leigh McCulloch, with input from the
+consulted individuals mentioned at the top of this document.
+
+## Motivation
+
+[CAP-21] adds transaction precondition primitives that make it possible for
+multi-party contracts, such as payment channels, to be implemented where a
+relative time delay must occur between two transactions that have been mutually
+agreed by all parties to the contract.
+
+Signing a batch of transactions in contracts that have a time delay as specified in [CAP-21] requires participants to exchange signatures for each transaction across multiple-steps, exchanging the signatures for the transactions in reverse order that they can be executed.
+
+A party must not share their signature for an earlier transaction before
+receiving all signatures for lattertransactions otherwise another party may be
+able to submit that earlier transaction and lock the contract by refusing to
+authorize a latter transaction.
+
+In the payment channel designs identified in the design rationale of [CAP-21]
+this requires participants to exchange signatures across at least three
+messages. This coordination increases implementation complexity. This complexity
+increases significantly for payment channel implementations that are
+asynchronous or payment channels where receiving participants are allowed to
+fall behind confirming payments from a sending participant.
+
+Making it safe for parties of a contract to exchange all signatures for a batch of transactions in a single message without risk that only a subset of the transactions could be authorized simplifies payment channel implementations.
+
+### Goals Alignment
+
+This CAP is aligned with the following Stellar Network Goals:
+
+- The Stellar Network should make it easy for developers of Stellar projects to
+create highly usable products
+
+## Specification
+
+### XDR Changes
+
+This patch of XDR changes is based on the XDR files in tag `v17.2.0` of
+[stellar-core].
+
+```diff mddiffcheck.base=v17.2.0
+diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
+index 8f7d5c20..820d67ff 100644
+--- a/src/xdr/Stellar-types.x
++++ b/src/xdr/Stellar-types.x
+@@ -19,6 +19,7 @@ enum CryptoKeyType
+     KEY_TYPE_ED25519 = 0,
+     KEY_TYPE_PRE_AUTH_TX = 1,
+     KEY_TYPE_HASH_X = 2,
++    KEY_TYPE_ED25519_SIGNED_HASH = 4,
+     // MUXED enum values for supported type are derived from the enum values
+     // above by ORing them with 0x100
+     KEY_TYPE_MUXED_ED25519 = 0x100
+@@ -33,7 +34,8 @@ enum SignerKeyType
+ {
+     SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+     SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
+-    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X
++    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
++    SIGNER_KEY_TYPE_ED25519_SIGNED_HASH = KEY_TYPE_ED25519_SIGNED_HASH
+ };
+ 
+ union PublicKey switch (PublicKeyType type)
+@@ -52,6 +54,11 @@ case SIGNER_KEY_TYPE_PRE_AUTH_TX:
+ case SIGNER_KEY_TYPE_HASH_X:
+     /* Hash of random 256 bit preimage X */
+     uint256 hashX;
++case SIGNER_KEY_TYPE_ED25519_SIGNED_HASH:
++    /* Hash to be signed by ed25519. */
++    uint256 hash;
++    /* Public key that must sign data. */
++    uint256 ed25519;
+ };
+ 
+ // variable size as the size depends on the signature scheme used
+```
+
+### Semantics
+
+This proposal introduces one new type of signer, the ed25519 signed hash signer,
+that is defined as a 32-byte hash and a ed25519 public key. A signature for the
+signer is the result of signing the hash with the private key that the public
+key is derived.
+
+The ed25519 signed hash signer is usable everywhere existing signers may be
+used, including in `extraSigners<1>` added in [CAP-21].
+
+#### Signature
+
+The maximum size of signatures remains unchanged.
+
+The ed25519 signed hash signer signature is created by ed25519 signing the hash
+using the private key that derives the ed25519 public key in the signer.
+
+#### Signature Hint
+
+The signature hint of an ed25519 signed hash signer is a sha256 hash of the
+signers hash and ed25519 public key bytes concatenated.
+
+#### Transaction Envelopes
+
+This proposal makes no structural changes to transaction envelopes other than
+the signature of an ed25519 hash signer may be included in the list of decorated
+signatures.
+
+#### Signature Checking
+
+Signature checking is changed to include verifying that any ed25519 signed hash
+signer's have matching signatures.
+
+Ed25519 signatures are verified by performing ed25519 signature verification
+using the signature, the hash from the signer, and the ed25519 public key from
+the signer.
+
+## Design Rationale
+
+This proposal provides a primitive that makes it possible to construct a batch of transactions where all transactions can be authorized and submitted if the first transaction is authorized and submitted.
+
+This proposal makes this possible when the signer is used with the
+`extraSigners` precondition introduced in [CAP-21], and does so without
+introducing any state new state to be stored on the ledger, allowing the signing
+dependency to exist without any new ledger state.
+
+While it is possible to achieve a similar effect of this proposal with the
+existing protocol by using the preauth transaction signer, use of that signer
+requires creating a new ledger entry which is impractical in contracts with
+multiple iterations.
+
+The maximum size of the batch of transactions is two, limited to being one more
+than the maximum number of `extraSigners` specified in [CAP-21], currently one,
+and can be increased past two if the maximum size of `extraSigners` is changed.
+
+### Payment Channels
+
+In the payment channel designs specified in [CAP-21] this proposal simplifies
+the requirements on when participants may exchange signatures for transactions.
+
+The following paragraph in CAP-21:
+
+>To update the payment channel state, the parties 1) increment i, 2)
+>sign and exchange a closing transaction C_i, and finally 3) sign and
+>exchange a declaration transaction D_i.
+
+May be changed to:
+
+>To update the payment channel state, the parties 1) increment i, 2)
+>sign and exchange a closing transaction C_i and declaration
+>transaction D_i.
+
+This simplified exchange would be implemented by requiring the sender of a
+payment to include in D_i the `extraSigners` precondition with an ed25519 signed
+hash signer where the hash is the transaction hash of C_i and the ed25519 public
+key is the public key of the receiving participant that must sign D_i and C_i.
+
+The effect of this change is the receiving participant must sign the hash of C_i
+to authorize D_i, embedding their signature for C_i into D_i. If the receiving
+participant neferaiously authorizes and submits D_i without sharing a signature
+for C_i, the sender may extra the signature for C_i from the signatures on D_i
+and submit C_i.
+
+### Other Uses
+
+This new signer is likely to have other applications in scenarios similar to
+where HASH_X signers are currently used, except that the data revealed would not
+only be a hash shared by multiple transactions across multiple chains, but could
+be a signature for a transaction on another chain. However, this has limited use
+to only signatures of ed25519 keys.
+
+## Protocol Upgrade Transition
+
+### Backwards Incompatibilities
+
+This proposal is backwards compatible.
+
+### Resource Utilization
+
+No substantial changes to resource utilization.
+
+The size of signatures remains the same.
+
+The effort to verify the signature is equivalen to the effort to verify an
+ed25519 signature.
+
+The size of signers stored in the ledger would be twice the size, at 64 bytes,
+for ed25519 signed hash signers compared to 32bytes for all other signers.
+
+## Test Cases
+
+None yet.
+
+## Security Concerns
+
+None known.
+
+## Implementation
+
+None yet.
+
+[CAP-21]: ./cap-0021.md

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -122,13 +122,15 @@ The signature of a ed25519 signed payload signer is the raw ed25519 signature of
 the signer's payload using the private key that derives the signer's ed25519
 public key.
 
-The payload is signed raw. The payload is not hashed during signing, and the
-Stellar network ID is not incorporated into the payload during signing, so the
-signature is independent of the Stellar network ID.
+Unlike other signatures in the Stellar protocol, the payload is not combined
+with the network ID or hashed before passing it to the ed25519 signing
+algorithm.
 
-When the payload is a Stellar transaction hash, the network ID must already be
-hashed into the payload in the same way the network ID is hashed into Stellar
-transaction hashes for ed25519 signers.
+To represent another Stellar transaction as the the payload field of a Ed25519
+signed payload signer, you must first place the transaction in a
+`TransactionSignaturePayload` and hash that. The resulting signature will be a
+ed25519 signature of the other Stellar transaction that could be attached to the
+other transaction.
 
 #### Signature Hint
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -40,7 +40,7 @@ across multiple-steps, exchanging the signatures for the transactions in reverse
 order that they can be executed.
 
 A party must not share their signature for an earlier transaction before
-receiving all signatures for lattertransactions otherwise another party may be
+receiving all signatures for latter transactions otherwise another party may be
 able to submit that earlier transaction and lock the contract by refusing to
 authorize a latter transaction.
 
@@ -117,8 +117,6 @@ The ed25519 signed hash signer is usable everywhere existing signers may be
 used, including in `extraSigners<1>` added in [CAP-21].
 
 #### Signature
-
-The maximum size of signatures remains unchanged.
 
 The ed25519 signed hash signer signature is created by ed25519 signing the hash
 using the private key that derives the ed25519 public key in the signer.

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -187,7 +187,7 @@ key is the public key of the receiving participant that must sign D_i and C_i.
 The effect of this change is the receiving participant must sign the hash of C_i
 to authorize D_i, embedding their signature for C_i into D_i. If the receiving
 participant nefariously authorizes and submits D_i without sharing a signature
-for C_i, the sender may extra the signature for C_i from the signatures on D_i
+for C_i, the sender may extract the signature for C_i from the signatures on D_i
 and submit C_i.
 
 ### Other Uses


### PR DESCRIPTION
### What
Add a proposal to add an ed25519 signed hash signer for use alongside the precondition primitives, specifically the `extraSigners` precondition, that are proposed in CAP-21.

### Why
See within the document.

Close stellar/experimental-payment-channels#165