### PR TITLE
CAP-40: Add discussion URL

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -9,7 +9,7 @@ Working Group:
     Consulted: Jon Jove <@jonjove>, David Mazières <@stanford-scs>
 Status: Draft
 Created: 2021-07-14
-Discussion: TBD
+Discussion: https://groups.google.com/g/stellar-dev/c/Wp7gNaJvt40
 Protocol version: TBD
 ```
 


### PR DESCRIPTION
### What
Add discussion URL to CAP-40.

### Why
There is now a mailing list discussion thread for the CAP.