### PR TITLE
CAP-40: Update max size of transaction batch to 3

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -168,9 +168,10 @@ existing protocol by using the preauth transaction signer, use of that signer
 requires creating a new ledger entry which is impractical in contracts with
 multiple iterations.
 
-The maximum size of the batch of transactions is two, limited to being one more
-than the maximum number of `extraSigners` specified in [CAP-21], currently one,
-and can be increased past two if the maximum size of `extraSigners` is changed.
+The maximum size of the batch of transactions is three, limited to being one
+more than the maximum number of `extraSigners` specified in [CAP-21], currently
+two, and can be increased past three if the maximum size of `extraSigners` is
+changed.
 
 ### Payment Channels
 


### PR DESCRIPTION
### What
Update the max size of the transaction batch to 3.

### Why
CAP-21 has been updated to support a max length of 2 in extraSigners.