### PR TITLE
CAP-40: Fix ed25519 signed payload signer key xdr

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -71,7 +71,7 @@ This patch of XDR changes is based on the XDR files in tag `v17.2.0` of
 
 ```diff mddiffcheck.base=v17.2.0
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c20..d4722ad1 100644
+index 8f7d5c20..3301ca17 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -19,6 +19,7 @@ enum CryptoKeyType
@@ -92,15 +92,17 @@ index 8f7d5c20..d4722ad1 100644
  };
  
  union PublicKey switch (PublicKeyType type)
-@@ -52,6 +54,11 @@ case SIGNER_KEY_TYPE_PRE_AUTH_TX:
+@@ -52,6 +54,13 @@ case SIGNER_KEY_TYPE_PRE_AUTH_TX:
  case SIGNER_KEY_TYPE_HASH_X:
      /* Hash of random 256 bit preimage X */
      uint256 hashX;
 +case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
-+    /* Public key that must sign the payload. */
-+    uint256 ed25519;
-+    /* Payload to be raw signed by ed25519. */
-+    opaque<32> payload;
++    struct {
++        /* Public key that must sign the payload. */
++        uint256 ed25519;
++        /* Payload to be raw signed by ed25519. */
++        opaque payload<32>;
++    } ed25519SignedPayload;
  };
  
  // variable size as the size depends on the signature scheme used


### PR DESCRIPTION
### What
Wrap the ed25519 signed payload signer key fields in a struct in the union.

### Why
There can only be a single value in each case of the union.