### PR TITLE
CAP-40: Change hint to the hint of the ed25519

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -136,8 +136,8 @@ other transaction.
 
 #### Signature Hint
 
-The signature hint of an ed25519 signed payload signer is the XOR of the last 4
-bytes of the payload and the last 4 bytes of the ed25519 public key.
+The signature hint of an ed25519 signed payload signer is signature hint of its
+ed25519 public key.
 
 #### Transaction Envelopes
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -136,8 +136,8 @@ other transaction.
 
 #### Signature Hint
 
-The signature hint of an ed25519 signed payload signer is signature hint of its
-ed25519 public key.
+The signature hint of an ed25519 signed payload signer is the signature hint of
+its ed25519 public key.
 
 #### Transaction Envelopes
 


### PR DESCRIPTION
### What
Change the signature hint of the signed payload to be the same hint as the ed25519 public key within the signed payload.

### Why
For two reasons:

1. In all existing signers the hint is derivable from both the public information and the secret information.

   For example:
   - An ed25519 signer's hint can be derived from the public key, or from the secret key by first deriving the public key from the secret key, then the hint from the public key.
   - A hash(x) signer's hint can be derived from the public hash(x), or from the secret x by first hashing x, then deriving the hint from the hash.

   The way that the signature hint is defined as being an xor of both the ed25519 public key and the payload means that code that intends to calculate the hint needs to know not only the secret component, the ed25519 secret key, but also the payload. This is inconvenient because hint generation is normally grouped with key code and types, and doesn't normally store state about the payloads being signed. While this is an implementation detail, there is increased simplicity in maintaining that all hints can be derived from their public and secret keys.

2. The intent is to use CAP-40 for transaction disclosure where the signatures for one transaction can be disclosed on another. By using the same hint as a regular signer we make the entire decorated signature copyable to the other transactions.