### PR TITLE
SEP-10: Advise servers to set minTime in the past

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -121,7 +121,9 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
 * `transaction`: an XDR-encoded Stellar transaction with the following:
   * source account set to the **Server Account**
   * invalid sequence number (set to 0) so the transaction cannot be run on the Stellar network
-  * time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of 15 minutes to give the **Client** time to sign transaction)
+  * time bounds: `{min: now() - 300, max: now() + 900 }`
+    * We recommend expiration of 15 minutes to give the **Client** time to sign transaction
+    * We recommend setting the min time to 5 minutes in the past, in case the **Client**'s clock is slightly behind the **Server**'s
   * operations:
     * `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
       * The source account is the **Client Account**


### PR DESCRIPTION
Currently, we ask SEP-10 implementors to set the minTime of their challenge transaction to now(). But if the server's clock is ahead of a client's clock, the client could try to validate the server's transaction, and validation would fail because their clock is faster than the transaction's minTime.
To fix this, we suggest setting the minTime to 5 minutes before now().