### PR TITLE
ChangeTrustResultCode negative values in CAP-38

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -570,8 +570,8 @@ index 75f39eb4e..754c11845 100644
 -    CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
 +    CHANGE_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
 +    CHANGE_TRUST_TRUST_LINE_MISSING = -6, // Asset trustline is missing for pool
-+    CHANGE_TRUST_CANNOT_DELETE = 7, // Asset trustline is still referenced in a pool
-+    CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES = 8 // Asset trustline is deauthorized
++    CHANGE_TRUST_CANNOT_DELETE = -7, // Asset trustline is still referenced in a pool
++    CHANGE_TRUST_NOT_AUTH_MAINTAIN_LIABILITIES = -8 // Asset trustline is deauthorized
  };
  
  union ChangeTrustResult switch (ChangeTrustResultCode code)


### PR DESCRIPTION
The values are also propagated to Stellar-Core code: https://github.com/stellar/stellar-core/compare/v17.2.0...v17.3.0rc1#diff-11f6a6577ee4d25e4eb1b1834bd71486cc73c26ad4eda68345286a27f5d74307R999-R1000