### PR TITLE
CAP-40: Make hint the xor of public key and payload

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -136,8 +136,8 @@ other transaction.
 
 #### Signature Hint
 
-The signature hint of an ed25519 signed payload signer is the signature hint of
-its ed25519 public key.
+The signature hint of an ed25519 signed payload signer is the last 4 bytes of
+the ed25519 public key XORed with last 4 bytes of the payload.
 
 #### Transaction Envelopes
 


### PR DESCRIPTION
### What
Make the hint of the signer the xor of the last 4 bytes of the public key and the last 4 bytes of the payload.

### Why
@stanford-scs pointed out that in the use cases we plan to use the new signer there would almost always be two sigantures using the public key on the transaction, one a regular signature, and one a payload signature. It isn't great if applications verification signatures have to verify 2x the signatures for every one of these transactions simply because the payload signature uses the same hint.

It is inconvenient for applications to make the hint not the same as the public key's hint because it will not be as simple as copying the decorated signature from one transaction with the payload to the transaction the payload signature disclosed. But that inconvenience is not insurmountable.