### PR TITLE
CAP-40: Address short payload cases

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -137,7 +137,9 @@ other transaction.
 #### Signature Hint
 
 The signature hint of an ed25519 signed payload signer is the last 4 bytes of
-the ed25519 public key XORed with last 4 bytes of the payload.
+the ed25519 public key XORed with last 4 bytes of the payload. If the payload
+has a length less than 4 bytes, then 1 to 3 zero bytes are appended to the
+payload such that it has a length of 4 bytes, for calculating the hint.
 
 #### Transaction Envelopes
 


### PR DESCRIPTION
### What
Define for the signature hint of the signer introduced by CAP-40's what happens if the payload is less than 4 bytes, stating that zero bytes are appended to make it 4 bytes just for the calculation of the hint.

### Why
This case is not particularly likely given that the use cases for payloads is to use the full 32 bytes, but I think the definition of the hint should be complete and cover all cases none-the-less.

For https://github.com/stellar/experimental-payment-channels/issues/196