### PR TITLE
SEP-23: Rework to be a standalone specification for strkeys

### DIFF
--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -2,52 +2,48 @@
 
 ```
 SEP: 0023
-Title: Muxed Account Strkeys
+Title: Strkeys
 Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Alfonso Acosta <@2opremio>
 Track: Standard
 Status: Active
 Created: 2019-09-16
-Updated: 2021-06-02
-Version: 1.0.0
+Updated: 2021-07-23
+Version: 1.0.1
 Discussion: https://groups.google.com/forum/#!forum/stellar-dev
 ```
 
 ## Simple Summary
 
 Strkey is an ASCII format for representing Stellar account IDs and
-addresses.  This document introduces augmented strkey to represent
-account IDs for multiplexed addresses introduced by CAP-0027.
+addresses.
 
 ## Motivation
 
-A common pattern in the Stellar ecosystem is for services to share a
-single Stellar account ID across many users or independent
-transactions, relying on the memo ID to disambiguate incoming
-payments.  CAP-0027 introduced the `MuxedAccount` type, which allows
-an address to be paired with a 64-bit ID.  This document extends the
-Strkey format to allow the specification of an arbitrary
-`MuxedAccount` as a string.  If widely adopted by the ecosystem, users
-will be able to use custodial services and exchanges in much the same
-way as wallets, by specifying a `MuxedAccount` instead of a separate
-`AccountID` and `Memo`.
+A canonical representation for encoding Stellar account IDs, muxed
+accounts, and other signers of Stellar transactions and accounts
+improves interoperability. Applications in the Stellar ecosystem may
+refer to an account, a muxed account, or a signer, using a common format
+and therefore understand each other. Strkeys are used widely in other
+SEPs.
 
 ## Abstract
 
-A new strkey format is introduced to represent both the public key and
-64-bit ID of a `MuxedAccount`, as specified in CAP-0027.
+Strkey is an ASCII encoding for Stellar account IDs, muxed accounts, and
+signers. Applications may reliably encode or decode a Strkey with each account
+having a single valid representation.
 
 ## Specification
 
 Strkey, the ASCII encoding for accounts, keys, and signers, currently
-covers covered ED25519 public keys, ED25519 private keys (also known
-as seeds), pre-authorized transaction hashes, and hash-x signers
-(which provide signing authority upon revelation of a SHA-256
-preimage). We make two changes:  First, we add a new type of strkey
-for multiplexed account IDs, represented by a new value in the top 5
-bits of the version byte, which is the 8 bits of the key.  The
-possible "base" values (top 5 bits) of the version byte, which
-determine the first character of the base-32 encoding of the key, are
-listed here:
+covers ED25519 public keys, ED25519 private keys (also known as seeds),
+pre-authorized transaction hashes, and hash-x signers (which provide
+signing authority upon revelation of a SHA-256 preimage), and muxed
+accounts.
+
+Each strkey has its type encoded in the top 5 bits of the version byte,
+which is the first 8 bits of the strkey. The possible "base" values (top
+5 bits) of the version byte, which determine the first character of the
+base-32 encoding of the key, are listed here:
 
 | Key type                | Base value   | First char | Muxed | Alg  |
 | ----------------------- | ------------ | ---------- | ----- | ---- |
@@ -57,11 +53,10 @@ listed here:
 | STRKEY\_PRE\_AUTH\_TX   | 19 << 3      | T          | no    | Hash |
 | STRKEY\_HASH\_X         | 23 << 3      | X          | no    | Hash |
 
-Second, instead of requiring the low 3 bits of the version byte to be
-zero, we now use them as an algorithm specifier.  Thus, a version byte
-becomes the bitwise OR of a base value above and one of the algorithm
-specifiers from the two tables below.  (These tables will be extended
-when Stellar adds additional crypto algorithms.)
+The low 3 bits of the version byte encode an algorithm specifier. Thus,
+a version byte becomes the bitwise OR of a base value above and one of
+the algorithm specifiers from the two tables below. (These tables will
+be extended when Stellar adds additional crypto algorithms.)
 
 | PK Algorithm                | Value |
 | --------------------------- | ----- |
@@ -106,43 +101,6 @@ not enforce these requirements.  Therefore, implementations of strkey
 decoding **must** check and reject such invalid inputs, or perform a
 round-trip and reject strkey inputs that do not re-encode to the exact
 same string.
-
-### Horizon API changes
-
-The following proposed Horizon API changes would expose multiplexed
-accounts in a backwards-compatible way:
-
-1. Anyplace a MuxedAccount appears, if the account is of a multiplexed
-   type (currently just `KEY_TYPE_MUXED_ED2551`), two new fields are
-   added to the JSON.
-
-   - Base field name + `_muxed` is the strkey of the multiplexed account.
-
-   - Base field name + `_muxed_id` is the integer.
-
-    For example, given the MuxedAccount
-   `MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26`,
-    you might get the following fields:
-
-    ~~~
-        source_account: GAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSTVY
-        source_account_muxed: MAQAA5L65LSYH7CQ3VTJ7F3HHLGCL3DSLAR2Y47263D56MNNGHSQSAAAAAAAAAAE2LP26
-        source_account_muxed_id: 1234
-    ~~~~
-
-2. Queries for a multiplexed MuxedAccount (starting M...) return only
-   operations that touch that particular multiplexed account ID.
-
-3. Queries for non-multiplexed accounts (starting G...) return all
-   transactions affecting the account, including multiplexed
-   subaccounts.  As an exception, a new optional query parameter
-   `nomux=1` returns only transaction operations that are to the
-   non-multiplexed representation of the target account (e.g.,
-   `KEY_TYPE_ED25519` not `KEY_TYPE_MUXED_ED2551`).
-
-## Implementation
-
-https://github.com/xdrpp/stc
 
 ## Tests
 
@@ -259,14 +217,19 @@ using the following array:
 }
 ~~~
 
-## Design Rationale
+## Implementation
 
-If widely adopted by the ecosystem, naming a multiplexed account with
-a single string will allow multiplexed accounts to be used as end-user
-addresses.
+There are many implementations of strkey in Stellar SDKs. As a
+reference, the following implementations are kept up-to-date with this
+SEP.
+
+https://github.com/xdrpp/stc
 
 ## Security Concerns
 
-Augmented strkey could potentially make it harder to see where
-payments are going, as different multiplexed accounts will reference
-the same underlying account.
+Implementations should not rely on the CRC to determine if a strkey is
+incomplete or has been truncated. Existing strkeys are designed to be
+fixed length, with their length determinible from their strkey type and
+algorithmn specifier. Future strkeys added that require variable length
+should encode a length prefix to ensure they are deterministically
+invalid in any case where the strkey is truncated.


### PR DESCRIPTION
### What
Rework SEP-23 so that it is a standalone specification for strkeys rather than a proposal to add a muxed account strkey.

### Why
SEP-23 is currently a definition of strkeys but written from the perspective of being a proposal for adding a muxed account strkey. We could really do with a single place to define all strkeys and iterate on that SEP as new strkeys are added. That is more like how other SEPs work.

We will soon propose a new strkey that will be used for CAP-40, and so I am doing this work to SEP-23 now so that it is already in the position of being the place where strkeys are specified.

This change attempts to make as least changes possible to change the intended use of the document. There are probably ways we could improve this document by adding invalid and valid test cases. We can do that, but let's do that in a different PR to this.

This change is a patch version bump because it does not introduce any breaking changes, nor introduce, change, or remove any functionality. The changes to the document are superficial and changing the intended future use of the document.

Related to https://github.com/stellar/experimental-payment-channels/issues/191