### PR TITLE
SEP-10: improve discovery flow

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2021-06-24
-Version 3.2.1
+Updated: 2021-07-27
+Version 3.2.2
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -47,8 +47,8 @@ The authentication flow is as follows:
    1. Source account set to the **Server Account**.
    1. Value set to the **Server**'s domain that the client requested the challenge from.
 1. The **Client** verifies that if the transaction has other operations they are Manage Data operations and that their source account is set to:
-   1. The **Server Account** if the Manage Data operation key is NOT set to `client_domain`
    1. The **Client Domain Account** if the Manage Data operation key is set to `client_domain`
+   1. Otherwise, the **Server Account**.
 1. If the client included a client domain in the request, and the transaction has a Manage Data operation with key `client_domain`, the **Client** obtains a signature from the **Client Domain Account** and adds it to the challenge transaction
 1. The **Client** signs the transaction using the secret key(s) of the signer(s) for the **Client Account**
 1. The **Client** submits the signed challenge back to the **Server** using [`token`](#token) endpoint

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -46,7 +46,9 @@ The authentication flow is as follows:
 1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
    1. Source account set to the **Server Account**.
    1. Value set to the **Server**'s domain that the client requested the challenge from.
-1. The **Client** verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the **Server Account**
+1. The **Client** verifies that if the transaction has other operations they are Manage Data operations and that their source account is set to:
+   1. The **Server Account** if the Manage Data operation key is NOT set to `client_domain`
+   1. The **Client Domain Account** if the Manage Data operation key is set to `client_domain`
 1. If the client included a client domain in the request, and the transaction has a Manage Data operation with key `client_domain`, the **Client** obtains a signature from the **Client Domain Account** and adds it to the challenge transaction
 1. The **Client** signs the transaction using the secret key(s) of the signer(s) for the **Client Account**
 1. The **Client** submits the signed challenge back to the **Server** using [`token`](#token) endpoint


### PR DESCRIPTION
for the client verification of the challenge: adds that the source account of the manage data operation must be the client domain account in case that the manage data operation key is "client_domain" and not the server account