### PR TITLE
Clarify and handle all pool revoke scenarios

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -896,11 +896,13 @@ If `line.type() == ASSET_TYPE_POOL_SHARE` and
 The authorization revocation behavior of `SetTrustLineFlagsOp` and
 `AllowTrustOp` is extended to force a redeem of pool shares if any of the
 referenced asset trust lines get their authorization revoked. For each redeemed
-pool share, a claimable balance will be created for every constituent asset.
-These claimable balances will be sponsored by the sponsor of the pool share
-trust line, and will be unconditionally claimable by the owner of the pool
-share trust line. The claimable balances will have a different
-`ClaimableBalanceIDType` to indicate their origin.
+pool share trust line, a claimable balance will be created for every constituent
+asset if there is a balance being withdrawn. This means that for a redeemed pool
+share trust line, there can be zero, one, or two claimable balances created. These
+claimable balances will be sponsored by the sponsor of the pool share trust line,
+and will be unconditionally claimable by the owner of the pool share trust line.
+The claimable balances will have a different `ClaimableBalanceIDType` to indicate
+their origin.
 
 The validity conditions for `SetTrustLineFlagsOp` and `AllowTrustOp` are unchanged.
 
@@ -933,6 +935,10 @@ if isAuthorizedToMaintainLiabilities(tl) && !isAuthorizedToMaintainLiabilities(e
         delete(poolTL)
 
         foreach (assetAndAmount in assetAndAmounts)
+
+            if assetAndAmount.amount == 0
+                continue
+
             tlA = loadTrustLine(trustor, assetsAndAmount.asset)
 
             LedgerEntry le;

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -343,7 +343,7 @@ index a21c577a..d56c7e9f 100644
  
  /* Entries used to define the bucket list */
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 75f39eb4..505edbe5 100644
+index 75f39eb4..618df177 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -7,6 +7,12 @@
@@ -575,7 +575,18 @@ index 75f39eb4..505edbe5 100644
  };
  
  union ChangeTrustResult switch (ChangeTrustResultCode code)
-@@ -1152,7 +1276,8 @@ enum RevokeSponsorshipResultCode
+@@ -956,7 +1080,9 @@ enum AllowTrustResultCode
+                                     // source account does not require trust
+     ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
+     ALLOW_TRUST_CANT_REVOKE = -4,     // source account can't revoke trust,
+-    ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
++    ALLOW_TRUST_SELF_NOT_ALLOWED = -5, // trusting self is not allowed
++    ALLOW_TRUST_LOW_RESERVE = -6 // claimable balances can't be created
++                                 // on revoke due to low reserves 
+ };
+ 
+ union AllowTrustResult switch (AllowTrustResultCode code)
+@@ -1152,7 +1278,8 @@ enum RevokeSponsorshipResultCode
      REVOKE_SPONSORSHIP_DOES_NOT_EXIST = -1,
      REVOKE_SPONSORSHIP_NOT_SPONSOR = -2,
      REVOKE_SPONSORSHIP_LOW_RESERVE = -3,
@@ -585,7 +596,18 @@ index 75f39eb4..505edbe5 100644
  };
  
  union RevokeSponsorshipResult switch (RevokeSponsorshipResultCode code)
-@@ -1229,6 +1354,63 @@ default:
+@@ -1218,7 +1345,9 @@ enum SetTrustLineFlagsResultCode
+     SET_TRUST_LINE_FLAGS_MALFORMED = -1,
+     SET_TRUST_LINE_FLAGS_NO_TRUST_LINE = -2,
+     SET_TRUST_LINE_FLAGS_CANT_REVOKE = -3,
+-    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4
++    SET_TRUST_LINE_FLAGS_INVALID_STATE = -4,
++    SET_TRUST_LINE_FLAGS_LOW_RESERVE = -5 // claimable balances can't be created
++                                          // on revoke due to low reserves
+ };
+ 
+ union SetTrustLineFlagsResult switch (SetTrustLineFlagsResultCode code)
+@@ -1229,6 +1358,63 @@ default:
      void;
  };
  
@@ -649,7 +671,7 @@ index 75f39eb4..505edbe5 100644
  /* High level Operation Result */
  enum OperationResultCode
  {
-@@ -1291,6 +1473,10 @@ case opINNER:
+@@ -1291,6 +1477,10 @@ case opINNER:
          ClawbackClaimableBalanceResult clawbackClaimableBalanceResult;
      case SET_TRUST_LINE_FLAGS:
          SetTrustLineFlagsResult setTrustLineFlagsResult;
@@ -901,9 +923,11 @@ if isAuthorizedToMaintainLiabilities(tl) && !isAuthorizedToMaintainLiabilities(e
         // redeem lp's pool shares using the logic from LiquidityPoolWithdrawOp
         assetsAndAmounts = redeem(poolTL)
 
-        // free up reserves from poolTL for the claimable balances below
         cbSponsoringAcc = poolTL.sponsoringID ? poolTL.sponsoringID : trustor
+        sponsorship = loadSponsorship(cbSponsoringAcc)
+        cbSponsoringAcc = sponsorship ? sponsorship.sponsoringID : cbSponsoringAcc
 
+        // free up reserves from poolTL for the claimable balances below
         // Delete poolTL using the logic from ChangeTrustOp
         // Note that this might also delete the corresponding LiquidityPoolEntry
         delete(poolTL)
@@ -931,10 +955,12 @@ if isAuthorizedToMaintainLiabilities(tl) && !isAuthorizedToMaintainLiabilities(e
             cb.asset = assetAndAmount.asset
             cb.claimant = trustor
 
-            if isClawbackEnabledOnTrustline(tl)
+            if isClawbackEnabledOnTrustline(tlA)
                 cb.flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG
 
-            create(cb)
+            // will return false if cbSponsoringAcc does not have the appropriate reserves
+            if(!create(cb))
+                Fail with ALLOW_TRUST_REVOKE_LOW_RESERVE or SET_TRUST_LINE_FLAGS_REVOKE_LOW_RESERVE
 ```
 
 #### PathPaymentStrictSendOp and PathPaymentStrictReceiveOp
@@ -1067,6 +1093,32 @@ entries? They won't be able to sponsor those claimable balances and the revocati
 would fail. For this reason, we should limit `numSponsoring + numSubentries` to
 `UINT32_MAX`, guaranteeing that an account can always sponsor a claimable
 balance for every subentry that gets removed.
+
+### Authorization revocation of an asset trust line in a pool can fail
+Here are the possible scenarios when a trust line in a pool has it's authorization revoked.
+Remember that the pool share trust line is deleted to free up reserves for two claimable balances - 
+
+1. Account A has a pool share trust line.
+   - On revoke, claimable balances are sponsored by A. Guaranteed to succeed.
+2. Account A has a pool share trust line, but the trust line is sponsored by B.
+   - On revoke, claimable balances are sponsored by B. Guaranteed to succeed.
+3. Account A has a pool share trust line, the trust line is sponsored by B, but B is in the middle
+of a sponsorship sandwich where its entries will be sponsored by C.
+    - On revoke, claimable balances are sponsored by C. This can fail if C does not have enough
+    available balance to sponsor two claimable balances. The issuer can just submit the revoke
+    again outside the sandwich for this to succeed.
+    - This still works if C=A because claimable balances aren't subentries.
+4. Account A has a pool share trust line, and is in the middle of a sponsorship sandwich
+where its entries will be sponsored by C.
+   - On revoke, claimable balances are sponsored by C. This can fail if C does not have enough
+   available balance to sponsor two claimable balances. The issuer can just submit the revoke
+   again outside the sandwich for this to succeed.
+
+For the failure cases, you can see that the account that owns/sponsors the pool
+share trust line is in the middle of a sponsorship sandwich. It is actually
+up to the issuer if the revoke is done in the middle of a sponsorship sandwich,
+so the issuer could always just submit the revoke with the sponsorship sandwich to make
+sure the revoke succeeds.
 
 ### Liquidity Pools Support Arbitrary Asset Pairs
 Some implementations of liquidity pools, such as Uniswap V1, enforced the


### PR DESCRIPTION
This PR has two changes-

1. Clears up the possible scenarios when the authorization for an asset in a pool is revoked.
2. Specifies what happens on a revoke where there is no asset balance to withdraw. (@tamirms this might interest you)