### PR TITLE
CAP-40: Expand on use cases in design rationale

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -230,7 +230,7 @@ Simplified two message process using CAP-21 and CAP-40:
   |            |
 ```
 
-Simplified one message process using CAP-21 and CAP-40 where R is the only 
+Simplified one message process using CAP-21 and CAP-40 where B is the only 
 beneficiary of the update, supporting queue-like processing of payments:
 ```
 +---+        +---+

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -194,6 +194,54 @@ May be changed to:
 >sign and exchange a closing transaction C_i and declaration
 >transaction D_i.
 
+This changes the number of messages the parties must send to each other to 
+update the payment channel, reducing the number from three to two. It reduces 
+the number of messages down to one for any the payment channel implementation 
+where the receiving party of a payment update is the beneficiary.
+
+Three messages using CAP-21:
+```
++---+        +---+
+| A |        | B |
++---+        +---+
+  |            |
+  | C_i        |
+  |----------->|
+  |            |
+  |   C_i, D_i |
+  |<-----------|
+  |            |
+  | D_i        |
+  |----------->|
+  |            |
+```
+
+Simplified two message process using CAP-21 and CAP-40:
+```
++---+        +---+
+| A |        | B |
++---+        +---+
+  |            |
+  | C_i, D_i   |
+  |----------->|
+  |            |
+  |   C_i, D_i |
+  |<-----------|
+  |            |
+```
+
+Simplified one message process using CAP-21 and CAP-40 where R is the only 
+beneficiary of the update, supporting queue-like processing of payments:
+```
++---+        +---+
+| A |        | B |
++---+        +---+
+  |            |
+  | C_i, D_i   |
+  |----------->|
+  |            |
+```
+
 This simplified exchange would be implemented by requiring the sender of a
 payment to include in D_i the `extraSigners` precondition with an ed25519 signed
 payload signer where the payload is the transaction hash of C_i and the ed25519


### PR DESCRIPTION
### What
Expand on the use cases and impact of using CAP-40 on the number of messages.

### Why
I realized that this is not particularly clear and the design rationale did not discuss it in as much detail as we have discussed in some in person conversations. I think this fleshes it out a bit. This doesn't change the proposal in any way.