### PR TITLE
CAP-40: Correct max length of zero byte padding for hint calc

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -138,7 +138,7 @@ other transaction.
 
 The signature hint of an ed25519 signed payload signer is the last 4 bytes of
 the ed25519 public key XORed with last 4 bytes of the payload. If the payload
-has a length less than 4 bytes, then 1 to 3 zero bytes are appended to the
+has a length less than 4 bytes, then 1 to 4 zero bytes are appended to the
 payload such that it has a length of 4 bytes, for calculating the hint.
 
 #### Transaction Envelopes


### PR DESCRIPTION
### What
Correct max length of zero byte padding for hint calculation.

### Why
@ire-and-curses pointed out that nothing in the specification sets a minimum length for payload, and since it can be zero, the hint may need to be padded to four bytes which is beyond the specified 3 bytes.

https://groups.google.com/g/stellar-dev/c/Wp7gNaJvt40/m/CcvxiOPHBAAJ