### PR TITLE
CAP-21: Add some notes about resource utilization

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -731,7 +731,9 @@ the transaction at s with `minSeqNum` s-99 ensures that if any of the
 servers do not submit transactions, the gap will not prevent other
 transactions from executing.
 
-## Backwards Incompatibilities
+## Protocol Upgrade Transition
+
+### Backwards Incompatibilities
 
 Previously signed transactions containing time points greater than
 2^{63} are no longer valid with this proposal.  However, given that
@@ -743,6 +745,25 @@ binary XDR of any other previously valid transactions will unmarshal
 to a valid transaction under the current proposal.  Obviously legacy
 software will not be able to parse transactions with the new
 preconditions, however.
+
+### Resource Utilization
+
+Transaction sizes will increase nominally, but only for transactions
+that use the new preconditions.
+
+All account ledger entries will increase in size nominally with the
+addition of the account extension.
+
+The maximum number of signatures that must be verified for each
+transaction will not change.
+
+The introduction of `extraSigners` makes the use of
+`SIGNER_KEY_TYPE_HASH_X` signers more efficient by making them
+stateless, moving them from the account signers to the transaction.
+For any use cases utilizing this signer this may reduce the number of
+ledger entries and reduce the number of transactions since there would
+be no transactions to setup a `SIGNER_KEY_TYPE_HASH_X` signer before
+its use, and no transactions to remove it after its use.
 
 ## Security Concerns
 


### PR DESCRIPTION
### What
Add some notes about resource utilization.

### Why
I noticed that one side-effect benefit of CAP-21's `extraSigners` is we make the use cases of the existing HASH_X signer more efficient since there is now no, or little, reason to store them on ledger as an account signer. I feel like it is worth calling that out, that this proposal may in some ways improve utilization, albeit small.

While adding a brief blurb about that, it felt natural to add some other comments about utilization that were missing.