### PR TITLE
SEP-12: rename 'Field Statuses' heading to 'Provided Field Statuses'

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-07-23
-Version 1.7.1
+Updated: 2021-08-16
+Version 1.7.2
 ```
 
 ## Abstract

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -279,7 +279,7 @@ Property | Type | Description
 `status` | string | (optional) One of the values described in [Provided Field Statuses](#provided-field-statuses). If the server does not wish to expose which field(s) were accepted or rejected, this property can be omitted.
 `error` | string | (optional) The human readable description of why the field is `REJECTED`.
 
-#### Field Statuses
+#### Provided Field Statuses
 
 Status | Description
 -------|------------


### PR DESCRIPTION
I noticed that our markdown referenced a heading title that didn't exist, so I updated the heading appropriately.