### PR TITLE
CAP-38: Clarify what assetA < assetB means

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -717,7 +717,11 @@ bool lessThan<T>(u, v)
         // less than v
         return false
     else if isContainer(T)
-        for i in 0...length(T)
+        // Handle variable length correctly
+        if length(u) != length(v)
+            return length(u) < length(v)
+
+        for i in 0...length(u)
             if lessThan(u[i], v[i])
                 return true
             else if lessThan(v[i], u[i])

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -686,15 +686,68 @@ index 75f39eb4..f590ad4b 100644
 
 ### Semantics
 
+#### Asset Ordering in LiquidityPoolConstantProductParameters
+`LiquidityPoolConstantProductParameters` describes the immutable properties of a
+constant product liquidity pool. Specifically, these parameters are the two
+assets between which the pool can trade and the fee rate charged for such a
+trade. But the two assets, referred to as `assetA` and `assetB`, must satisfy an
+ordering relation to avoid the existence of functionally duplicate pools. For
+example, a pool that can exchange between `X` and `Y` is no different from a
+pool that can exchange between `Y` and `X`. The ordering relation imposed is
+field-wise lexicographic ordering, defined as follows for arbitrary XDR values
+`u` and `v` of the same type `T`:
+
+```
+bool lessThan<T>(u, v)
+    if isUnion(T)
+        if u.discriminant == v.discriminant
+            // body means the contents corresponding to this value of the
+            // discriminant
+            return lessThan(u.body, v.body)
+        else
+            return u.discriminant < v.discriminant
+    else if isStruct(T)
+        for i in 0...numFields(T)
+            if lessThan(u.field[i], v.field[i])
+                return true
+            else if lessThan(v.field[i], u.field[i])
+                return false
+            // This field was equal so compare the next one
+        // If we reached this point, all fields were equal so clearly u is not
+        // less than v
+        return false
+    else if isContainer(T)
+        for i in 0...length(T)
+            if lessThan(u[i], v[i])
+                return true
+            else if lessThan(v[i], u[i])
+                return false
+            // This element was equal so compare the next one
+        // If we reached this point, all elements were equal so clearly u is not
+        // less than v
+        return false
+    else // T is an integer type
+        return u < v
+```
+
+We will now consider a few examples:
+
+- If `assetA` is native and `assetB` is non-native, then `assetA < assetB`
+  because `ASSET_TYPE_NATIVE` is the lowest discriminant value. In other words,
+  if a pool contains the native asset then the native asset is always first.
+- If `assetA` and `assetB` are both of type `ASSET_TYPE_CREDIT_ALPHANUM4` with
+  the same asset code, then `assetA < assetB` if and only if the issuer of
+  `assetA` has a public key that compares less than the public key of issuer of
+  `assetB`.
+
 #### LiquidityPoolDepositOp
 `LiquidityPoolDepositOp` is the only way for an account to deposit funds into a
 liquidity pool. The operation specifies a maximum amount to deposit for each
-asset in the pool (ordered field-wise lexicographically among assets). The
-operation then converts these amounts into a number of pool shares that will be
-received. Using that number of pool shares, it calculates amounts of each asset
-to deposit with a maximum error (rounded against the depositor) of 1 stroop in
-each asset. Finally, it checks that the deposit price is within the bounds
-specified by minPrice and maxPrice.
+asset in the pool. The operation then converts these amounts into a number of
+pool shares that will be received. Using that number of pool shares, it
+calculates amounts of each asset to deposit with a maximum error (rounded
+against the depositor) of 1 stroop in each asset. Finally, it checks that the
+deposit price is within the bounds specified by minPrice and maxPrice.
 
 `LiquidityPoolDepositOp` will return `opNOT_SUPPORTED` during validation if
 `(ledgerHeader.v1.flags & DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG) == DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG`

--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -717,19 +717,15 @@ bool lessThan<T>(u, v)
         // less than v
         return false
     else if isContainer(T)
-        // Handle variable length correctly
-        if length(u) != length(v)
-            return length(u) < length(v)
-
-        for i in 0...length(u)
+        for i in 0...min(length(u), length(v))
             if lessThan(u[i], v[i])
                 return true
             else if lessThan(v[i], u[i])
                 return false
             // This element was equal so compare the next one
-        // If we reached this point, all elements were equal so clearly u is not
-        // less than v
-        return false
+        // If we reached this point, all elements were equal so u is less than
+        // v if it is shorter
+        return length(u) < length(v)
     else // T is an integer type
         return u < v
 ```


### PR DESCRIPTION
There has been a lot of confusion around what `assetA < assetB` means, so clearly CAP-38 was not communicating this clearly enough. I have sufficiently expanded the explanation and given it a prominent place in the semantics section.