### PR TITLE
SEP-6, SEP-31: add explicit support for source and destination accounts different than authenticated accounts

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-08-09
-Version 3.6.0
+Updated: 2021-08-16
+Version 3.7.0
 ```
 
 ## Simple Summary
@@ -190,7 +190,7 @@ Request Parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the on-chain asset the user wants to get from the Anchor after doing an off-chain deposit. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
-`account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
+`account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
@@ -381,7 +381,7 @@ Name | Type | Description
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
-`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
+`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
@@ -455,6 +455,7 @@ Name | Type | Description
 `source_asset` | string | The off-chain asset the Anchor will receive from the user. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?buy_asset=stellar:<destination_asset>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `quote_id` | string | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this parameter is provided and the user delivers the deposit funds to the Anchor before the quote expiration, the Anchor should respect the conversion rate agreed in that quote. If the values of `destination_asset`, `source_asset` and `amount` conflict with the ones used to create the [SEP-38] quote, this request should be rejected with a `400`.
 `amount` | string | The amount of the source_asset the user would like to deposit to the anchor's off-chain account. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `email_address` | string | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.
@@ -504,7 +505,7 @@ Name | Type | Description
 `type` | string | Type of withdrawal. Can be: `crypto`, `bank_account`, `cash`, `mobile`, `bill_payment` or other custom values. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `dest` | string | The account that the user wants to withdraw their funds to. This can be a crypto account, a bank account number, IBAN, mobile number, or email address.
 `dest_extra` | string | (optional) Extra information to specify withdrawal location. For crypto it may be a memo in addition to the `dest` address. It can also be a routing number for a bank, a BIC, or the name of a partner handling the withdrawal.
-`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
+`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
@@ -902,7 +903,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
-`account` | string | The stellar account ID involved in the transactions.
+`account` | string | The stellar account ID involved in the transactions. If the service requires SEP-10 authentication, this parameter match the authenticated account.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) A list containing the desired transaction kinds. The possible values are `deposit`, `deposit-exchange`, `withdrawal` and `withdrawal-exchange`.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -65,8 +65,6 @@ It is highly recommended to require authentication for all endpoints other than 
 
 Note that both the source account of a withdrawal payment and the destination account of a deposit can be different than the account authenticated via SEP-10. 
 
-This is particularly useful for clients who use a third-party custody provider for their users' funds held on Stellar. Using this flexibility, a client can use a Stellar public and private key managed using their own infrastructure to authenticate with anchor services while using the Stellar account managed by a custodian as the source and destination of users' transactions.
-
 ## Cross-Origin Headers
 
 Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -903,7 +903,7 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `asset_code` | string | The code of the asset of interest. E.g. BTC, ETH, USD, INR, etc.
-`account` | string | The stellar account ID involved in the transactions. If the service requires SEP-10 authentication, this parameter match the authenticated account.
+`account` | string | The stellar account ID involved in the transactions. If the service requires SEP-10 authentication, this parameter must match the authenticated account.
 `no_older_than` | UTC ISO 8601 string | (optional) The response should contain transactions starting on or after this date & time.
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) A list containing the desired transaction kinds. The possible values are `deposit`, `deposit-exchange`, `withdrawal` and `withdrawal-exchange`.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -61,6 +61,12 @@ Authorization: Bearer <JWT>
 
 It is highly recommended to require authentication for all endpoints other than `/info` (and optionally `/fee`).
 
+### Source and Destination Accounts
+
+Note that both the source account of a withdrawal payment and the destination account of a deposit can be different than the account authenticated via SEP-10. 
+
+This is particularly useful for clients who use a third-party custody provider for their users' funds held on Stellar. Using this flexibility, a client can use a Stellar public and private key managed using their own infrastructure to authenticate with anchor services while using the Stellar account managed by a custodian as the source and destination of users' transactions.
+
 ## Cross-Origin Headers
 
 Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -53,6 +53,12 @@ Authorization: Bearer <JWT>
 
 In the case of the interactive webapp, since the client cannot add the authorization header, we recommend passing a short-lived JWT via URL query parameters and then using your own backend session scheme for the rest of the interactive flow.  Query parameters can leak, so its important to have this JWT be one-time use, or at least short-lived.
 
+### Source and Destination Accounts
+
+Note that both the source account of a withdrawal payment and the destination account of a deposit can be different than the account authenticated via SEP-10. 
+
+This is particularly useful for clients who use a third-party custody provider for their users' funds held on Stellar. Using this flexibility, a client can use a Stellar public and private key managed using their own infrastructure to authenticate with anchor services while using the Stellar account managed by a custodian as the source and destination of users' transactions.
+
 ## Cross-Origin Headers
 
 Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -57,8 +57,6 @@ In the case of the interactive webapp, since the client cannot add the authoriza
 
 Note that both the source account of a withdrawal payment and the destination account of a deposit can be different than the account authenticated via SEP-10. 
 
-This is particularly useful for clients who use a third-party custody provider for their users' funds held on Stellar. Using this flexibility, a client can use a Stellar public and private key managed using their own infrastructure to authenticate with anchor services while using the Stellar account managed by a custodian as the source and destination of users' transactions.
-
 ## Cross-Origin Headers
 
 Valid CORS headers are necessary to allow web clients from other sites to use the endpoints. The following HTTP header must be set for all transfer server responses, including error responses.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-05-17
-Version 1.3.2
+Updated: 2021-08-16
+Version 1.3.3
 ```
 
 ## Simple Summary
@@ -158,7 +158,7 @@ Name | Type | Description
 `asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
-`account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent.
+`account` | `G...` string | The stellar account ID of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
@@ -294,7 +294,7 @@ Name | Type | Description
 `asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
-`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information.
+`account` | `G...` string | (optional) The stellar account ID of the user that wants to do the withdrawal. This is only needed if the anchor requires KYC information for withdrawal. The anchor can use `account` to look up the user's KYC information. Note that the account specified in this request could differ from the account authenticated via SEP-10.
 `memo` | string | (optional) A wallet will send this to uniquely identify a user if the wallet has multiple users sharing one Stellar account. The anchor can use this along with `account` to look up the user's KYC info.
 `memo_type` | string | (optional) Type of `memo`. One of `text`, `id` or `hash`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2021-08-09
-Version 1.3.0
+Updated: 2021-08-16
+Version 1.3.1
 ```
 
 ## Simple Summary
@@ -54,6 +54,8 @@ Authorization: Bearer <JWT>
 ```
 
 Any API request that fails to meet proper authentication should return a 403 Forbidden response.
+
+Note that the source account of payments made by Sending Anchors can differ from the account used to authenticate with Receiving Anchors. Only the payment transaction's memo should be used to match incoming payments with the transaction record in the Receiving Anchor's database.
 
 ## HTTPS Only
 


### PR DESCRIPTION
resolves #1039 

With the exception of adding a required `account` field to SEP-6's `deposit-exchange` endpoint, the changes here are largely patch-level changes that clarify the ability to send and receive funds to and from accounts that were not used in SEP-10 authentication.

Its possible that anchors assume deposits are always made to the account authenticated via SEP-10. Hopefully these anchors reject requests that specify `account` parameters that differ from the authenticated account. If they do not, anchors would mistakenly send funds to the account authenticated via SEP-10 instead of account provided in the deposit request. However, this should not be a major issue since the client has access to the authenticated account and can send the funds to the correct account.