### PR TITLE
SEP-6 & 24: Add `features` object to GET /info

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-08-16
-Version 3.7.0
+Updated: 2021-08-17
+Version 3.8.0
 ```
 
 ## Simple Summary
@@ -281,7 +281,9 @@ Mexican peso (MXN) response example:
 ### Special Cases
 #### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The Anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
+If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature_flags` object to `false`, otherwise clients will assume account creation is supported.
+
+The Anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
 Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account in Stellar to complete the deposit.
 
@@ -315,6 +317,7 @@ Using this feature, anchors will no longer have to wait until the user's Stellar
 
 **Anchors**: To support claimable balances anchors must
 
+* Set the `claimable_balances` attribute within `GET /info`'s `feature_flags` object to `true`
 * Accept the `claimable_balance_supported` request parameter in `GET /deposit` requests
 * Submit deposit transactions using `CreateClaimableBalance` operations to Stellar accounts that don't yet have a trustline to the asset requested.
 * Add the `claimable_balance_id` attribute to `GET /transaction(s)` deposit records
@@ -793,6 +796,10 @@ The response should be a JSON object like:
   "transaction": {
     "enabled": false,
     "authentication_required": true
+  },
+  "feature_flags": {
+    "account_creation": true,
+    "claimable_balances": true
   }
 }
 ```
@@ -843,6 +850,17 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 
 * `enabled`: `true` if the endpoint is available.
 * `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the endpoint.
+
+#### Feature Flags
+
+The `feature_flags` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
+
+Name | Default | Description
+-----|---------|------------
+`account_creation` | `true` | Whether or not the anchor supports creating accounts for users requesting deposits.
+`claimable_balances` | `false` | Whether or not the anchor supports sending deposit funds as claimable balances. This is relevant for users of Stellar accounts without a trustline to the requested asset.
+
+The default values for the features listed above have been selected based on the ecosystem's current support. It is highly recommened to support all features enumerated for the best user experience.
 
 ## Fee
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -860,7 +860,7 @@ Name | Default | Description
 `account_creation` | `true` | Whether or not the anchor supports creating accounts for users requesting deposits.
 `claimable_balances` | `false` | Whether or not the anchor supports sending deposit funds as claimable balances. This is relevant for users of Stellar accounts without a trustline to the requested asset.
 
-The default values for the features listed above have been selected based on the ecosystem's current support. It is highly recommened to support all features enumerated for the best user experience.
+The default values for the features listed above have been selected based on the ecosystem's current support. Supporting all features provided the best user experience.
 
 ## Fee
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -281,7 +281,7 @@ Mexican peso (MXN) response example:
 ### Special Cases
 #### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature_flags` object to `false`, otherwise clients will assume account creation is supported.
+If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature` object to `false`, otherwise clients will assume account creation is supported.
 
 The Anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
@@ -317,7 +317,7 @@ Using this feature, anchors will no longer have to wait until the user's Stellar
 
 **Anchors**: To support claimable balances anchors must
 
-* Set the `claimable_balances` attribute within `GET /info`'s `feature_flags` object to `true`
+* Set the `claimable_balances` attribute within `GET /info`'s `features` object to `true`
 * Accept the `claimable_balance_supported` request parameter in `GET /deposit` requests
 * Submit deposit transactions using `CreateClaimableBalance` operations to Stellar accounts that don't yet have a trustline to the asset requested.
 * Add the `claimable_balance_id` attribute to `GET /transaction(s)` deposit records
@@ -797,7 +797,7 @@ The response should be a JSON object like:
     "enabled": false,
     "authentication_required": true
   },
-  "feature_flags": {
+  "features": {
     "account_creation": true,
     "claimable_balances": true
   }
@@ -853,7 +853,7 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 
 #### Feature Flags
 
-The `feature_flags` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
+The `feature` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
 
 Name | Default | Description
 -----|---------|------------

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-08-16
-Version 1.3.3
+Updated: 2021-08-17
+Version 1.4.0
 ```
 
 ## Simple Summary
@@ -193,7 +193,9 @@ Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-a
 
 ##### Stellar account does not exist
 
-If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
+If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature_flags` object to `false`, otherwise clients will assume account creation is supported.
+
+The anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
 Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account on Stellar to complete the deposit.
 
@@ -227,6 +229,7 @@ Using this feature, anchors will no longer have to wait until the user's Stellar
 
 **Anchors**: To support claimable balances anchors must
 
+* Set the `claimable_balances` attribute within `GET /info`'s `feature_flags` object to `true`
 * Accept the `claimable_balance_supported` request parameter in `POST /transactions/deposit/interactive` requests
 * Submit deposit transactions using `CreateClaimableBalance` operations to Stellar accounts that don't yet have a trustline to the asset requested.
 * Add the `claimable_balance_id` attribute to their [deposit `GET /transaction(s)` responses.](####Fields-for-deposit-transactions)
@@ -551,6 +554,10 @@ The response should be a JSON object like:
   },
   "fee": {
     "enabled": false
+  },
+  "feature_flags": {
+    "account_creation": true,
+    "claimable_balances": true
   }
 }
 ```
@@ -581,6 +588,17 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 
 * `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the `fee` endpoint.
 * `enabled`: `true` if the endpoint is available.
+
+#### Feature Flags
+
+The `feature_flags` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
+
+Name | Default | Description
+-----|---------|------------
+`account_creation` | `true` | Whether or not the anchor supports creating accounts for users requesting deposits.
+`claimable_balances` | `false` | Whether or not the anchor supports sending deposit funds as claimable balances. This is relevant for users of Stellar accounts without a trustline to the requested asset.
+
+The default values for the features listed above have been selected based on the ecosystem's current support. It is highly recommened to support all features enumerated for the best user experience.
 
 ## Fee
 


### PR DESCRIPTION
resolves #1030

Adds a `feature_flags` object to `GET /info`'s response body containing boolean values indicating whether or not specific features are support by the anchor. Currently the only two values and defaults are:

- `account_creation`: `true`
- `claimable_balances`: `false`

As ecosystem adoption for claimable balances increases, the feature flag's default may be updated to `true`.

This is helpful for clients who would adjust their behavior or UX based on the anchor's supported features. For example, a wallet could either require that a user create an account prior to requesting a deposit if the account didn't exist and `account_creation` was `false`, or require the user to create a trustline prior to requesting a deposit if `claimable_balances` was `false`.