### PR TITLE
Remove a new ClaimableBalanceIDType mention in CAP-38

### DIFF
--- a/core/cap-0038.md
+++ b/core/cap-0038.md
@@ -889,8 +889,7 @@ asset if there is a balance being withdrawn and the claimant is not the issuer.
 This means that for a redeemed pool share trust line, there can be zero, one, or
 two claimable balances created. These claimable balances will be sponsored by the
 sponsor of the pool share trust line, and will be unconditionally claimable by the
-owner of the pool share trust line. The claimable balances will have a different
-`ClaimableBalanceIDType` to indicate their origin.
+owner of the pool share trust line.
 
 The validity conditions for `SetTrustLineFlagsOp` and `AllowTrustOp` are unchanged.
 


### PR DESCRIPTION
`CLAIMABLE_BALANCE_ID_TYPE_FROM_POOL_REVOKE` was removed in one of previous commits but the new type is still referenced.

See: https://github.com/stellar/stellar-core/pull/3162#discussion_r702150851