### PR TITLE
Modify the wording of PATCH /transactions/:id description

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2021-08-16
-Version 1.3.1
+Updated: 2021-09-07
+Version 1.3.2
 ```
 
 ## Simple Summary
@@ -513,7 +513,7 @@ Another possibility is that the per-transaction information provided in the `POS
 
 ### PATCH Transaction
 
-This endpoint should only be used when the Receiver Anchor requests more info via the `pending_transaction_info_update` status.  The `required_info_updates` transaction field should contain the fields required for the update. If the Sending Anchor tries to update at a time when no info is requested, the Receiver Anchor should fail with an error response.
+This endpoint should only be used when the Receiving Anchor needs more info via the `pending_transaction_info_update` status from the Sending Anchor.  The `required_info_updates` transaction field should contain the fields required for the update. If the Sending Anchor tries to update at a time when no info is requested, the Receiving Anchor should fail with an error response.
 
 ```
 PATCH DIRECT_PAYMENT_SERVER/transactions/:id


### PR DESCRIPTION
1. Changed "Receiver Anchor" to "Receiving Anchor" to make the document consistent.
2. The word "Receiving Anchor requests" sounds like the receiving anchor is polling information from the sending anchor. But it should be the sending anchor "patching" to receiving anchor. Change the wording to avoid the confusion.