### PR TITLE
SEP-8: Change heading

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-05-26
-Version 1.7.1
+Updated: 2021-09-13
+Version 1.7.2
 ```
 
 ## Simple Summary
@@ -29,7 +29,7 @@ Implementing a regulated asset requires these parts:
 - [SEP-1 stellar.toml] used for discovering [Approval Server].
 - [Approval Server] that validates client transactions according to the service's approval criteria. Validated transactions are signed by the asset's issuing account.
 
-## Regulated Assets Approval Flow
+## Regulated Assets Transaction Flow
 
 1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.


### PR DESCRIPTION
### What
Change the heading of the flow section to transaction flow instead of approval flow.

### Why
The section details how a client transacts and what they need to do, part of which is approval. I think it makes it easier to understand that if we refer to this as the transaction flow. It is not only about approval.