### PR TITLE
SEP-8: Distinguish requires auth vs regulated asset

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -7,7 +7,7 @@ Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (
 Status: Active
 Created: 2018-08-22
 Updated: 2021-09-13
-Version 1.7.2
+Version 1.7.3
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -32,12 +32,13 @@ Implementing a regulated asset requires these parts:
 ## Regulated Assets Approval Flow
 
 1. Wallet creates and signs a transaction.
-2. Wallet resolves asset information and detects that it's a regulated asset.
-	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
-3. Wallet sends the transaction to the approval server.
-	1. Wallet can find the approval server via [SEP-1 stellar.toml] set up by the issuer.
-4. Approval server determines whether the transaction should be approved.
-5. Wallet handles approval response:
+2. Wallet resolves asset information and detects that it's an asset that requires authorization.
+	1. Wallet can detect whether an asset requires authorization by checking the [authorization flags] of the asset issuer's account
+3. Wallet detects that it's a regulated asset.
+	1. Wallet can detect whether an asset is a regulated asset by checking for an approval server via [SEP-1 stellar.toml] set up by the issuer
+4. Wallet sends the transaction to the approval server.
+5. Approval server determines whether the transaction should be approved.
+6. Wallet handles approval response:
     1. *Success?* Transaction has been approved and signed by the issuer.
     2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. **It is important to understand that an approval service could respond with a different transaction.**
     3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2021-08-16
-Version 1.3.1
+Updated: 2021-09-07
+Version 1.3.2
 ```
 
 ## Simple Summary
@@ -513,7 +513,7 @@ Another possibility is that the per-transaction information provided in the `POS
 
 ### PATCH Transaction
 
-This endpoint should only be used when the Receiver Anchor requests more info via the `pending_transaction_info_update` status.  The `required_info_updates` transaction field should contain the fields required for the update. If the Sending Anchor tries to update at a time when no info is requested, the Receiver Anchor should fail with an error response.
+This endpoint should only be used when the Receiving Anchor needs more info via the `pending_transaction_info_update` status from the Sending Anchor.  The `required_info_updates` transaction field should contain the fields required for the update. If the Sending Anchor tries to update at a time when no info is requested, the Receiving Anchor should fail with an error response.
 
 ```
 PATCH DIRECT_PAYMENT_SERVER/transactions/:id


### PR DESCRIPTION
### What
Distinguish between assets that simply require authorization from assets that are regulated assets.

### Why
An asset can require authorization without being a regulated asset or having an approval server. I think it is helpful to set this distinction and be clear that an asset requiring authorization without the issuer having an approval server is not a "SEP-8 Regulated Asset", although it may be a "regulated asset" by some other definition.