### PR TITLE
CAP-21: Expand on the transaction validity/execution aspected in the security section

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -782,10 +782,29 @@ transactions have been validated leads to a counterintuitive situation
 in which two operations can execute in the same block but not in
 different blocks.  This was already the case before the current
 proposal, but the `minSeqAge` and `minSeqLedgerGap` fields create more
-such situations.  Fortunately, it appears that in most useful
-protocols time-delayed "closing" transactions use a NULL `minSeqNum`,
-while transactions with non-NULL `minSeqNum` are "disclosure"
-transactions intended to be valid at any time.
+such situations.
+
+An example of this is if a source account has a valid transaction with
+`minSeqAge` or `minSeqLedgerGap` and a second transaction, containing
+a `BUMP_SEQUENCE` that bumps the sequence of the source account, is
+created that is also valid. Any protocol that does this risks both
+transactions being accepted as valid in the same ledger. If both
+transactions execute in the same ledger and the bump sequence
+transaction is executed first, the other transaction will fail as its
+`minSeqAge` or `minSeqLedgerGap` will no longer be satisfied.
+
+Any protocol that specifies for a source account a transaction with
+`minSeqAge` or `minSeqLedgerGap`, should not allow another transaction
+to be valid at the same moment unless the intent of that other
+transaction is to cause the first to fail or become invalid. Any
+transaction that is valid in the same moment as a transaction with
+`minSeqAge` or `minSeqLedgerGap` can cause the transaction to fail
+during execution even if it passed validation.
+
+Fortunately, it appears that in most useful protocols time-delayed
+"closing" transactions use a NULL `minSeqNum`, while transactions with
+non-NULL `minSeqNum` are "disclosure" transactions intended to be
+valid at any time.
 
 ## Test Cases
 

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -799,7 +799,9 @@ to be valid at the same moment unless the intent of that other
 transaction is to cause the first to fail or become invalid. Any
 transaction that is valid in the same moment as a transaction with
 `minSeqAge` or `minSeqLedgerGap` can cause the transaction to fail
-during execution even if it passed validation.
+during execution even if it passed validation. Once the transaction
+has failed during execution it cannot be executed again as its
+sequence number will have been consumed.
 
 Fortunately, it appears that in most useful protocols time-delayed
 "closing" transactions use a NULL `minSeqNum`, while transactions with


### PR DESCRIPTION
### What
Add to the security section about transaction validity an example, and a statement for protocols to test again.

### Why
The security section highlights that transaction validity vs failure during execution is something to be aware of but without further discussion it may not be grasped by the reader.

Thinking through the example helped me understand the problem better and would probably help others.

Making a statement like "if you do X, don't do Y" is also helpful at understanding what the distinction is between a transaction that is safe or unsafe in this context. 