### PR TITLE
SEP-38: add status codes

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,9 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-07-21
+Updated: 2021-09-28
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.3.0
+Version 1.4.0
 ```
 
 ## Summary

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -119,6 +119,8 @@ No request arguments required.
 
 #### Response
 
+A `200 Success` status code should be returned for successful requests.
+
 Name | Type | Description
 -----|------|------------
 `assets` | array | An array of objects describing the assets available in exchange for one or more of the other assets listed.
@@ -210,6 +212,8 @@ Name | Type | Description
 
 #### Response
 
+A `200 Success` status code should be returned for successful requests.
+
 Name | Type | Description
 -----|------|------------
 `buy_assets` | array | An array of objects containing information on the assets that the client will receive when they provide `sell_asset`.
@@ -281,6 +285,8 @@ Name | Type | Description
 
 
 #### Response
+
+A `200 Success` status code should be returned for successful requests.
 
 Name | Type | Description
 -----|------|------------
@@ -377,6 +383,8 @@ Name | Type | Description
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response
+
+A `201 Created` status code should be returned for successful requests.
 
 Name | Type | Description
 -----|------|------------


### PR DESCRIPTION
We forgot to document the status codes that should be returned in success responses for SEP-38 requests. 