### PR TITLE
SEP-6: clarify GET /fee endpoint usage for Stellar assets

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
-* [`GET /fee`](#fee): **deprecated**, optional (only needed for complex fee structures)
+* [`GET /fee`](#fee-deprecated): **deprecated**, optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history): required
 * [`GET /transaction`](#single-historical-transaction): required
 
@@ -173,7 +173,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 
 * Provide a full-featured implementation of [`/info`](#info).
 * Decide which endpoints, if any, need to be [authenticated](#authentication), and declare that properly in the `/info` endpoint.
-* Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
+* Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee-deprecated). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
     * We recommend you use [SEP-10 authentication](#authentication) for all endpoints other than `/info`. Anchors may want to allow clients to access the `/fee` endpoint as well.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -880,7 +880,7 @@ The fee endpoint allows an anchor to report the fee that would be charged when u
 
 This endpoint is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
 
-This endpoint only reports fees expressed in units of Stellar assets. Fetching fee amounts for transactions using both on & off-chain assets (using either `/deposit-exchange` and `/withdraw-exchange`)is not supported unless fees are only dependent on the amount of the Stellar asset transacted.
+This endpoint only reports fees expressed in units of Stellar assets. Fetching fee amounts for transactions using both on & off-chain assets (using either `/deposit-exchange` and `/withdraw-exchange`) is not supported unless fees are only dependent on the amount of the Stellar asset transacted.
 
 ```
 GET TRANSFER_SERVER/fee

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-08-17
-Version 3.8.0
+Updated: 2021-10-01
+Version 3.9.0
 ```
 
 ## Simple Summary
@@ -299,7 +299,7 @@ If the anchor does not support creating new accounts for users and `account` doe
 
 #### Stellar account doesn't trust asset
 
-Unless [Claimable Balances](#claimable-balanecs) are supported by both the wallet and anchor, the deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
+Unless [Claimable Balances](#claimable-balances) are supported by both the wallet and anchor, the deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
 
 1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
 2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -790,7 +790,7 @@ The response should be a JSON object like:
   },
   "fee": {
     "enabled": false,
-    "description": "Fees vary based on the the assets transacted and method by which funds are delivered to or collected by the anchor."
+    "description": "Fees vary from 3 to 7 percent based on the the assets transacted and method by which funds are delivered to or collected by the anchor."
   },
   "transactions": {
     "enabled": true, 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -862,7 +862,7 @@ An anchor should also indicate in the `/info` response if they support the `GET 
 ##### Fee Info
 
 
-Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short explaination of how fees are calculated so client applications will be able to display this message to their users. This is especially important the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage values for each Stellar asset.
+Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short explaination of how fees are calculated so client applications will be able to display this message to their users. This is especially important if the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage values for each Stellar asset.
 
 #### Feature Flags
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
-* [`GET /fee`](#fee-deprecated): **deprecated**, optional (only needed for complex fee structures)
+* [`GET /fee`](#fee-deprecated): **deprecated**, optional
 * [`GET /transactions`](#transaction-history): required
 * [`GET /transaction`](#single-historical-transaction): required
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -790,7 +790,7 @@ The response should be a JSON object like:
   },
   "fee": {
     "enabled": false,
-    "description": ""
+    "description": "Fees vary based on the the assets transacted and method by which funds are delivered to or collected by the anchor."
   },
   "transactions": {
     "enabled": true, 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
-* [`GET /fee`](#fee): optional (only needed for complex fee structures)
+* [`GET /fee`](#fee): **deprecated**, optional (only needed for complex fee structures)
 * [`GET /transactions`](#transaction-history): required
 * [`GET /transaction`](#single-historical-transaction): required
 
@@ -679,8 +679,6 @@ The response should be a JSON object like:
     "USD": {
       "enabled": true,
       "authentication_required": true,
-      "fee_fixed": 5,
-      "fee_percent": 1,
       "min_amount": 0.1,
       "max_amount": 1000,
       "fields": {
@@ -704,8 +702,6 @@ The response should be a JSON object like:
     "ETH": {
       "enabled": true,
       "authentication_required": false,
-      "fee_fixed": 0.002,
-      "fee_percent": 0
     }
   },
   "deposit-exchange": {
@@ -734,8 +730,6 @@ The response should be a JSON object like:
     "USD": {
       "enabled": true,
       "authentication_required": true,
-      "fee_fixed": 5,
-      "fee_percent": 0,
       "min_amount": 0.1,
       "max_amount": 1000,
       "types": {
@@ -795,7 +789,8 @@ The response should be a JSON object like:
     }
   },
   "fee": {
-    "enabled": false
+    "enabled": false,
+    "description": ""
   },
   "transactions": {
     "enabled": true, 
@@ -824,8 +819,8 @@ All assets listed in a `deposit` and `deposit-exchange` can contain these attrib
 
 Deposit assets listed in the `deposit` object can also contain the attributes:
 
-* `fee_fixed`: Optional fixed (flat) fee for deposit, in units of the deposited off-chain asset. Leave blank if there is no fee or the fee schedule is complex.
-* `fee_percent`: Optional percentage fee for deposit, in percentage points of the deposited off-chain asset. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_fixed`: Optional fixed (flat) fee for deposit, in units of the Stellar asset. Leave blank if there is no fee or the fee schedule is complex.
+* `fee_percent`: Optional percentage fee for deposit, in percentage points of the Stellar asset. Leave blank if there is no fee or the fee schedule is complex.
 * `min_amount`: Optional minimum amount. No limit if not specified.
 * `max_amount`: Optional maximum amount. No limit if not specified.
 
@@ -835,14 +830,16 @@ All assets listed in a `withdraw` and `withdraw-exchange` can contain these attr
 
 * `enabled`: `true` if SEP-6 withdrawal for this asset is supported
 * `authentication_required`: Optional. `true` if client must be [authenticated](#authentication) before accessing the withdraw endpoint for this asset. `false` if not specified.
-* `min_amount`: Optional minimum amount. No limit if not specified.
-* `max_amount`: Optional maximum amount. No limit if not specified.
-* a `types` field with each type of withdrawal supported for that asset as a key. Each type can specify a `fields` object as below explaining what fields are needed and what they do.
+* `types`: a field with each type of withdrawal supported for that asset as a key. Each type can specify a `fields` object as below explaining what fields are needed and what they do.
 
 Withdrawal assets listed in the `withdraw` object can also contain the attributes:
 
 * `fee_fixed`: Optional fixed (flat) fee for withdraw, in units of the Stellar asset. Leave blank if there is no fee or the fee schedule is complex.
 * `fee_percent`: Optional percentage fee for withdraw, in percentage points of the Stellar asset. Leave blank if there is no fee or the fee schedule is complex.
+* `min_amount`: Optional minimum amount. No limit if not specified.
+* `max_amount`: Optional maximum amount. No limit if not specified.
+
+#### Fields
 
 The `fields` object allows an anchor to describe fields that are passed into `/deposit`, `/withdraw`, `/deposit-exchange` and/or `/withdraw-exchange`. It can explain standard fields like `dest` and `dest_extra` for withdrawals, as well as extra fields that could be needed for all deposit and withdrawal endpoints such as an email address or bank name. If a field is part of the KYC/AML flow handled by SEP-12 or the field is handled by the Anchor's interactive deposit/withdrawal flow, there's no need to list it in `/info`. Only fields that are passed to `/deposit`, `/withdraw`, `/deposit-exchange` or `/withdraw-exchange` need to appear here.
 
@@ -854,10 +851,18 @@ The `fields` object contains a key for each field name and an object with the fo
 
 The wallet should display a form to the user to fill out any fields with unknown values as part of the deposit/withdrawal flow. Each field should be a text `input`, unless `choices` is specified, in which case a dropdown should be used.
 
-An anchor should also indicate in the `/info` response if they support the `fee`, `transactions` and `transaction` endpoints, by providing the following fields for each:
+#### Endpoints
+
+An anchor should also indicate in the `/info` response if they support the `GET /fee` (**deprecated**), `GET /transactions`, and `GET /transaction` endpoints, by providing the following fields for each:
 
 * `enabled`: `true` if the endpoint is available.
 * `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the endpoint.
+* `description`: Optional and only for `GET /fee`. See the [Fee Info](#fee-info) section below for more information.
+
+##### Fee Info
+
+
+Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short explaination of how fees are calculated so client applications will be able to display this message to their users. This is especially important the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage values for each Stellar asset.
 
 #### Feature Flags
 
@@ -870,7 +875,9 @@ Name | Default | Description
 
 The default values for the features listed above have been selected based on the ecosystem's current support. Supporting all features provided the best user experience.
 
-## Fee
+## Fee (deprecated)
+
+This endpoint is deprecated, see [#1061](https://github.com/stellar/stellar-protocol/issues/1061) for a detailed explaination. Instead, anchors are enouraged to provide a short description on fee calculation in the `GET /info` response, see the [Fee Info](#fee-info) section for more information.
 
 The fee endpoint allows an anchor to report the fee that would be charged when using the `/deposit` or `/withdraw` endpoints.
 
@@ -881,6 +888,7 @@ This endpoint is important to allow an anchor to accurately report fees to a use
 ```
 GET TRANSFER_SERVER/fee
 ```
+
 
 Request parameters:
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -861,7 +861,6 @@ An anchor should also indicate in the `/info` response if they support the `GET 
 
 ##### Fee Info
 
-
 Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short explaination of how fees are calculated so client applications will be able to display this message to their users. This is especially important if the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage values for each Stellar asset.
 
 #### Feature Flags

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -43,7 +43,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
-* [`GET /fee`](#fee-deprecated): **deprecated**, optional
+* [`GET /fee`](#fee): optional
 * [`GET /transactions`](#transaction-history): required
 * [`GET /transaction`](#single-historical-transaction): required
 
@@ -173,7 +173,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 
 * Provide a full-featured implementation of [`/info`](#info).
 * Decide which endpoints, if any, need to be [authenticated](#authentication), and declare that properly in the `/info` endpoint.
-* Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee-deprecated). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
+* Pick your approach to [fees](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#fee). We recommend using `/info` to express fees as it provides a better user experience (the user can see the fee structure in the wallet early in the process).
 * **For both deposit and withdrawal**:
     * Include the `id` field in your response so the wallet can check up on the status of the transaction if it wants.
     * We recommend you use [SEP-10 authentication](#authentication) for all endpoints other than `/info`. Anchors may want to allow clients to access the `/fee` endpoint as well.
@@ -853,7 +853,7 @@ The wallet should display a form to the user to fill out any fields with unknown
 
 #### Endpoints
 
-An anchor should also indicate in the `/info` response if they support the `GET /fee` (**deprecated**), `GET /transactions`, and `GET /transaction` endpoints, by providing the following fields for each:
+An anchor should also indicate in the `/info` response if they support the `GET /fee`, `GET /transactions`, and `GET /transaction` endpoints, by providing the following fields for each:
 
 * `enabled`: `true` if the endpoint is available.
 * `authentication_required`: `true` if client must be [authenticated](#authentication) before accessing the endpoint.
@@ -874,20 +874,17 @@ Name | Default | Description
 
 The default values for the features listed above have been selected based on the ecosystem's current support. Supporting all features provided the best user experience.
 
-## Fee (deprecated)
-
-This endpoint is deprecated, see [#1061](https://github.com/stellar/stellar-protocol/issues/1061) for a detailed explaination. Instead, anchors are enouraged to provide a short description on fee calculation in the `GET /info` response, see the [Fee Info](#fee-info) section for more information.
+## Fee
 
 The fee endpoint allows an anchor to report the fee that would be charged when using the `/deposit` or `/withdraw` endpoints.
 
-When using the `/deposit-exchange` or `/withdraw-exchange` endpoints fees are included in the conversion price provided with [`SEP-38 GET /price`](sep-0038.md#get-price) or [`SEP-38 POST /quote`](sep-0038.md#post-quote).
-
 This endpoint is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
+
+This endpoint only reports fees expressed in units of Stellar assets. Fetching fee amounts for transactions using both on & off-chain assets (using either `/deposit-exchange` and `/withdraw-exchange`)is not supported unless fees are only dependent on the amount of the Stellar asset transacted.
 
 ```
 GET TRANSFER_SERVER/fee
 ```
-
 
 Request parameters:
 
@@ -895,7 +892,7 @@ Name | Type | Description
 -----|------|------------
 `operation` | string | Kind of operation (`deposit` or `withdraw`).
 `type` | string | (optional) Type of deposit or withdrawal (`SEPA`, `bank_account`, `cash`, etc...).
-`asset_code` | string | Asset code.
+`asset_code` | string | Stellar asset code.
 `amount` | float | Amount of the asset that will be deposited/withdrawn.
 
 Example request:


### PR DESCRIPTION
resolves #1061

Adds a disclaimer to the `GET /fee` endpoint for a lack of multi-asset transaction support. The fee endpoint will only support reporting fees in terms of Stellar assets for amounts of the same Stellar asset.

Also corrects the description of `fee_fixed` and `fee_percent` for deposit assets. Fees cannot be expressed in terms of the off-chain asset in these cases because the fee values would vary per off-chain asset.