### PR TITLE
SEP-24: Add support for transacting non-equivalent assets

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-08-17
-Version 1.4.0
+Updated: 2021-10-05
+Version 1.5.0
 ```
 
 ## Simple Summary
@@ -64,6 +64,14 @@ Note that Stellar accounts are either shared or they are not. This means anchors
 ### Source and Destination Accounts
 
 Note that both the source account of a withdrawal payment and the destination account of a deposit can be different than the account authenticated via SEP-10.
+
+## Asset Exchanges
+
+This protocol was originally designed to provide conversions between off-chain and on-chain equivalent assets – for instance `BRL <> BRLT`, `USD <> USDC`, `NGN <> NGNT`, etc. – but it has been updated to make exchanges between off-chain and on-chain non-equivalent assets like `BRL <> USDC`.
+
+To support the exchange of non-equivalent assets using this protocol, the anchor must allow users to select the off-chain asset they would like to provide or receive (for deposit and withdrawal, respectively) within the anchor's interactive flow. The anchor should then display an exchange rate to the user in addition to any fees charged for facilitating the transaction. Whether this exchange rate is binding or an estimate is up to the anchor, but this distinction must be communicated to the user.
+
+Finally, anchors should populate the optional attributes listed in the `GET /transaction(s)` endpoints related to non-equivalent asset transactions, specifically `amount_in_asset`, `amount_fee_asset`, and `amount_out_asset`. This allows client applications can relay this information, in addition to the amounts specified in the associated attributes, back to their users.
 
 ## Cross-Origin Headers
 
@@ -612,6 +620,8 @@ The default values for the features listed above have been selected based on the
 
 The fee endpoint allows an anchor to report the fee that would be charged for a given deposit or withdraw operation. This is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed`, `fee_percent` or `fee_minimum` fields in the `/info` response, then an anchor should not implement this endpoint.
 
+Note that this endpoint does not support providing fees for transactions using non-equivalent on and off-chain assets, since it only accepts the on-chain `asset_code` request parameter.
+
 ```
 GET TRANSFER_SERVER_SEP0024/fee
 ```
@@ -693,8 +703,11 @@ Name | Type | Description
 `kyc_verified` | boolean | (optional) True if the anchor has verified the user's KYC information for this transaction.
 `more_info_url` | string | A URL that is opened by wallets after the interactive flow is complete. It can include banking information for users to start deposits, the status of the transaction, or any other information the user might need to know about the transaction.
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
+`amount_in_asset` | string | (optional) The asset received or to be received by the Anchor. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
+`amount_out_asset` | string | `amount_out_asset` | string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `amount_fee` | string | Amount of fee charged by anchor.
+`amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | Completion date and time of transaction.  Assigned null for in-progress transactions.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.


### PR DESCRIPTION
Adds support for exchanging non-equivalent assets (i.e. using quotes) in SEP-24. Note SEP-38 is not required, unlike in SEP-6 and SEP-31, because all quote-related info can be communicated via the interactive flow.

Note the change made to the `GET /fee` endpoint description. This is a temporary change while the decision around deprecating the `GET /fee` endpoint altogether is finalized (see #1061).