### PR TITLE
SEP-11: Add canonical string representation of the ASSET_TYPE_POOL_SHARE asset type

### DIFF
--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -199,7 +199,7 @@ The `Asset`, and `TrustLineAsset` union types are rendered as a string in one of
 
   - `LiquidityPoolID:lp` for liquidity pool shares, i.e. assets of type `ASSET_TYPE_POOL_SHARE`.
 
-    "LiquidityPoolID" is the hex encoded `PoolID`.
+    "LiquidityPoolID" is the hex encoded `PoolID` using a lowercase alphabet.
 
     "lp" is the string `"lp"`.
 


### PR DESCRIPTION
### What
Add a string representation of the `ASSET_TYPE_POOL_SHARE` asset type in the form of `<LiquidityPoolID>:lp`, where LiquidityPoolID is the `PoolID` in lower case hex form, and `lp` is a hardcoded string identifying that the prior form is a pool share.

### Why
SEP-11 defines a canonical string form for all asset types for Protocol 17 and earlier, however Protocol 18 adds a new asset type and SEP-11 does not define how that asset type should be rendered as a string.

This is problematic for tools implementing the full breadth of SEP-11, such as stc, who rely on concise text formats for the XDR types. Tools of that type no longer have a concise string representation for all assets.

This is problematic for SDKs because SDKs used to be able to provide a canonical string representation for all asset types. In the SDKs this manifested as the ability to take any string and get a string representation, and then the ability to take that string representation and reform the asset. Since Protocol 18 was rolled out to SDKs this is no longer the case. 

Introducing a new canonical string representation is not straight-forward because asset strings do not contain any data that acts as an absolute discriminant.

The format proposed for the pool share exploits the fact that the existing asset types have gaps in values that would be otherwise invalid. The format proposed, where-by a fixed value is used post a colon and the ID is used pre the colon, was proposed by @stanford-scs. The form is backwards compatible with existing asset string representations since it never collides with the native asset type which is limited to 12 characters not including the colon, and it never collides with issued credit assets since they require a valid strkey encoded key as defined in SEP-23.

The suffix `:lp` was selected because `ASSET_TYPE_POOL_SHARE` assets are always liquidity pool IDs, and as far as we expect will always be. The string `lp` does not collide with issuer account IDs used for credit assets.

The version has been updated to v1.1.0 assuming that the prior version of the SEP was v1.0.0 even though it was not explicitly noted in the pragma.