### PR TITLE
SEP-6 & 24: make feature object consistent

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-10-01
-Version 3.9.0
+Updated: 2021-10-22
+Version 3.9.1
 ```
 
 ## Simple Summary
@@ -289,7 +289,7 @@ Mexican peso (MXN) response example:
 ### Special Cases
 #### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature` object to `false`, otherwise clients will assume account creation is supported.
+If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `features` object to `false`, otherwise clients will assume account creation is supported.
 
 The Anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
@@ -865,7 +865,7 @@ Anchors are encouraged to add a `description` field to the `fee` object returned
 
 #### Feature Flags
 
-The `feature` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
+The `features` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
 
 Name | Default | Description
 -----|---------|------------

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-10-05
-Version 1.5.0
+Updated: 2021-10-22
+Version 1.5.1
 ```
 
 ## Simple Summary
@@ -209,7 +209,7 @@ Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-a
 
 ##### Stellar account does not exist
 
-If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `feature_flags` object to `false`, otherwise clients will assume account creation is supported.
+If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). To indicate that account creation is not supported, set the `account_creation` attribute within `GET /info`'s `features` object to `false`, otherwise clients will assume account creation is supported.
 
 The anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
@@ -245,7 +245,7 @@ Using this feature, anchors will no longer have to wait until the user's Stellar
 
 **Anchors**: To support claimable balances anchors must
 
-* Set the `claimable_balances` attribute within `GET /info`'s `feature_flags` object to `true`
+* Set the `claimable_balances` attribute within `GET /info`'s `features` object to `true`
 * Accept the `claimable_balance_supported` request parameter in `POST /transactions/deposit/interactive` requests
 * Submit deposit transactions using `CreateClaimableBalance` operations to Stellar accounts that don't yet have a trustline to the asset requested.
 * Add the `claimable_balance_id` attribute to their [deposit `GET /transaction(s)` responses.](####Fields-for-deposit-transactions)
@@ -571,7 +571,7 @@ The response should be a JSON object like:
   "fee": {
     "enabled": false
   },
-  "feature_flags": {
+  "features": {
     "account_creation": true,
     "claimable_balances": true
   }
@@ -607,7 +607,7 @@ An anchor should also indicate in the `/info` response if they support the `fee`
 
 #### Feature Flags
 
-The `feature_flags` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
+The `features` object contains boolean values indicating whether or not specific features are supported by the anchor. If the object or specific feature is not present in the response, the default value described below may be assumed. This information enables wallets to adjust their behavior based on the feature set supported by the anchor.
 
 Name | Default | Description
 -----|---------|------------


### PR DESCRIPTION
resolves #1073 

Makes the name of the `features` object included in `GET /info` responses consistent between SEPs. This is technically a breaking change, although the adoption of this object is likely low since it was introduced recently.

We could keep the names as is, with SEP-6 using `feature` and SEP-24 using `feature_flags`, in which case I'll close this PR.