### PR TITLE
SEP-31: add `quotes_required` attribute to `GET /info` response

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2021-09-07
-Version 1.3.2
+Updated: 2021-10-22
+Version 1.4.0
 ```
 
 ## Simple Summary
@@ -167,6 +167,7 @@ The response should be a JSON object like:
   "receive": {
     "USDC": {
       "quotes_supported": true,
+      "quotes_required": false,
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
@@ -234,7 +235,10 @@ Name | Type | Description
 `sender_sep12_type` | string | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a value from `sep12.sender.types` instead if any are present.
 `receiver_sep12_type` | string | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a values from `sep12.receiver.types` instead if any are present.
 `fields` | object | An object containing the per-transaction parameters required in `POST /transactions` requests.
-`quotes_supported` | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.
+`quotes_supported` | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.
+`quotes_required` | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.
+
+```
 
 
 #### `sep12` Object Schema


### PR DESCRIPTION
Some on-chain assets cannot be exchange for an equivalent ( 1-1 ) off-chain. For example, a Brazilian anchor may accept USDC on chain but can only provide fiat BRL to recipients. In this case, `quotes_supported` is too general, since a request without a `destination_asset` would result in 400 with something like `{"error": "quotes are required"}`.