### PR TITLE
SEP-24: allow both strings and javascript objects in callback bodies

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-10-22
-Version 1.5.1
+Updated: 2021-10-27
+Version 1.6.0
 ```
 
 ## Simple Summary


### PR DESCRIPTION
[Window.postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#syntax) accepts both objects and strings, but on the documentation it notes that serialization of data is unnecessary. 

Our standard uses the term "JSON message" which sounds like "string" to me, but this change indicates that plain javascript objects can also be used in `postMessage()` calls.