### PR TITLE
SEP-24: Un-deprecate `postMessage` callbacks and add security section

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -421,7 +421,7 @@ If the wallet wants to be notified that the user has completed the anchor's inte
 
 **`postMessage` details**
 
-Note that there are some [security concerns](#security-concerns-noopener-postmessage) associated with supporting `postMessage` callbacks.
+Note that there are some security concerns associated with supporting `postMessage` callbacks. These conerns are detailed in the section below.
 
 If provided, the anchor must post a JSON message (either as a JSON-serialized string or a plain javascript object) to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -429,7 +429,7 @@ Because `callback` is used to notify the wallet that the interactive flow is com
 
 Wallet applications display content rendered by a third party anchor service. It is recommended to use the [`rel=noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) attribute on links or the `noopener` feature for [`Window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_functionality_features).
 
-Note that using `noopener` prohibits the use of `postMessage` callbacks. If `postMessage` callbacks are required for your implementation, it recommended to only open URLs from known and trusted third party anchors.
+Note that using `noopener` prohibits the use of `postMessage` callbacks. If `postMessage` callbacks are required for your implementation, it recommended to only open URLs from anchors that you, the wallet developer, trust.
 
 **Differences between `callback` and `on_change_callback`**
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -425,7 +425,7 @@ If provided, the anchor must post a JSON message (either as a JSON-serialized st
 
 Because `callback` is used to notify the wallet that the interactive flow is complete, it is common for anchors to make the `postMessage` callback as a result of the user clicking a "Close" button or similar UI element. The wallet can then close the window displaying the anchor's interactive flow using `[Window.close()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/close). This ensures the wallet application receives the transaction's information and the user has a smooth experience.
 
-**Interactive Flow Security Concerns**
+**Security Concerns (`noopener`, `postMessage`)**
 
 Wallet applications display content rendered by a third party anchor service. It is recommended to use the [`rel=noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) attribute on links or the `noopener` feature for [`Window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_functionality_features).
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-10-27
-Version 1.6.0
+Updated: 2021-11-02
+Version 1.7.0
 ```
 
 ## Simple Summary
@@ -410,20 +410,26 @@ The basic parameters are summarized in the table below.
 
 Name | Type | Description
 -----|------|------------
-`callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow. The use of `postMessage` is **deprecated**.
-`on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change. The use of `postMessage` is **deprecated**.
+`callback` | string | (optional) [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) or a URL that the anchor should `POST` a JSON message to when the user successfully completes the interactive flow.
+`on_change_callback` | string | (optional) [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) or a URL that the anchor should `POST` a JSON message to when the `status` or `kyc_verified` properties change.
 
 The URL supplied by both callback parameters should receive the full transaction object.
 
 **`callback` details**
 
-If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body. 
+If the wallet wants to be notified that the user has completed the anchor's interactive flow (either success or failure), it can add this parameter to the URL. If the user abandons the process, the anchor does not need to report anything to the wallet. If the `callback` value is a URL, the anchor must `POST` to it with a JSON message as the body.
 
-**`postMessage` deprecation**
+**`postMessage` details**
 
-Instead of using `postMessage` callbacks, the wallet should either provide a public-facing URL as the `callback` parameter value or poll the anchor's [`GET /transaction(s)`] endpoint for updates to the transaction's status.
+If provided, the anchor must post a JSON message (either as a JSON-serialized string or a plain javascript object) to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
-The anchor should still support the use of `postMessage` callbacks. If provided, the anchor must post a JSON message (either as a JSON-serialized string or a plain javascript object) to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
+Because `callback` is used to notify the wallet that the interactive flow is complete, it is common for anchors to make the `postMessage` callback as a result of the user clicking a "Close" button or similar UI element. The wallet can then close the window displaying the anchor's interactive flow using `[Window.close()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/close). This ensures the wallet application receives the transaction's information and the user has a smooth experience.
+
+**Interactive Flow Security Concerns**
+
+Because wallet applications display content rendered by a third party anchor service, it is recommended to use the [`noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) link type or feature for [`Window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_functionality_features).
+
+Note that using `noopener` prohibits the use of `postMessage` callbacks. If `postMessage` callbacks are required for your implementation, it recommended to only open URLs from known and trusted third party anchors.
 
 **Differences between `callback` and `on_change_callback`**
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -421,6 +421,8 @@ If the wallet wants to be notified that the user has completed the anchor's inte
 
 **`postMessage` details**
 
+Note that there are some [security concerns](#security-concerns-noopener-postmessage) associated with supporting `postMessage` callbacks.
+
 If provided, the anchor must post a JSON message (either as a JSON-serialized string or a plain javascript object) to `window.opener` via the Javascript [`Window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) method. If `window.opener` is undefined, the message must be posted to `window.parent` instead.
 
 Because `callback` is used to notify the wallet that the interactive flow is complete, it is common for anchors to make the `postMessage` callback as a result of the user clicking a "Close" button or similar UI element. The wallet can then close the window displaying the anchor's interactive flow using `[Window.close()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/close). This ensures the wallet application receives the transaction's information and the user has a smooth experience.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -427,7 +427,7 @@ Because `callback` is used to notify the wallet that the interactive flow is com
 
 **Interactive Flow Security Concerns**
 
-Because wallet applications display content rendered by a third party anchor service, it is recommended to use the [`noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) link type or feature for [`Window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_functionality_features).
+Wallet applications display content rendered by a third party anchor service. It is recommended to use the [`rel=noopener`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener) attribute on links or the `noopener` feature for [`Window.open()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_functionality_features).
 
 Note that using `noopener` prohibits the use of `postMessage` callbacks. If `postMessage` callbacks are required for your implementation, it recommended to only open URLs from known and trusted third party anchors.
 


### PR DESCRIPTION
Un-deprecates the use of `postMessage` callbacks and adds a section outlining recommendations for it's usage.

I also added a section detailing how `postMessage` callbacks can be used to signal to the wallet to close the anchor's window triggered by user action. This the pattern we're seeing develop in the ecosystem.

cc @pitsevich