### PR TITLE
SEP-24: remove unused withdrawal response

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-10-27
-Version 1.6.0
+Updated: 2021-11-03
+Version 2.0.0
 ```
 
 ## Simple Summary
@@ -341,38 +341,7 @@ When uploading data for fields specificed in [SEP-9](sep-0009.md), `binary` type
 
 There are several possible kinds of response, depending on whether the anchor needs more information about the user, how it should be sent to the anchor, and if there are any errors.
 
-The first response, the success response, is explained below. The other possible responses are shared with the deposit endpoint, and are explained in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section directly below.
-
-#### 1. Success: no additional information needed
-
-Response code: `200 OK`
-
-This is the correct response if the anchor is able to execute the withdrawal and needs no additional information about the user. It should also be used if the anchor requires information about the user, but the information has previously been submitted and accepted.
-
-The response body should be a JSON object with the following fields:
-
-Name | Type | Description
------|------|------------
-`account_id` | `G...` string | The account the user should send its token back to.
-`memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
-`memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. The anchor should use this memo to match the Stellar transaction with the database entry associated created to represent it.
-`eta` | int | (optional) Estimate of how long the withdrawal will take to credit in seconds.
-`min_amount` | float | (optional) Minimum amount of an asset that a user can withdraw.
-`max_amount` | float | (optional) Maximum amount of asset that a user can withdraw.
-`fee_fixed` | float | (optional)  Fixed (Base) fee, in units of withdrawn asset.  This is in addition to any `fee_percent`.
-`fee_percent` | float | (optional) Percentage fee in units of percent.  This is in addition to any `fee_fixed`.
-`fee_minimum` | float | (optional) Minimum fee in units of withdrawn asset.
-`extra_info` | object | (optional) Any additional data needed as an input for this withdraw, example: Bank Name.
-
-Example:
-
-```json
-{
-  "account_id": "GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ",
-  "memo_type": "id",
-  "memo": "123"
-}
-```
+Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-and-withdraw-shared-responses) section below.
 
 ## Deposit and Withdraw shared responses
 


### PR DESCRIPTION
resolves #864 

Removes the no-additional-info-needed response from the withdrawal endpoint, making it consistent with the responses offered for the deposit endpoint.

I can see a future where wallets concerned about UX want the ability to skip the interactive flow entirely, but we can add responses back for both endpoints when that use case arises.
