### PR TITLE
CAP-21: Add deterministic account creation use case to design rationale

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -8,7 +8,7 @@ Working Group:
     Authors: David Mazières <@stanford-scs>, Leigh McCulloch <@leighmcculloch>
 Status: Awaiting Decision
 Created: 2019-05-24
-Updated: 2021-07-15
+Updated: 2021-11-03
 Discussion: https://groups.google.com/g/stellar-dev/c/N8vzP2Mi89U
 Protocol version: TBD
 ```

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -760,6 +760,10 @@ greater than the `bumpTo` sequence number. The `ledgerBounds` restricts
 the creation to occur only up to the `bumpTo` to ensure that creation
 results with the account having the determined sequence number.
 
+It is also possible to eliminate the `BUMP_SEQUENCE` operation from the
+transaction is a subsequent transaction uses `minSeqNum` with a value
+matching the `minLedger` of `ledgerBounds`.
+
 This property makes it possible to setup contracts using pre-authorized
 transactions where the pre-authorized transaction has the created
 account as its source account.

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -741,6 +741,29 @@ the transaction at s with `minSeqNum` s-99 ensures that if any of the
 servers do not submit transactions, the gap will not prevent other
 transactions from executing.
 
+### Deterministic account sequence numbers at creation
+
+The proposed `ledgerBounds` field can be used to create an account with
+a predictable sequence number that is guaranteed if the account creation
+succeeds.
+
+Assuming the user plans to create the account between ledgers 0 and N,
+they can specify `ledgerBounds` as 0 and N, and include a
+`BUMP_SEQUENCE` operation that bumps the sequence of the created account
+to N<<32. The transaction will be guaranteed to only succeed with the
+created account having a sequence number of N<<32.
+
+The sequence number is guaranteed because the account is created with a
+sequence number derived from the current ledger's sequence number. The
+`BUMP_SEQUENCE` operation is a no-op if the account's sequence number is
+greater than the `bumpTo` sequence number. The `ledgerBounds` restricts
+the creation to occur only up to the `bumpTo` to ensure that creation
+results with the account having the determined sequence number.
+
+This property makes it possible to setup contracts using pre-authorized
+transactions where the pre-authorized transaction has the created
+account as its source account.
+
 ## Protocol Upgrade Transition
 
 ### Backwards Incompatibilities


### PR DESCRIPTION
### What
Add deterministic account creation as a use case in the design rational section of CAP-21.

### Why
See the change for why this is useful.