### PR TITLE
SEP-38: relax the requirements for specifying delivery methods

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -366,7 +366,9 @@ In the reverse scenario, the anchor will submit a Stellar transaction to deliver
 
 #### Request
 
-The client must provide either `sell_amount` or `buy_amount`, but not both.
+The client must provide either `sell_amount` or `buy_amount`, but not both. 
+
+Unless the list included in the `GET /info` response is empty or missing for the associated off-chain asset, the client must also provide either `sell_delivery_method` or `buy_delivery_method`, but not both.
 
 Name | Type | Description
 -----|------|------------
@@ -375,8 +377,8 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no methods are specified.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no methods are specified.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -377,8 +377,8 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no methods are specified in the `GET /info` response.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no methods are specified in the `GET /info` response.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no more than one method is specified in the `GET /info` response.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no more than one method is specified in the `GET /info` response.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,9 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-09-28
+Updated: 2021-11-08
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.4.0
+Version 1.5.0
 ```
 
 ## Summary
@@ -205,10 +205,9 @@ Name | Type | Description
 -----|------|------------
 `sell_asset` | string | The asset you want to sell, using the [Asset Identification Format](#asset-identification-format).
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for each of the `buy_assets`.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Can be provided if the user is delivering an off-chain asset to the anchor but is not strictly required.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Can be provided if the user intends to receive an off-chain asset from the anchor but is not strictly required.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
-
 
 #### Response
 
@@ -227,7 +226,6 @@ Name | Type | Description
 `decimals` | integer | The number of decimals needed to represent `asset`.
 
 ##### Examples
-
 
 ```
 GET /prices?sell_asset=stellar:USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&sell_amount=100&country_code=BRA&buy_delivery_method=ACH
@@ -279,10 +277,9 @@ Name | Type | Description
 `buy_asset` | string | The asset the client would like to exchange for `sell_asset`.
 `sell_amount` | string | The amount of `sell_asset` the client would exchange for `buy_asset`.
 `buy_amount` | string | The amount of `buy_asset` the client would like to purchase with `sell_asset`.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Can be provided if the user is delivering an off-chain asset to the anchor but is not strictly required.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Can be provided if the user intends to receive an off-chain asset from the anchor but is not strictly required.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
-
 
 #### Response
 

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -130,8 +130,8 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `asset` | string | The [Asset Identification Format](#asset-identification-format) value.
-`sell_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to sell/deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
-`buy_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to buy/retrieve funds from the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response.
+`sell_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to sell/deliver funds to the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response. If the delivery method is not necessary for providing accurate quotes and expirations, the server can omit this attribute.
+`buy_delivery_methods` | array | (optional) Only for non-Stellar assets. An array of objects describing the methods a client can use to buy/retrieve funds from the anchor. The method of delivery may affect the expiration and/or price provided in a [`POST /quote`](#post-quote) response. If the delivery method is not necessary for providing accurate quotes and expirations, the server can omit this attribute.
 `country_codes` | array | (optional) Only for fiat assets. A list of [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) codes of the countries where the Anchor operates for fiat transactions.
 
 Object Schema for `sell_delivery_methods` and `buy_delivery_methods`.
@@ -377,8 +377,8 @@ Name | Type | Description
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
 `expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
-`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no methods are specified.
-`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no methods are specified.
+`sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no methods are specified in the `GET /info` response.
+`buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no methods are specified in the `GET /info` response.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
 
 #### Response


### PR DESCRIPTION
The `buy_delivery_method` and `sell_delivery_method` parameters on the `GET /price`, `GET /prices`, and `POST /quote` endpoints are used to provide the anchor with additional information that can be used to adjust the price and expiration provided in the response.

However, client have reasons to make requests to the `GET /price(s)` endpoints other than actually exchanging the assets, namely:

- Displaying the available pairs
- Displaying an estimated exchange rates prior to the user initiating a transaction

For the above use cases, especially the first, its not strictly necessary to specify how the user will deliver or pick up the off-chain asset to the anchor. The anchor can decide to show its best rates when not specified.

For `POST /quote`, the delivery method parameters are certainly relevant and should be required if the anchor needs them. However, its possible that the anchor doesn't need them, and we specification should allow for that possibility.