### PR TITLE
SEP-10: Fix "Verifying the Client Domain" hyperlink

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -208,7 +208,7 @@ Upon successful verification, **Server** responds with a session JWT, containing
      * Otherwise, the `sub` value should be Stellar account (`G...`).
 * `iat` (the time at which the JWT was issued [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6)) — current timestamp (`1530644093`)
 * `exp` (the expiration time on or after which the JWT must not be accepted for processing, [RFC7519, Section 4.1.4](https://tools.ietf.org/html/rfc7519#section-4.1.4)) — a server can pick its own expiration period for the token (`1530730493`)
-* `client_domain` - (optional) a nonstandard JWT claim containing the client home domain, included if the challenge transaction contained a `client_domain` (see [Verifying Client Application Identity](#verifying-client-application-identity))
+* `client_domain` - (optional) a nonstandard JWT claim containing the client home domain, included if the challenge transaction contained a `client_domain` (see [Verifying the Client Domain](#verifying-the-client-domain))
 
 The JWT may contain other claims specific to your application, see [RFC7519].
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2021-08-10
-Version 3.3.0
+Updated: 2021-11-17
+Version 3.3.1
 ```
 
 ## Simple Summary


### PR DESCRIPTION
This PR updates the "Verifying Client Application Identity" copy to read "Verifying the Client Domain" instead (like it's appearing in all the other places in the doc) and fix the hyperlink.