### PR TITLE
SEP Proposal: Extend ManageData for arbitrary on-chain data storage

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -68,6 +68,7 @@
 | [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
 | [SEP-0037](sep-0037.md) | Address Directory API | OrbitLens | Informational | Draft |
 | [SEP-0038](sep-0038.md) | Anchor RFQ API | Jake Urban and Leigh McCulloch | Standard | Draft |
+| [SEP-0039](sep-0039.md) | On-Chain Storage of Non-Fungible Assets | George Kudrayvtsev | Standard | Draft |
 
 
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -68,7 +68,7 @@
 | [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
 | [SEP-0037](sep-0037.md) | Address Directory API | OrbitLens | Informational | Draft |
 | [SEP-0038](sep-0038.md) | Anchor RFQ API | Jake Urban and Leigh McCulloch | Standard | Draft |
-| [SEP-0039](sep-0039.md) | On-Chain Storage of Non-Fungible Assets | George Kudrayvtsev | Standard | Draft |
+| [SEP-0039](sep-0039.md) | On-Chain Storage of Non-Fungible Assets | George Kudrayvtsev, Tyler van der Hoeven | Standard | Draft |
 
 
 

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -53,20 +53,32 @@ Note also that this SEP does not address concerns around *immutability*. While t
 Our exclusive focus in this SEP is Step 2: **storing the asset within the account.**
 
 ### Data Format
-We begin by describing the raw data format, then dive into each component.
+We begin by describing the raw data format, then dive into each component:
 
-    00|version|metadata length|media-type;param1=value;param2=value;etc<binary data>
+  - index (2 bytes)
+  - version (1 byte)
+  - metadata length, `n` (varying)
+  - metadata (`n` bytes)
+  - binary data (varying)
 
-Here, `|` is not a character, but rather a semantic divider used to separate the components. The following sections break down each component in detail.
+For example,
+
+    00|1|26|text/plain;l=13,image/webp|TPwJh>}A"=r@@Y?Fetc...
+
+(Here, the `|` characters are semantic, included just to separate the pieces in the list above; they are not actually in the data itself.)
+
+The following sections break down each component in detail.
 
 #### Index
-Since an account can only have 1000 entries, we only need 10 bits for an index field. We need indices to be ASCII-sortable in Horizon, so the index is expressed as a "base 36" value: 0-9 then a-z.
+Since an account can only have 1000 entries, we only need 10 bits for an index field. We _only_ need indices present so that the data entries are ASCII-sortable in Horizon. In fact, decoders can ignore it entirely if they wish. Thus, the index is expressed as a "base 36" value: 0-9 then a-z.
 
 A valid SEP-39 entry always begins with `00`, indicating that this is the 0th row of data. In fact, every row's key _must_ begin with a two-character, [Base36] index.
 
 ---------
 
-**Author's note**: This portion is definitely up for debate. Base36 (well, more accurately, a radix of 36) allows us to shave a byte off of each row (saving up to 1kB total), but we could stick to a 000-999 model (stringified integer) for simplicity. Note that supporting it is trivial in any language, however, since we know it's strictly an integer. For example,
+**Author's note**: This portion is definitely up for debate. Base36 (well, more accurately, a radix of 36) allows us to shave a byte off of each row (saving up to 1kB total), but we could stick to a 000-999 model (stringified integer) for simplicity. We could also do `aa` through `zz`, because as noted, the indices are _purely_ for sorting. 
+
+Note that supporting a 36-radix is trivial in any language, since we know the value is strictly an integer. For example,
 
 ```python
 import string 
@@ -80,27 +92,27 @@ def b36_to_int(s: str) -> int:
     return ALPHABET.index(s[0]) * len(ALPHABET) + ALPHABET.index(s[1])
 ```
 
-Another consideration is perhaps trying to have **two** indices within this value. Since we need 10 bits, we can use the other 6 for identifying this asset within the account itself. There's still the question of printables, but  though, so this needs more thought.
-
 ---------
 
 #### Version
 The first entry's index is followed by the version string. For the current version of this SEP, this is just `1`.
 
 #### Metadata
-The **metadata** is a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) alongside any associated parameters. It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid Media Type will never start with a digit. Note that row indices are not included in the metadata length.
+The **metadata** is a comma-separated list of [Media Type]s alongside any associated parameters.
 
-**Author's note**: If we go with a radix of 36, we could use that here, too.
+It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid [Media Type] will never start with a digit. Note that row indices are not included in the metadata length.
 
-There are no *required* parameters.
+There is only one standardized parameter:
 
-Standard *optional* parameters include:
+  * `l`: this defines the *length* (in _raw_ bytes, not encoded data) of this media type within the binary data
 
-  * `n`: this defines the name or "title" of your asset
-  * `d`: this provides a description your asset
-  * `c`: a crc32 checksum of the asset
+You may include others as you see fit.
 
-Metadata _must_ only be composed of printable ASCII characters.
+If there is more than one [Media Type], the length parameter `l` _must_ be set for all but the last type. If there is only one, it may be omitted entirely.
+
+Media types are separated by a comma (`,`) character. For example, this metadata tells us that there text followed by an image within the binary buffer:
+
+    text/plain;l=13,image/png
 
 #### Binary Data
 With the header out of the way, we need to describe the way the remaining binary data should be represented in `ManageData` entries.
@@ -112,6 +124,8 @@ The _value_ can be any binary data; thus, no encoding is necessary.
 All of the binary data is thus prepended with an index, the next BasE91-encoded chunk sized to fit into the 64-length key string, and the next 64-byte binary chunk as the value.
 
 If the final entry fits into the key (that is, the value is not necessary), the encoder _must_ set the value to an empty buffer (as opposed to `nil` or `null`). Otherwise, this will delete the entry.
+
+If there are multiple media types (see [above](#metadata)), the binary data should be _encoded as one big stream_, rather than encoded separately. This eases decoding.
 
 #### Implementation Note
 Because you cannot predict the length of your encoded string without doing the encoding itself, it will be necessary to use trial-and-error to find the longest binary chunk that fits in <= 64 bytes. While this does mildly impact encoding time, it ensures optimality on-chain.
@@ -179,4 +193,4 @@ A malicious account could have data entries whose indices interleave with the SE
 
 [Base32]: https://en.wikipedia.org/wiki/Base36
 [BasE91]: http://base91.sourceforge.net/
-[MIME type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+[Media Type]: https://www.iana.org/assignments/media-types/media-types.xhtml

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -96,7 +96,7 @@ Based on an approximation formula to account for encoding expanding the binary s
 
     ceil(|data| / ((64 / 1.15) + 64))
 
-Note that accounts are limited to 1000 sub-entries (so just over 100 KiB), so larger assets would need to either be split across multiple accounts or stored off-chain.
+Note that accounts are limited to 1000 sub-entries (so just over 100 KiB), so larger assets would need to either be split across multiple accounts or stored off-chain. This SEP does not address this.
 
 ### Example Implementation
 The following is an example Python implementation of this SEP.

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -22,7 +22,7 @@ With that CAP, the data model introduced [below](#specification) could/should ch
 
 
 ## Motivation
-With NFT marketplaces on the rise in the Stellar network (e.g. [Litemint](https://litemint.com/) and [Stellar Quest](https://quest.stellar.org/)), it's important to establish standards to ensure cross-compatibility of NFTs. Certain platforms may choose to store their asset--whether that be an image as we often see today or any arbitrary digital trinket--on the Stellar ledger itself rather than delegating to an off-chain storage mechanism such as [IPFS](https://ipfs.io/).
+With NFT marketplaces on the rise in the Stellar network (e.g. [Litemint](https://litemint.com/) and [Stellar Quest](https://quest.stellar.org/)), it's important to establish standards to ensure cross-compatibility of NFTs. Certain platforms may choose to store their asset---whether that be an image as we often see today or any arbitrary digital trinket---on the Stellar ledger itself rather than delegating to an off-chain storage mechanism such as [IPFS](https://ipfs.io/).
 
 A standard storage mechanism will help these marketplaces and wallets render or otherwise represent the NFT within their applications, enhancing their transferability.
 
@@ -56,9 +56,9 @@ The _value_ can be any binary data; thus, no encoding is necessary.
 ### Representing the Data
 With the encoding described [above](#encoding-binary-data), we can now discuss the actual storage. Again, we'll use the `ManageData` operation to store the binary data. 
 
-The first entry _may_ be a [MIME type], followed by the first chunk of data, separated by a dash character (`-`). The MIME type *must* fit in a single key, and so must be <= 63 characters long.
+The first entry _may_ be a [MIME type], followed by the first chunk of data, separated by a comma character (`,`). The MIME type *must* fit in a single key, and so must be <= 63 characters long.
 
-If the MIME type is excluded, the dash _must_ still be included so that readers can easily distinguish where the type starts and the data begins.
+If the MIME type is excluded, the comma _must_ still be included so that readers can easily distinguish where the type starts and the data begins.
 
 Every subsequent entry is simply the next BasE91-encoded chunk, sized to fit into the 64-length key string, and the next 64-byte binary chunk.
 
@@ -68,7 +68,7 @@ For example,
 
 | Key | Value |
 |:----|:-----:|
-| text/plain-'ZP^gp@..<etc>.. | .. 64 bytes .. |
+| text/plain,'ZP^gp@..<etc>.. | .. 64 bytes .. |
 | Io1Tc%ZEYkE#^IR`0e..<etc>.. | .. 64 bytes .. |
 | %yO){B&mA#_1:W8{lT..<etc>.. | .. 64 bytes .. |
 | Cvnu8jZBP>1]TX2$g%..<etc>.. | .. 64 bytes .. |
@@ -111,7 +111,8 @@ from typing import List, Tuple
 
 def encode(mime_type: str, data: bytes) -> List[Tuple[str, bytes]]:
     rows = []
-    mime_type += '-' # add separator
+    assert ',' not in mime_type, "invalid MIME type"
+    mime_type += ',' # add separator
 
     # Prepend the mime type to the first entry
     key, data = _encode_nearest(data, 64 - len(mime_type))
@@ -131,7 +132,7 @@ def encode(mime_type: str, data: bytes) -> List[Tuple[str, bytes]]:
 
 def decode(rows):
     key1, value1 = rows[0]
-    i = key1.rfind('-')     # search from the tail since MIME might contain dash
+    i = key1.find(',')
     mime_type, etc = key1[:i], key1[i+1:]
 
     binary = base91.decode(etc) + value1
@@ -171,7 +172,7 @@ Due to the ever-evolving nature of the crypto space, we should not restrict ours
 
 There are obviously many ways to encode arbitrary data in a text stream. However, due to the high cost of storing data on chain, every byte counts, so we aim to have an efficient design.
 
-Keeping in mind the restrictions on `ManageData`--specifically, that the key *must* be a valid string (that is, made of printable characters), while the value *can* be any bytes--we need the most efficient encoder of binary to text data we can find. In a similar vein, we _could_ encode the binary values of each `ManageData` row to have consistency across keys and values, but this would be unnecessarily sacrificing a non-trivial efficiency.
+Keeping in mind the restrictions on `ManageData`---specifically, that the key *must* be a valid string (that is, made of printable characters), while the value *can* be any bytes---we need the most efficient encoder of binary to text data we can find. In a similar vein, we _could_ encode the binary values of each `ManageData` row to have consistency across keys and values, but this would be unnecessarily sacrificing a non-trivial efficiency.
 
 While BasE91 is a little more esoteric than the near-universal base64, libraries exist in many languages and the efficient gain is significant enough to be worth the additional implementation overhead. The implementation itself is also very straightforward (for example, [here](https://github.com/aberaud/base91-python/blob/master/base91.py) is a one-page Python implementation).
 

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -63,7 +63,7 @@ We begin by describing the raw data format, then dive into each component:
 
 For example,
 
-    00|1|26|text/plain;l=13,image/webp|TPwJh>}A"=r@@Y?Fetc...
+    00|1|26|text/plain;s=13,image/webp|TPwJh>}A"=r@@Y?Fetc...
 
 (Here, the `|` characters are semantic, included just to separate the pieces in the list above; they are not actually in the data itself.)
 
@@ -104,11 +104,11 @@ It is prefixed by a **length**, which is just a stringified integer (that is, a 
 
 There is only one standardized parameter:
 
-  * `l`: this defines the *length* (in _raw_ bytes, not encoded data) of this media type within the binary data
+  * `s`: this defines the *size* (in _raw_ bytes, not encoded data) of this media type within the binary data
 
 You may include others as you see fit.
 
-If there is more than one [Media Type], the length parameter `l` _must_ be set for all but the last type. If there is only one, it may be omitted entirely.
+If there is more than one [Media Type], the size parameter `s` _must_ be set for all but the last type. If there is only one, it may be omitted entirely.
 
 Media types are separated by a comma (`,`) character. For example, this metadata tells us that there text followed by an image within the binary buffer:
 

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -95,7 +95,7 @@ The first entry's index is followed by the version string. For the current versi
 #### Metadata
 The **metadata** is a comma-separated list of [Media Type]s alongside any associated parameters. Naturally, the [Media Type]s must be valid.
 
-It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid [Media Type] will never start with a digit. Note that row indices are not included in the metadata length.
+It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid [Media Type] will never start with a digit. However, since the [Media Type] is optional, take care to stop correctly if the length is `0`. Note that row indices are not included in the metadata length.
 
 There are a few standardized parameters:
 

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -5,9 +5,9 @@ SEP: 0039
 Title: On-Chain NFTs: Storage of Non-Fungible Assets
 Authors: George Kudrayvtsev (@Shaptic), Tyler van der Hoeven (@tyvdh)
 Track: Standard
-Status: Draft
+Status: Awaiting Decision
 Created: 2021-11-22
-Updated: 2021-12-01
+Updated: 2021-12-05
 Version: 0.1.0
 Discussion: https://github.com/stellar/stellar-protocol/pull/1090/
 ```

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -62,16 +62,19 @@ If the MIME type is excluded, the dash _must_ still be included so that readers 
 
 Every subsequent entry is simply the next BasE91-encoded chunk, sized to fit into the 64-length key string, and the next 64-byte binary chunk.
 
+If the final entry fits into the key (that is, the value is not necessary), the encoder _must_ split it into a key and a value. Specifically, since the number of bytes remaining is definitely <= 64, the key _must_ be composed of dash (`-`) characters and the value _must_ be the final chunk.
+
 For example,
 
 | Key | Value |
 |:----|:-----:|
-| text/plain-'ZP^gp@... | .. 64 bytes .. |
-| Io1Tc%ZEYkE#^IR`0e... | .. 64 bytes .. |
-| %yO){B&mA#_1:W8{lT... | .. 64 bytes .. |
-| Cvnu8jZBP>1]TX2$g%B'  | <empty> |
+| text/plain-'ZP^gp@..<etc>.. | .. 64 bytes .. |
+| Io1Tc%ZEYkE#^IR`0e..<etc>.. | .. 64 bytes .. |
+| %yO){B&mA#_1:W8{lT..<etc>.. | .. 64 bytes .. |
+| Cvnu8jZBP>1]TX2$g%..<etc>.. | .. 64 bytes .. |
+| `-`                         | B' |
 
-would be a valid entry. There's no need for padding.
+Is a valid formulation of this edge case.
 
 #### Implementation Note
 Because you cannot predict the length of your encoded string without doing the encoding itself, it will be necessary to use trial-and-error to find the longest binary chunk that fits in <= 64 bytes. While this does mildly impact encoding time, it ensures optimality on-chain.
@@ -117,6 +120,10 @@ def encode(mime_type: str, data: bytes) -> List[Tuple[str, bytes]]:
 
     while data:
         key, data = _encode_nearest(data, 64)
+        if not data:
+            rows.append(('-', data))
+            break
+
         value, data = data[:64], data[64:]
         rows.append((key, value))
 
@@ -129,6 +136,9 @@ def decode(rows):
 
     binary = base91.decode(etc) + value1
     for key, value in rows[1:]:
+        if key.startswith("-"):
+            binary += value
+            break
         binary += base91.decode(key) + value
 
     return mime_type, binary

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -74,45 +74,42 @@ Since an account can only have 1000 entries, we only need 10 bits for an index f
 
 A valid SEP-39 entry always begins with `00`, indicating that this is the 0th row of data. In fact, every row's key _must_ begin with a two-character, [Base36] index.
 
----------
-
-**Author's note**: This portion is definitely up for debate. Base36 (well, more accurately, a radix of 36) allows us to shave a byte off of each row (saving up to 1kB total), but we could stick to a 000-999 model (stringified integer) for simplicity. We could also do `aa` through `zz`, because as noted, the indices are _purely_ for sorting. 
-
-Note that supporting a 36-radix is trivial in any language, since we know the value is strictly an integer. For example,
+Note that supporting a radix of 36 is trivial in any language, since we know the value is strictly an integer. For example,
 
 ```python
 import string 
 ALPHABET = string.digits + string.ascii_lowercase
 
-def int_to_b36(i: int) -> str:
+def encode_index(i: int) -> str:
+    assert i >= 0 and i <= 1295, f"{i} is out of range"
     d, r = divmod(i, len(ALPHABET))
     return ALPHABET[d] + ALPHABET[r]
 
-def b36_to_int(s: str) -> int:
-    return ALPHABET.index(s[0]) * len(ALPHABET) + ALPHABET.index(s[1])
+def decode_index(s: str) -> int:
+    return int(i, 36)
 ```
 
----------
-
 #### Version
-The first entry's index is followed by the version string. For the current version of this SEP, this is just `1`.
+The first entry's index is followed by the version string. For the current version of this SEP, this is just the character `1`.
 
 #### Metadata
-The **metadata** is a comma-separated list of [Media Type]s alongside any associated parameters.
+The **metadata** is a comma-separated list of [Media Type]s alongside any associated parameters. Naturally, the [Media Type]s must be valid.
 
 It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid [Media Type] will never start with a digit. Note that row indices are not included in the metadata length.
 
-There is only one standardized parameter:
+There are a few standardized parameters:
 
   * `s`: this defines the *size* (in _raw_ bytes, not encoded data) of this media type within the binary data
+  * `n` (optional): this defines the *name* of the buffer
+  * `c` (optional): includes the [crc32] checksum of the buffer, allowing for error-checking after parsing
 
 You may include others as you see fit.
 
-If there is more than one [Media Type], the size parameter `s` _must_ be set for all but the last type. If there is only one, it may be omitted entirely.
+If there is more than one [Media Type], the size parameter `s` _must_ be set for all but the last Type. It is optional on the last Type. If there is only one Type, it may be omitted entirely.
 
-Media types are separated by a comma (`,`) character. For example, this metadata tells us that there text followed by an image within the binary buffer:
+[Media Type]s are separated by a comma (`,`) character. For example, this metadata tells us that there text followed by an image within the binary buffer:
 
-    text/plain;l=13,image/png
+    text/plain;s=13;n=title,image/png
 
 #### Binary Data
 With the header out of the way, we need to describe the way the remaining binary data should be represented in `ManageData` entries.
@@ -161,10 +158,7 @@ Based on an approximation formula to account for encoding expanding the binary s
 Note that accounts are limited to 1000 sub-entries (so just over 100 KiB), so larger assets would need to either be split across multiple accounts or stored off-chain. This SEP does not address this.
 
 ### Example Implementation
-The following section will include an example Python implementation of this SEP once it exists the _Draft_ phase.
-
-```python
-```
+A reference implementation in Python is included [here](https://github.com/Shaptic/sep-39).
 
 
 ## Design Rationale
@@ -182,15 +176,16 @@ A comparison with alternative encoders follows below. The tests were done by usi
   * `uuencode`: +20%
   * `hex`: +24%
 
-If we also encode the value with BasE91 (for consistency across keys and values), we need +13% more entries.
+If we also encoded values with BasE91 (for consistency across keys and values), we need +13% more entries.
 
 
 ## Security Concerns
 The BasE91 encoding does not have the web (or JSON) in mind. Any rendering of the actual entries will need to take care to do proper escaping.
 
-A malicious account could have data entries whose indices interleave with the SEP-39 entries. If this is a concern, care should be taken to (a) ensure that indices are correct (that is, increment each time) and (b) validate a checksum on the data.
+A malicious account could have data entries whose indices interleave with the SEP-39 entries. If this is a concern, care should be taken to (a) ensure that indices are correct (that is, increment each time) and (b) validate a checksum on the data. Note that the checksum is **not** intended to provide integrity or any cryptographic guarantees; it's merely there for error-checking.
 
 
 [Base32]: https://en.wikipedia.org/wiki/Base36
 [BasE91]: http://base91.sourceforge.net/
 [Media Type]: https://www.iana.org/assignments/media-types/media-types.xhtml
+[CRC32]: https://en.wikipedia.org/wiki/Cyclic_redundancy_check#CRC-32_algorithm

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -1,7 +1,7 @@
 ## Preamble
 
 ```
-SEP: To Be Assigned
+SEP: 0039
 Title: On-Chain Storage of Non-Fungible Assets
 Author: George Kudrayvtsev (@Shaptic)
 Track: Standard

--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -2,17 +2,19 @@
 
 ```
 SEP: 0039
-Title: On-Chain Storage of Non-Fungible Assets
-Author: George Kudrayvtsev (@Shaptic)
+Title: On-Chain NFTs: Storage of Non-Fungible Assets
+Authors: George Kudrayvtsev (@Shaptic), Tyler van der Hoeven (@tyvdh)
 Track: Standard
 Status: Draft
 Created: 2021-11-22
-Discussion: TODO
+Updated: 2021-12-01
+Version: 0.1.0
+Discussion: https://github.com/stellar/stellar-protocol/pull/1090/
 ```
 
 
 ## Simple Summary
-This SEP describes a specific way to store arbitrary data on-chain with the goal of standardizing the way NFTs are represented in the Stellar ledger.
+This SEP describes a specific way to store arbitrary binary data on-chain with the goal of standardizing the way NFTs are represented in the Stellar ledger.
 
 
 ## Dependencies
@@ -28,11 +30,13 @@ A standard storage mechanism will help these marketplaces and wallets render or 
 
 
 ## Abstract
-We present an efficient encoding mechanism to store arbitrary binary data on the Stellar ledger via the `ManageData` operation. It will concatenate a MIME-type alongside the aforementioned encoded-text as keys and raw binary data as values.
+We present an efficient encoding mechanism to store arbitrary binary data on the Stellar ledger via the `ManageData` operation, specifically catering towards NFTs. It will concatenate a special SEP-39 header alongside a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) containing asset metadata alongside the aforementioned encoded-text as keys and raw binary data as values.
 
 
 ## Specification
 First, we will discuss a common NFT issuance model and its ownership implications. This is not a required model, but sets the stage for why a standardized encoding of digital assets is necessary.
+
+**Warning**: Because of how indexing works (that is, each data entry for the asset begins with an index), an account can only hold a single SEP-39 asset at a time. Users should also take care not to have colliding keys that may interfere with ordering, and should lean on the (optional) checksum parameter if they're worried about decoding inconsistencies.
 
 ### NFT Issuance
 Given an arbitrary digital asset, here's how issuance typically works:
@@ -44,42 +48,86 @@ Given an arbitrary digital asset, here's how issuance typically works:
 
 Notice that ownership of the token directly conveys ownership of a unit of the asset, entirely within the Stellar ledger. Other scenarios such as locking down the issuing account to avoid supply increases, ownership transfers via payments, etc. are built on top of this basic model and are thus extraneous to this SEP.
 
-Our focus is Step 2: storing the asset within the account.
+Note also that this SEP does not address concerns around *immutability*. While there is an optional checksum component (addressed later), the account itself is free to modify the data at-will if it is not locked.
 
-### Encoding Binary Data
-We begin by describing how binary data should be represented in a `ManageData` entry.
+Our exclusive focus in this SEP is Step 2: **storing the asset within the account.**
 
-Since the _key_ is restricted specifically to printable characters (ref: Stellar Core's [`isString32Valid()`](https://github.com/stellar/stellar-core/blob/b031954458df3bb31d8d98f136c6fee40523a10d/src/util/types.cpp#L89-L101) and C's [`isprint()`](https://en.cppreference.com/w/cpp/string/byte/isprint)), this gives us an encoding space of 94 characters or ~6.5 bits per character (a ~25% reduction in the space). From some cursory research, the [BasE91] encoding scheme closest to this theoretical limit and outperforms base64 encoding.
+### Data Format
+We begin by describing the raw data format, then dive into each component.
+
+    00|version|metadata length|media-type;param1=value;param2=value;etc<binary data>
+
+Here, `|` is not a character, but rather a semantic divider used to separate the components. The following sections break down each component in detail.
+
+#### Index
+Since an account can only have 1000 entries, we only need 10 bits for an index field. We need indices to be ASCII-sortable in Horizon, so the index is expressed as a "base 36" value: 0-9 then a-z.
+
+A valid SEP-39 entry always begins with `00`, indicating that this is the 0th row of data. In fact, every row's key _must_ begin with a two-character, [Base36] index.
+
+---------
+
+**Author's note**: This portion is definitely up for debate. Base36 (well, more accurately, a radix of 36) allows us to shave a byte off of each row (saving up to 1kB total), but we could stick to a 000-999 model (stringified integer) for simplicity. Note that supporting it is trivial in any language, however, since we know it's strictly an integer. For example,
+
+```python
+import string 
+ALPHABET = string.digits + string.ascii_lowercase
+
+def int_to_b36(i: int) -> str:
+    d, r = divmod(i, len(ALPHABET))
+    return ALPHABET[d] + ALPHABET[r]
+
+def b36_to_int(s: str) -> int:
+    return ALPHABET.index(s[0]) * len(ALPHABET) + ALPHABET.index(s[1])
+```
+
+Another consideration is perhaps trying to have **two** indices within this value. Since we need 10 bits, we can use the other 6 for identifying this asset within the account itself. There's still the question of printables, but  though, so this needs more thought.
+
+---------
+
+#### Version
+The first entry's index is followed by the version string. For the current version of this SEP, this is just `1`.
+
+#### Metadata
+The **metadata** is a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) alongside any associated parameters. It is prefixed by a **length**, which is just a stringified integer (that is, a 32-byte metadata will have "32" as its length). When parsing, you should consume characters until hitting a non-digit, since a valid Media Type will never start with a digit. Note that row indices are not included in the metadata length.
+
+**Author's note**: If we go with a radix of 36, we could use that here, too.
+
+There are no *required* parameters.
+
+Standard *optional* parameters include:
+
+  * `n`: this defines the name or "title" of your asset
+  * `d`: this provides a description your asset
+  * `c`: a crc32 checksum of the asset
+
+Metadata _must_ only be composed of printable ASCII characters.
+
+#### Binary Data
+With the header out of the way, we need to describe the way the remaining binary data should be represented in `ManageData` entries.
+
+Since the _key_ is restricted specifically to printable characters (ref: Stellar Core's [`isString32Valid()`](https://github.com/stellar/stellar-core/blob/b031954458df3bb31d8d98f136c6fee40523a10d/src/util/types.cpp#L89-L101) and C's [`isprint()`](https://en.cppreference.com/w/cpp/string/byte/isprint)), this gives us an encoding space of 95 characters or ~6.5 bits per character (a ~25% reduction in the space). From our research, the [BasE91] encoding scheme is closest to this theoretical limit.
 
 The _value_ can be any binary data; thus, no encoding is necessary.
 
-### Representing the Data
-With the encoding described [above](#encoding-binary-data), we can now discuss the actual storage. Again, we'll use the `ManageData` operation to store the binary data. 
+All of the binary data is thus prepended with an index, the next BasE91-encoded chunk sized to fit into the 64-length key string, and the next 64-byte binary chunk as the value.
 
-The first entry _may_ be a [MIME type], followed by the first chunk of data, separated by a comma character (`,`). The MIME type *must* fit in a single key, and so must be <= 63 characters long.
-
-If the MIME type is excluded, the comma _must_ still be included so that readers can easily distinguish where the type starts and the data begins.
-
-Every subsequent entry is simply the next BasE91-encoded chunk, sized to fit into the 64-length key string, and the next 64-byte binary chunk.
-
-If the final entry fits into the key (that is, the value is not necessary), the encoder _must_ split it into a key and a value. Specifically, since the number of bytes remaining is definitely <= 64, the key _must_ be composed of dash (`-`) characters and the value _must_ be the final chunk.
-
-For example,
-
-| Key | Value |
-|:----|:-----:|
-| text/plain,'ZP^gp@..<etc>.. | .. 64 bytes .. |
-| Io1Tc%ZEYkE#^IR`0e..<etc>.. | .. 64 bytes .. |
-| %yO){B&mA#_1:W8{lT..<etc>.. | .. 64 bytes .. |
-| Cvnu8jZBP>1]TX2$g%..<etc>.. | .. 64 bytes .. |
-| `-`                         | B' |
-
-Is a valid formulation of this edge case.
+If the final entry fits into the key (that is, the value is not necessary), the encoder _must_ set the value to an empty buffer (as opposed to `nil` or `null`). Otherwise, this will delete the entry.
 
 #### Implementation Note
 Because you cannot predict the length of your encoded string without doing the encoding itself, it will be necessary to use trial-and-error to find the longest binary chunk that fits in <= 64 bytes. While this does mildly impact encoding time, it ensures optimality on-chain.
 
-(This is the function of `_encode_nearest()` in the sample implementation, [below](#implementation).)
+### Example
+Here is an example asset stored in SEP-39 format:
+
+| Key | Value |
+|:----|:-----:|
+| 00117text/plain;n=rick'ZP..<etc>.. | .. 64 bytes .. |
+| 01^gp@Io1Tc%ZEYkE#^IR`0e%..<etc>.. | .. 64 bytes .. |
+| 02yO){B&mA#_1:W8{lTCvnu8j..<etc>.. | .. 64 bytes .. |
+| ... etc ... |
+| a2ZBP>1]TX2$g%B' | <empty buffer> |
+
+There are 322 (`a2`) rows and 17 characters of metadata: `text/plain;n=rick`.
 
 ### Pricing Implications
 Every additional `ManageData` entry encurs an increase in the base reserve required by an account by 0.5 XLM. Some napkin-math pricing tables ensue:
@@ -99,84 +147,22 @@ Based on an approximation formula to account for encoding expanding the binary s
 Note that accounts are limited to 1000 sub-entries (so just over 100 KiB), so larger assets would need to either be split across multiple accounts or stored off-chain. This SEP does not address this.
 
 ### Example Implementation
-The following is an example Python implementation of this SEP.
+The following section will include an example Python implementation of this SEP once it exists the _Draft_ phase.
 
 ```python
-#! /usr/bin/env python3
-import math
-import base91
-
-from typing import List, Tuple
-
-
-def encode(mime_type: str, data: bytes) -> List[Tuple[str, bytes]]:
-    rows = []
-    assert ',' not in mime_type, "invalid MIME type"
-    mime_type += ',' # add separator
-
-    # Prepend the mime type to the first entry
-    key, data = _encode_nearest(data, 64 - len(mime_type))
-    value, data = data[:64], data[64:]
-    rows.append((mime_type + key, value))
-
-    while data:
-        key, data = _encode_nearest(data, 64)
-        if not data:
-            rows.append(('-', data))
-            break
-
-        value, data = data[:64], data[64:]
-        rows.append((key, value))
-
-    return rows
-
-def decode(rows):
-    key1, value1 = rows[0]
-    i = key1.find(',')
-    mime_type, etc = key1[:i], key1[i+1:]
-
-    binary = base91.decode(etc) + value1
-    for key, value in rows[1:]:
-        if key.startswith("-"):
-            binary += value
-            break
-        binary += base91.decode(key) + value
-
-    return mime_type, binary
-
-def _encode_nearest(data: bytes, n: int=64) -> Tuple[str, bytes]:
-    """ BasE91-encodes `data` as close to (but not exceeding) `n` as possible.
-    """
-    # We know that BasE91 will never do better than 10% overhead, so that's a
-    # reasonable starting point for trying to get exactly an n-sized chunk
-    # encoded.
-    for i in range(int(math.ceil(n / 1.10)), 0, -1):
-        encoded = base91.encode(data[:i])
-        if len(encoded) <= n:
-            return encoded, data[i:]
-
-    raise ValueError("can't encode %d-byte data into %d-len string" % (data, n))
-
-
-import random
-asset = random.randbytes(int(100e4))
-rows = encode("application/octet-stream", asset)
-mime, binary = decode(rows)
-assert asset == binary
-assert mime == "application/octet-stream"
 ```
 
 
 ## Design Rationale
 Due to the ever-evolving nature of the crypto space, we should not restrict ourselves to the specific use cases of NFTs we have today. Therefore, instead of catering directly towards a particular image format, we provide a specification for storing _arbitrary_ data.
 
-There are obviously many ways to encode arbitrary data in a text stream. However, due to the high cost of storing data on chain, every byte counts, so we aim to have an efficient design.
+However, we still designed the specification with NFTs in mind, stopping short of defining a universal spec for storing data on-chain. There are obviously many ways to encode arbitrary data in a text stream. However, due to the high cost of storing data on chain, every byte counts, so we aim to have an efficient design.
 
-Keeping in mind the restrictions on `ManageData`---specifically, that the key *must* be a valid string (that is, made of printable characters), while the value *can* be any bytes---we need the most efficient encoder of binary to text data we can find. In a similar vein, we _could_ encode the binary values of each `ManageData` row to have consistency across keys and values, but this would be unnecessarily sacrificing a non-trivial efficiency.
+Keeping in mind the restrictions on `ManageData`---specifically, that the key *must* be made of printable ASCII characters, while the value *can* be any bytes---we need the most efficient encoder of binary to text data we can find. In a similar vein, we _could_ encode the binary values of each `ManageData` row to have consistency across keys and values, but this would be unnecessarily sacrificing a non-trivial efficiency.
 
 While BasE91 is a little more esoteric than the near-universal base64, libraries exist in many languages and the efficient gain is significant enough to be worth the additional implementation overhead. The implementation itself is also very straightforward (for example, [here](https://github.com/aberaud/base91-python/blob/master/base91.py) is a one-page Python implementation).
 
-A comparison with alternative encoding methods follows below. It was done by using the same encoding scheme (that is, encode the key and store the value as-is) and on random data. Random data accurately reflects most _compressed_ data, and (lossless) compression should always be used to ensure no extra rows are needed on chain.
+A comparison with alternative encoders follows below. The tests were done by using the same specification as above on random data. Random data accurately reflects most _compressed_ data, and (lossless) compression should always be used to ensure no extra rows are needed on chain.
 
   * `base64`: +5% more entries, on average
   * `uuencode`: +20%
@@ -188,6 +174,9 @@ If we also encode the value with BasE91 (for consistency across keys and values)
 ## Security Concerns
 The BasE91 encoding does not have the web (or JSON) in mind. Any rendering of the actual entries will need to take care to do proper escaping.
 
+A malicious account could have data entries whose indices interleave with the SEP-39 entries. If this is a concern, care should be taken to (a) ensure that indices are correct (that is, increment each time) and (b) validate a checksum on the data.
 
+
+[Base32]: https://en.wikipedia.org/wiki/Base36
 [BasE91]: http://base91.sourceforge.net/
 [MIME type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types

--- a/ecosystem/sep-xxxx.md
+++ b/ecosystem/sep-xxxx.md
@@ -1,0 +1,182 @@
+## Preamble
+
+```
+SEP: To Be Assigned
+Title: On-Chain Storage of Non-Fungible Assets
+Author: George Kudrayvtsev (@Shaptic)
+Track: Standard
+Status: Draft
+Created: 2021-11-22
+Discussion: TODO
+```
+
+
+## Simple Summary
+This SEP describes a specific way to store arbitrary data on-chain with the goal of standardizing the way NFTs are represented in the Stellar ledger.
+
+
+## Dependencies
+While not an explicit dependency, there may be a future CAP that modifies the protocol to allow a 128-byte row of ManageData to be arbitrarily divided into the string "key" and binary "data" portions, as opposed to the current model of having strict 64-byte halves.
+
+With that CAP, the data model introduced [below](#specification) could/should change to be friendlier and more optimized.
+
+
+## Motivation
+With NFT marketplaces on the rise in the Stellar network (e.g. [Litemint](https://litemint.com/) and [Stellar Quest](https://quest.stellar.org/)), it's important to establish standards to ensure cross-compatibility of NFTs. Certain platforms may choose to store their asset--whether that be an image as we often see today or any arbitrary digital trinket--on the Stellar ledger itself rather than delegating to an off-chain storage mechanism such as [IPFS](https://ipfs.io/).
+
+A standard storage mechanism will help these marketplaces and wallets render or otherwise represent the NFT within their applications, enhancing their transferability.
+
+
+## Abstract
+We present an efficient encoding mechanism to store arbitrary binary data on the Stellar ledger via the `ManageData` operation. It will concatenate a MIME-type alongside the aforementioned encoded-text as keys and raw binary data as values.
+
+
+## Specification
+First, we will discuss a common NFT issuance model and its ownership implications. This is not a required model, but sets the stage for why a standardized encoding of digital assets is necessary.
+
+### NFT Issuance
+Given an arbitrary digital asset, here's how issuance typically works:
+
+  1. An account is created to represent the digital asset on the ledger
+  2. The account stores the entire digital asset within its managed data entries.
+  3. The account issues a Stellar asset representing ownership over the digital asset we just stored.
+  4. Any account holding that Stellar asset lays claim to the digital asset.
+
+Notice that ownership of the token directly conveys ownership of a unit of the asset, entirely within the Stellar ledger. Other scenarios such as locking down the issuing account to avoid supply increases, ownership transfers via payments, etc. are built on top of this basic model and are thus extraneous to this SEP.
+
+Our focus is Step 2: storing the asset within the account.
+
+### Encoding Binary Data
+We begin by describing how binary data should be represented in a `ManageData` entry.
+
+Since the _key_ is restricted specifically to printable characters (ref: Stellar Core's [`isString32Valid()`](https://github.com/stellar/stellar-core/blob/b031954458df3bb31d8d98f136c6fee40523a10d/src/util/types.cpp#L89-L101) and C's [`isprint()`](https://en.cppreference.com/w/cpp/string/byte/isprint)), this gives us an encoding space of 94 characters or ~6.5 bits per character (a ~25% reduction in the space). From some cursory research, the [BasE91] encoding scheme closest to this theoretical limit and outperforms base64 encoding.
+
+The _value_ can be any binary data; thus, no encoding is necessary.
+
+### Representing the Data
+With the encoding described [above](#encoding-binary-data), we can now discuss the actual storage. Again, we'll use the `ManageData` operation to store the binary data. 
+
+The first entry _may_ be a [MIME type], followed by the first chunk of data, separated by a dash character (`-`). The MIME type *must* fit in a single key, and so must be <= 63 characters long.
+
+If the MIME type is excluded, the dash _must_ still be included so that readers can easily distinguish where the type starts and the data begins.
+
+Every subsequent entry is simply the next BasE91-encoded chunk, sized to fit into the 64-length key string, and the next 64-byte binary chunk.
+
+For example,
+
+| Key | Value |
+|:----|:-----:|
+| text/plain-'ZP^gp@... | .. 64 bytes .. |
+| Io1Tc%ZEYkE#^IR`0e... | .. 64 bytes .. |
+| %yO){B&mA#_1:W8{lT... | .. 64 bytes .. |
+| Cvnu8jZBP>1]TX2$g%B'  | <empty> |
+
+would be a valid entry. There's no need for padding.
+
+#### Implementation Note
+Because you cannot predict the length of your encoded string without doing the encoding itself, it will be necessary to use trial-and-error to find the longest binary chunk that fits in <= 64 bytes. While this does mildly impact encoding time, it ensures optimality on-chain.
+
+(This is the function of `_encode_nearest()` in the sample implementation, [below](#implementation).)
+
+### Pricing Implications
+Every additional `ManageData` entry encurs an increase in the base reserve required by an account by 0.5 XLM. Some napkin-math pricing tables ensue:
+
+| Data Size | ManageData Entries | Cost (XLM) |
+|----------:|--------------------|------------|
+|  10 B     | 1                  | 0.5        |
+|   1 KB    | 9                  | 4.5        |
+|  50 KB    | 418                | 209        |
+| 112 KB    | 937                | 468.5      |
+|   1 MB    | 8358               | 4179       |
+
+Based on an approximation formula to account for encoding expanding the binary size by 10-15%:
+
+    ceil(|data| / ((64 / 1.15) + 64))
+
+Note that accounts are limited to 1000 sub-entries (so just over 100 KiB), so larger assets would need to either be split across multiple accounts or stored off-chain.
+
+### Example Implementation
+The following is an example Python implementation of this SEP.
+
+```python
+#! /usr/bin/env python3
+import math
+import base91
+
+from typing import List, Tuple
+
+
+def encode(mime_type: str, data: bytes) -> List[Tuple[str, bytes]]:
+    rows = []
+    mime_type += '-' # add separator
+
+    # Prepend the mime type to the first entry
+    key, data = _encode_nearest(data, 64 - len(mime_type))
+    value, data = data[:64], data[64:]
+    rows.append((mime_type + key, value))
+
+    while data:
+        key, data = _encode_nearest(data, 64)
+        value, data = data[:64], data[64:]
+        rows.append((key, value))
+
+    return rows
+
+def decode(rows):
+    key1, value1 = rows[0]
+    i = key1.rfind('-')     # search from the tail since MIME might contain dash
+    mime_type, etc = key1[:i], key1[i+1:]
+
+    binary = base91.decode(etc) + value1
+    for key, value in rows[1:]:
+        binary += base91.decode(key) + value
+
+    return mime_type, binary
+
+def _encode_nearest(data: bytes, n: int=64) -> Tuple[str, bytes]:
+    """ BasE91-encodes `data` as close to (but not exceeding) `n` as possible.
+    """
+    # We know that BasE91 will never do better than 10% overhead, so that's a
+    # reasonable starting point for trying to get exactly an n-sized chunk
+    # encoded.
+    for i in range(int(math.ceil(n / 1.10)), 0, -1):
+        encoded = base91.encode(data[:i])
+        if len(encoded) <= n:
+            return encoded, data[i:]
+
+    raise ValueError("can't encode %d-byte data into %d-len string" % (data, n))
+
+
+import random
+asset = random.randbytes(int(100e4))
+rows = encode("application/octet-stream", asset)
+mime, binary = decode(rows)
+assert asset == binary
+assert mime == "application/octet-stream"
+```
+
+
+## Design Rationale
+Due to the ever-evolving nature of the crypto space, we should not restrict ourselves to the specific use cases of NFTs we have today. Therefore, instead of catering directly towards a particular image format, we provide a specification for storing _arbitrary_ data.
+
+There are obviously many ways to encode arbitrary data in a text stream. However, due to the high cost of storing data on chain, every byte counts, so we aim to have an efficient design.
+
+Keeping in mind the restrictions on `ManageData`--specifically, that the key *must* be a valid string (that is, made of printable characters), while the value *can* be any bytes--we need the most efficient encoder of binary to text data we can find. In a similar vein, we _could_ encode the binary values of each `ManageData` row to have consistency across keys and values, but this would be unnecessarily sacrificing a non-trivial efficiency.
+
+While BasE91 is a little more esoteric than the near-universal base64, libraries exist in many languages and the efficient gain is significant enough to be worth the additional implementation overhead. The implementation itself is also very straightforward (for example, [here](https://github.com/aberaud/base91-python/blob/master/base91.py) is a one-page Python implementation).
+
+A comparison with alternative encoding methods follows below. It was done by using the same encoding scheme (that is, encode the key and store the value as-is) and on random data. Random data accurately reflects most _compressed_ data, and (lossless) compression should always be used to ensure no extra rows are needed on chain.
+
+  * `base64`: +5% more entries, on average
+  * `uuencode`: +20%
+  * `hex`: +24%
+
+If we also encode the value with BasE91 (for consistency across keys and values), we need +13% more entries.
+
+
+## Security Concerns
+The BasE91 encoding does not have the web (or JSON) in mind. Any rendering of the actual entries will need to take care to do proper escaping.
+
+
+[BasE91]: http://base91.sourceforge.net/
+[MIME type]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types


### PR DESCRIPTION
Minimum interested parties: @leighmcculloch, @tyvdh, @FredericRezeau.

This is a resurrection of #902, specifically scoped to tackle standardizing the way we store arbitrary binary on the ledger under the context of NFTs. This does not cover a standard for NFT _metadata_, which I hope Frederic will spearhead.

The proposal iterates on @tyvdh's approach in [this comment](https://github.com/stellar/stellar-protocol/pull/902#issuecomment-840766958) on how it's done in Stellar Quest (replicated here for convenience):

> How I'm accomplishing this is by using the key and value entries to store data vs just the value. The key of the manage data attribute is capped at 64 characters or 48 bytes. The first 2 bytes of the key are an indexing value from 0 to 999. The last 46 bytes are the first/next chunk of the data buffer. The value is just a simple slice of 64 bytes of the next chunk of the data buffer. You carry on creating chunks and adding them to the transaction(s) up to 1,000 key:value pairs. 

The iteration in this SEP on the above is:

1. standardizing the way binary data is encoded into the ASCII key field by using the highly-efficient [BasE91 encoding](http://base91.sourceforge.net/)
2. optimizing the storage format, e.g. because `ManageData` entries in an account are already ordered, there is no need to store indexing information
3. introducing a way to hint about the type of data by prepending a [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) to the first entry
4. providing an example implementation alongside performance comparisons to a handful of other binary-to-text encoding schemes