### PR TITLE
SEP: Add updated and version pragma to sep template

### DIFF
--- a/sep-template.md
+++ b/sep-template.md
@@ -7,6 +7,8 @@ Author: <list of authors' names, GitHub handles, and optionally, email addresses
 Track: <Informational or Standard>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+Updated: <date last updated, in ISO 8601 (yyyy-mm-dd) format>
+Version: 0.1.0
 Discussion: <link to where discussion for this SEP is taking place, typically the mailing list>
 ```
 

--- a/sep-template.md
+++ b/sep-template.md
@@ -7,7 +7,7 @@ Author: <list of authors' names, GitHub handles, and optionally, email addresses
 Track: <Informational or Standard>
 Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
-Updated: <date last updated, in ISO 8601 (yyyy-mm-dd) format>
+Updated: <date created or last updated, in ISO 8601 (yyyy-mm-dd) format>
 Version: 0.1.0
 Discussion: <link to where discussion for this SEP is taking place, typically the mailing list>
 ```


### PR DESCRIPTION
### What
Add updated and version pragma to SEP template.

### Why
The fields are frequently used in many SEPs. The ecosystem folder's README even details instructions for how the version field should be used. It looks like it was never added to the template.

The version in the template is set to 0.1.0 because for a new draft SEP that's the typical version we'll use, keeping the major number 0.