### PR TITLE
SEP-9: Add organization registration date

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -7,7 +7,7 @@ Author: stellar.org
 Status: Active
 Created: 2018-07-27
 Updated: 2022-01-03
-Version 1.5.1
+Version 1.5.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2021-07-19
-Version 1.4.1
+Updated: 2022-01-03
+Version 1.5.1
 ```
 
 ## Simple Summary
@@ -90,6 +90,7 @@ Name | Type | Description
 `organization.name` | string | Full organiation name as on the incorporation papers
 `organization.VAT_number` | string | Organization VAT number 
 `organization.registration_number` | string | Organization registration number
+`organization.registration_date` | string | Date the organization was registered
 `organization.registered_address` | string | Organization registered address
 `organization.number_of_shareholders` | number | Organization shareholder number
 `organization.shareholder_name` | string | Can be an organization or a person and should be queried recursively up to the ultimate beneficial owners (with KYC information for natural persons such as above)


### PR DESCRIPTION
### What
Add organization registration date to SEP-9.

### Why
It's been reported in #1074 that the registration date of a business is a field that is commonly asked for during onboarding. This field is currently missing in the organization KYC fields and it would be useful if we included it given it is common.

Close #1074

cc @ymatienzo