### PR TITLE
SEP: Add changelog section to SEP template

### DIFF
--- a/sep-template.md
+++ b/sep-template.md
@@ -46,8 +46,8 @@ All SEPs should contain a changelog that succinctly lists its versions and what 
 
 Example:
 
-- `v0.1.0`: Initial draft. [#1000](https://github.com/stellar/stellar-protocol/pulls/1000)
-- `v0.2.0`: Redesigned the API. [#1004](https://github.com/stellar/stellar-protocol/pulls/1004)
-- `v1.0.0`: Updated status to Active. [#1234](https://github.com/stellar/stellar-protocol/pulls/1234)
-- `v1.1.0`: Add new paremeters to the X endpoint. [#3498](https://github.com/stellar/stellar-protocol/pulls/3498)
 - `v1.1.1`: Fix misleading statements about the P parameter. [#3499](https://github.com/stellar/stellar-protocol/pulls/3499)
+- `v1.1.0`: Add new paremeters to the X endpoint. [#3498](https://github.com/stellar/stellar-protocol/pulls/3498)
+- `v1.0.0`: Updated status to Active. [#1234](https://github.com/stellar/stellar-protocol/pulls/1234)
+- `v0.2.0`: Redesigned the API. [#1004](https://github.com/stellar/stellar-protocol/pulls/1004)
+- `v0.1.0`: Initial draft. [#1000](https://github.com/stellar/stellar-protocol/pulls/1000)

--- a/sep-template.md
+++ b/sep-template.md
@@ -42,7 +42,7 @@ All SEPs should carefully consider areas where security may be a concern, and do
 accordingly. If a change does not have security implications, write "N/A".
 
 ## Changelog
-All SEPs should contain a changelog that succinctly lists its versions and what change was introduced in each version. Information included should contain a succinct by complete description of what has changed. Succinct is important so that over time a large changelog is easily digested.
+All SEPs should contain a changelog that succinctly lists its versions and what changes were introduced in each version. A complete description of what has changed should be included, but it should be as succinct as possible. Succinct is important so that over time a large changelog is easily digested.
 
 Example:
 

--- a/sep-template.md
+++ b/sep-template.md
@@ -42,6 +42,12 @@ All SEPs should carefully consider areas where security may be a concern, and do
 accordingly. If a change does not have security implications, write "N/A".
 
 ## Changelog
+All SEPs should contain a changelog that succinctly lists its versions and what change was introduced in each version. Information included should contain a succinct by complete description of what has changed. Succinct is important so that over time a large changelog is easily digested.
+
+Example:
+
 - `v0.1.0`: Initial draft.
 - `v0.2.0`: Redesigned the API.
 - `v1.0.0`: Updated status to Active.
+- `v1.1.0`: Add new paremeters to the X endpoint.
+- `v1.1.1`: Fix misleading statements about the P parameter.

--- a/sep-template.md
+++ b/sep-template.md
@@ -46,8 +46,8 @@ All SEPs should contain a changelog that succinctly lists its versions and what 
 
 Example:
 
-- `v0.1.0`: Initial draft.
-- `v0.2.0`: Redesigned the API.
-- `v1.0.0`: Updated status to Active.
-- `v1.1.0`: Add new paremeters to the X endpoint.
-- `v1.1.1`: Fix misleading statements about the P parameter.
+- `v0.1.0`: Initial draft. [#1000](https://github.com/stellar/stellar-protocol/pulls/1000)
+- `v0.2.0`: Redesigned the API. [#1004](https://github.com/stellar/stellar-protocol/pulls/1004)
+- `v1.0.0`: Updated status to Active. [#1234](https://github.com/stellar/stellar-protocol/pulls/1234)
+- `v1.1.0`: Add new paremeters to the X endpoint. [#3498](https://github.com/stellar/stellar-protocol/pulls/3498)
+- `v1.1.1`: Fix misleading statements about the P parameter. [#3499](https://github.com/stellar/stellar-protocol/pulls/3499)

--- a/sep-template.md
+++ b/sep-template.md
@@ -40,3 +40,8 @@ objections or concerns raised during discussion.
 ## Security Concerns
 All SEPs should carefully consider areas where security may be a concern, and document them
 accordingly. If a change does not have security implications, write "N/A".
+
+## Changelog
+- `v0.1.0`: Initial draft.
+- `v0.2.0`: Redesigned the API.
+- `v1.0.0`: Updated status to Active.


### PR DESCRIPTION
### What
Add a very lightweight changelog section to the SEP template.

### Why
This idea was suggested by @marcelosalloum in https://github.com/stellar/stellar-protocol/issues/1046#issuecomment-995861028.

SEP documents evolve over time but there is no location where a reader can quickly read in prose a description of what has changed from one version to the next. While the Git history and PR descriptions for changes made to the SEP provide insights it requires a lot of effort for a reader to sift through all that information to find what the final incremental changes are that have been made.

Requiring a changelog entry will also help us evaluate the necessity and clarity of a change since the changelog is persisted forever we must choose wisely the changes we make.

The changelog @marcelosalloum had proposed was a larger document with sections under each version. After some experimentation I am proposing a more lightweight changelog. The reason being is that version changes in SEPs are often quite different to software releases in that we don't usually queue up changes then issue a release. Instead we issue a release and update a version with every small change we make to a SEP. For this reason I think we need only a single line to briefly state what each versions change is. Since the changelog will grow over time this will also keep it succinct and easy to parse and read.

The changelog @marcelosalloum had proposed was a separate markdown document but I've included the changelog in the SEP itself. I think it is very helpful today that most things for a SEP live inside the one SEP document. If the changelog is at the end it is unlikely to get in the way of the document content. It is easier to discover as well if it is embedded.