### PR TITLE
SEP Proposal: A non-fungible token issuance and metadata specification

### DIFF
--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -96,12 +96,14 @@ The metadata must be valid JSON and must contain the following **required** fiel
 
 | Field       | Description |
 | ----------- | ----------- |
-| name | a short name or title for the NFT |
-| description | a longer, more-detailed description of the NFT |
-| type | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
-| uri  | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to the actual NFT contents |
-| issuer | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
-| code | the NFT's asset code |
+| `name` | a short name or title for the NFT |
+| `description` | a longer, more-detailed description of the NFT |
+| `type` | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
+| `uri` **or** `url`  | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to the actual NFT contents |
+| `issuer` | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
+| `code` | the NFT's asset code |
+
+We allow either `uri` or `url` to maintain compatibility with existing ecosystem conventions. If _both_ are present, prefer the `uri`.
 
 For example,
 
@@ -110,11 +112,13 @@ For example,
   "name": "A demonstration of NFT metadata",
   "description": "This is a description of the cool NFT used in this demo.",
   "type": "image/png",
-  "uri": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
+  "url": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
   "issuer": "GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO",
   "code": "DEMOASSET"
 }
 ```
+
+Means that the `DEMOASSET:GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO` asset represents [this image](https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg).
 
 There are other fields which are **optional** but standardized:
 
@@ -168,7 +172,7 @@ The issuance model follows Stellar's [standard model for issuing assets](https:/
 ### On the metadata specification
 While `ipfs://cid` is a type of URI, we allow `type: ipfshash` for compatibility with existing ecosystem conventions as well as to highlight the popularity of IPFS as a storage mechanism in the NFT ecosystem.
 
-The field `uri` was chosen instead of `url` in order to emphasize that data does not have to live on the traditional Web. Since URLs are a subset of URIs, this should not pose a problem to Web-centric platforms.
+The field `uri` was chosen in preference to `url` in order to emphasize that data does not have to live on the traditional Web. Since URLs are a subset of URIs, this should not pose a problem to Web-centric platforms, and the specification still allows `url` for ecosystem compatibility.
 
 
 ## Security Concerns
@@ -180,4 +184,4 @@ Those processing an NFT should take care to ensure that the `issuer` field match
 
 
 ## Changelog
-- `v0.1.0`: Initial draft ([#1000](https://github.com/stellar/stellar-protocol/pulls/1000)).
+- `v0.1.0`: Initial draft ([#1111](https://github.com/stellar/stellar-protocol/pulls/1111)).

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -25,7 +25,7 @@ Non-fungible tokens (NFTs) can describe many types of assets, from digital colle
 
 
 ## Specification
-We begin with the [issuance model](#issuance-model) and then cover the NFT [metadata specification](#nft-metadata-specification).
+The protocol defines an [issuance model](#issuance-model) that defines how NFT assets are issued on Stellar, and a [metadata specification](#nft-metadata-specification) that defines how data about the NFT is captured in a way that Stellar guarantees is immutable.
 
 ### Issuance Model
 Given an arbitrary digital asset, here's how issuance typically works:

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -23,21 +23,39 @@ A standard interface for NFTs that makes NFTs issued by any ecosystem applicatio
 ## Abstract
 Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. This protocol defines a standard series of steps that NFT creators should use to issue NFTs on the Stellar network, defines metadata to describe an NFT, and specifies how the metadata is linked to the NFT asset on Stellar.
 
-
-## Specification
-The protocol defines an [issuance model](#issuance-model) that defines how NFT assets are issued on Stellar, and a [metadata specification](#nft-metadata-specification) that defines how data about the NFT is captured in a way that Stellar guarantees is immutable.
-
-### Issuance Model
-Given an arbitrary digital asset, here's how issuance typically works:
+The issuance model involves four steps:
 
   1. An account is created specifically to represent the NFT in the Stellar ledger.
   2. The account configures itself with metadata describing the NFT.
   3. The account issues a new Stellar asset representing ownership over said NFT.
   4. Any account holding that asset lays claim to the NFT.
 
-Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as locking down the issuing account to avoid supply increases, ownership transfers via payments, etc. are built on top of this basic model and are thus extraneous to this SEP.
+The NFT model involves two levels of indirection in order to minimize on-chain storage:
 
-Note also that this SEP does not address concerns around immutability. While there is an optional checksum component (addressed later), the account itself is free to modify the data at-will if it is not locked.
+    +---------------+      +----------+      +---------+
+    |  Stellar NFT  | ---> | metadata | ---> |   NFT   |
+    |  account data |      |   JSON   |      | content |
+    +---------------+      +----------+      +---------+
+
+
+## Specification
+This SEP defines an [issuance model](#issuance-model) that defines how NFT assets are issued on Stellar and a [metadata specification](#nft-metadata-specification) that defines how data about the NFT is captured. The metadata is stored in a way such that the Stellar network guarantee its authenticity.
+
+### Issuance Model
+Standard issuance of NFTs must take the following steps:
+
+  1. Create an account to represent the NFT: `CreateAccountOp(A, <reserve>)`
+  2. Configure the NFT's metadata pointer, as described [below](#nft-account-description): `ManageDataOp("type", "...")`
+  3. Form an asset describing your NFT: `Code:Issuer` (where issuer is `A`)
+  4. Create a distribution account: `B = CreateAccountOp()` and `ChangeTrust("Code:Issuer", <limit>)`
+  5. Issue the tokens: `PaymentOp(B, "Code:Issuer", <amount>)`
+  6. (Optional) Lock the issuing account: `SetOptionsOp(MasterWeight: 0)`
+
+Note that without this final step, there are concerns around both immutability and supply: an account may modify its NFT metadata pointer or issue more tokens unless it's locked down. Thus, Step 6 is recommended.
+
+Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as ownership transfers via payments are built on top of this basic issuance model and are thus extraneous to this SEP.
+
+Other issuance models may exist and may be compatible with the following specification, but this is the standard issuance model on Stellar.
 
 ### NFT Specification
 This specification is partially inspired by Ethereum's [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721#specification) on NFTs; however, it is generalized to arbitrary asset types (i.e. not necessarily images).

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -41,41 +41,6 @@ The NFT model involves two levels of indirection in order to minimize on-chain s
 ## Specification
 This SEP defines an [issuance model](#issuance-model) that defines how NFT assets are issued on Stellar and a [metadata specification](#nft-metadata-specification) that defines how data about the NFT is captured. The metadata is stored in a way such that the Stellar network guarantee its authenticity.
 
-### Issuance Model
-Standard issuance of NFTs involves the following components:
-
-  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `I`.
-  - A **token**: This is an asset issued by the issuing account. Its _asset code_ should be descriptive. We'll refer to this asset token as `T`.
-  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `I` and initially holds the entire supply of `T`. We'll refer to it as `D`.
-
-The parties must take the following steps:
-
-  1. Someone creates the issuing account `I` to represent the NFT.
-  2. `I` stores a reference to the NFT's [metadata](#nft-account-description) pointer.
-  4. `I` creates a distribution account, `D`.
-  5. `D` creates a trustline to `T`.
-  6. `I` issues the full supply of tokens `T` to `D`.
-  7. (Optional) `I` locks itself out of its account.
-  8. `D` distributes `T` to the world.
-
-This corresponds to the following series of (pseudocode) operations:
-
-```
-    I = CreateAccountOp(...)
-    ManageDataOp(source: I, key: "type", value: "...")
-    T = "AssetCode:I"
-    D = CreateAccountOp(source: I, ...)
-    ChangeTrustOp(source: D, asset: T, limit: <supply>)
-    PaymentOp(source: I, destination: D, asset: T, amount: <supply>)
-    SetOptionsOp(source: I, masterWeight: 0)
-```
-
-Note that Step 7 _permanently_ locks the issuing account which makes it immutable, meaning that the issuer can neither modify the NFT metadata pointer it stored nor issue more tokens. For fixed supply tokens and tokens intended to be immutable, Step 7 is recommended.
-
-Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as ownership transfers via payments are built on top of this basic issuance model and are thus extraneous to this SEP.
-
-Other issuance models may exist and may be compatible with the following specification, but this is the standard issuance model on Stellar.
-
 ### NFT Specification
 This specification is partially inspired by Ethereum's [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721#specification) on NFTs; however, it is generalized to arbitrary asset types (i.e. not necessarily images).
 
@@ -185,6 +150,35 @@ Looking this up on IPFS [via CloudFlare](https://cloudflare-ipfs.com/ipfs/QmaydG
 ```
 
 We can see that this account [really does](https://horizon.stellar.org/operations/164563600389443587) own and issue this asset, meaning the NFT is genuine.
+
+### Recommended Issuance Model
+Standard issuance of NFTs involves the following components:
+
+  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `I`.
+  - A **token**: This is an asset issued by the issuing account. Its _asset code_ should be descriptive. We'll refer to this asset token as `T`.
+
+The parties must take the following steps:
+
+  1. Someone creates the issuing account `I` to represent the NFT.
+  2. `I` stores a reference to the NFT's [metadata](#nft-account-description) pointer.
+  3. `I` distributes the token to the world.
+  4. (Optional) `I` locks itself out of its account.
+
+This corresponds to the following series of (pseudocode) operations:
+
+```
+    I = CreateAccountOp(...)
+    T = "AssetCode:I"
+    ManageDataOp(source: I, key: "type", value: "...")
+    PaymentOp(source: I, asset: T, ...)
+    SetOptionsOp(source: I, masterWeight: 0)
+```
+
+Note that the last step _permanently_ locks the issuing account which makes it immutable, meaning that the issuer can neither modify the NFT metadata pointer it stored nor issue more tokens. For fixed supply tokens and tokens intended to be immutable, this step is recommended.
+
+Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as ownership transfers via payments are built on top of this basic issuance model and are thus extraneous to this SEP.
+
+Other issuance models may exist and may be compatible with the following specification, but this is the standard issuance model on Stellar.
 
 
 ## Design Rationale

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -91,7 +91,7 @@ Fields should be stored as simple key-value pairs within an account's data entri
 ##### IPFS Storage
 If the `type` is `ipfshash`, the `ipfshash` key must point to an [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata.
 
-If you are the issuer, make sure you understand the implications of using IPFS. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service. If you're the issuer, you must also ensure that IPFS actually stores your data (by running your own node or entrusting a provider).
+If you are the issuer, make sure you understand the implications of using IPFS. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service. If you're the issuer, you must also ensure that the resource is addressable and accessible on the IPFS network by running your own IPFS node or entrusting a provider to do so.
 
 ##### URL Storage
 If the `type` is `uri`, the corresponding `uri` key must point to a [valid URI](https://datatracker.ietf.org/doc/html/rfc3986) containing the NFT's metadata. 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -44,29 +44,31 @@ This SEP defines an [issuance model](#issuance-model) that defines how NFT asset
 ### Issuance Model
 Standard issuance of NFTs involves the following components:
 
-  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `A`.
+  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `I`.
   - A **token**: This is an asset issued by the issuing account. Its _asset code_ should be descriptive. We'll refer to this asset token as `T`.
-  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `A` and initially holds the entire supply of `T`. We'll refer to it as `B`
+  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `I` and initially holds the entire supply of `T`. We'll refer to it as `D`.
 
 The parties must take the following steps:
 
-  1. Someone creates the issuing account `A` to represent the NFT.
-  2. `A` stores a reference to the NFT's [metadata](#nft-account-description) pointer.
-  4. `A` creates a distribution account, `B`.
-  5. `B` creates a trustline to `T`.
-  6. `A` issues the full supply of tokens `T` to `B`.
-  7. (Optional) `A` locks itself out of its account.
-  8. `B` distributes `T` to the world.
+  1. Someone creates the issuing account `I` to represent the NFT.
+  2. `I` stores a reference to the NFT's [metadata](#nft-account-description) pointer.
+  4. `I` creates a distribution account, `D`.
+  5. `D` creates a trustline to `T`.
+  6. `I` issues the full supply of tokens `T` to `D`.
+  7. (Optional) `I` locks itself out of its account.
+  8. `D` distributes `T` to the world.
 
 This corresponds to the following series of (pseudocode) operations:
 
-    A = CreateAccountOp(...)
-    ManageDataOp(source: A, key: "type", value: "...")
-    T = "AssetCode:A"
-    B = CreateAccountOp(source: A, ...)
-    ChangeTrustOp(source: B, asset: T, limit: <supply>)
-    PaymentOp(source: A, destination: B, asset: T, amount: <supply>)
-    SetOptionsOp(source: A, masterWeight: 0)
+```
+    I = CreateAccountOp(...)
+    ManageDataOp(source: I, key: "type", value: "...")
+    T = "AssetCode:I"
+    D = CreateAccountOp(source: I, ...)
+    ChangeTrustOp(source: D, asset: T, limit: <supply>)
+    PaymentOp(source: I, destination: D, asset: T, amount: <supply>)
+    SetOptionsOp(source: I, masterWeight: 0)
+```
 
 Note that Step 7 _permanently_ locks the issuing account which makes it immutable, meaning that the issuer can neither modify the NFT metadata pointer it stored nor issue more tokens. For fixed supply tokens and tokens intended to be immutable, Step 7 is recommended.
 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -70,14 +70,20 @@ There are two **required** fields on the account itself:
 | Field       | Purpose |
 | ----------- | ------- |
 | `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `uri` |
-| `hash`      | The SHA3 hash of the metadata contents |
+| `hash`      | The [SHA3](https://csrc.nist.gov/publications/detail/fips/202/final) hash of the metadata contents |
 
+
+##### `type`
 The two possible values for the `type` field describe two standard ways to store the metadata, and the details will be in a data entry corresponding to this value. In other words, `type: ipfshash` means that you should look under the `ipfshash` key data entry which further defines how to find the metadata.
 
 All other values for the `type` are considered non-standard until they are approved for inclusion within this SEP.
 
+##### `hash`
 The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer.
 
+If it is excluded, the NFT **must not be considered genuine**, _unless_ the `type` is `ipfshash`, since the IPFS CID includes an integrity check on the data it points to. 
+
+##### Storage
 Fields should be stored as simple key-value pairs within an account's data entries. The standard limitations of `ManageDataOp` apply: field names and their values can only be 64 bytes each. Most metadata attributes should be stored at the NFT reference location itself.
 
 **Backward Compatibility:** Existing NFT platforms essentially default to `type: ipfshash`. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with existing conventions that developed organically. To do so, **if you see an account with a lone `ipfshash` data entry, you may treat it as equivalent to an NFT account with `type: ipfshash`**.

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -81,7 +81,7 @@ This specification is partially inspired by Ethereum's [EIP-721 specification](h
 
 In order to minimize the costs of creating an NFT (i.e. on-chain storage), the issuing account only stores a reference to the NFT metadata which is stored off-chain.
 
-#### NFT Account Description
+#### NFT Account Configuration
 An issuing account should specify its `homedomain` (via `SetOptionsOp`). It should also configure the token in its domain's `stellar.toml` file (see [SEP-1](https://stellar.org/sep-1#currency-documentation)) if appropriate. This ensures compatibility with the existing ecosystem (for example, rendering it in wallets).
 
 There are two ways to configure an account for an NFT and both involve storing data entries within the account. These are simple key-value pairs configured with `ManageDataOp`. Its standard limitations apply: field names and their values can only be 64 bytes each.
@@ -92,9 +92,9 @@ There are two **required** fields on the account itself:
 | Field  | Purpose |
 | ------ | ------- |
 | `url`  | A [URL][url] pointing to the "first hop" of metadata about the NFT |
-| `hash` | A [SHA-256](https://datatracker.ietf.org/doc/html/rfc4634#section-4.1) digest of the metadata referenced by the `url` |
+| `hash` | A raw [SHA-256][sha256] digest of the metadata referenced by the `url` |
 
-The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer.
+The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer. This hash should be computed on the raw metadata file rather than on a "loaded" JSON object in order to ensure consistent hashing. The hash must be stored in its raw, binary form.
 
 **Warning**: If the hash does not match the metadata content, you should carefully consider the NFT's authenticity.
 
@@ -117,14 +117,15 @@ This section describes the metadata itself rather than how to find it.
 
 The metadata must be valid JSON and must contain the following **required** fields:
 
-| Field       | Description |
-| ----------- | ----------- |
-| `name` | a short name or title for the NFT |
+| Field         | Description |
+| ------------- | ----------- |
+| `name`        | a short name or title for the NFT |
 | `description` | a longer, more-detailed description of the NFT |
-| `type` | a [Media Type][mediatype] describing the NFT's primary format (pointed to by `url`) |
-| `url`  | a [URL][url] pointing to the actual NFT contents |
-| `issuer` | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
-| `code` | the NFT's asset code |
+| `type`        | a [Media Type][mediatype] describing the NFT's primary format (pointed to by `url`) |
+| `url`         | a [URL][url] pointing to the actual NFT contents |
+| `hash`        | the hex-encoded [SHA-256][sha256] digest of the content pointed to by `url` |
+| `issuer`      | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
+| `code`        | the NFT's asset code |
 
 For example,
 
@@ -134,6 +135,7 @@ For example,
   "description": "This is a description of the cool NFT used in this demo.",
   "type": "image/png",
   "url": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
+  "hash": "2837de01bc746f7840aee6ebedcd60d07b4b0781453205ffd376e42e2f1a30fd",
   "issuer": "GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO",
   "code": "DEMOASSET"
 }
@@ -210,3 +212,4 @@ Those processing an NFT should take care to ensure that the `issuer` field match
 [cid]: https://docs.ipfs.io/concepts/content-addressing/
 [url]: https://www.ietf.org/rfc/rfc1738.txt
 [mediatype]: https://www.iana.org/assignments/media-types/media-types.xhtml
+[sha256]: https://datatracker.ietf.org/doc/html/rfc4634#section-4.1

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -65,15 +65,18 @@ In order to minimize the costs of on-chain storage, we have multiple levels of i
 #### NFT Account Description
 A proper NFT account should specify its `homedomain`. It should also configure the asset in its domain's `stellar.toml` file (see [SEP-1](https://stellar.org/sep-1#currency-documentation)) if appropriate.
 
-There's only one required field on the account itself:
+There are two **required** fields on the account itself:
 
 | Field       | Purpose |
 | ----------- | ------- |
 | `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `uri` |
+| `hash`      | The SHA3 hash of the metadata contents |
 
 The two possible values for the `type` field describe two standard ways to store the metadata, and the details will be in a data entry corresponding to this value. In other words, `type: ipfshash` means that you should look under the `ipfshash` key data entry which further defines how to find the metadata.
 
 All other values for the `type` are considered non-standard until they are approved for inclusion within this SEP.
+
+The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer.
 
 Fields should be stored as simple key-value pairs within an account's data entries. The standard limitations of `ManageDataOp` apply: field names and their values can only be 64 bytes each. Most metadata attributes should be stored at the NFT reference location itself.
 
@@ -167,9 +170,11 @@ We can see that this account [really does](https://horizon.stellar.org/operation
 ## Design Rationale
 
 ### On the issuance model
-The issuance model follows Stellar's [standard model for issuing assets](https://developers.stellar.org/docs/issuing-assets/how-to-issue-an-asset/): there's an _issuing account_ and a _distribution account_. The benefits of this model are described in the linked document, but the most important one is this: it makes it easier to track supply. In the world of NFTs, it's really important to track how many of a particular token are in circulation, and 
+The issuance model follows Stellar's [standard model for issuing assets](https://developers.stellar.org/docs/issuing-assets/how-to-issue-an-asset/): there's an _issuing account_ and a _distribution account_. The benefits of this model are described in the linked document, but the most important one is this: it makes it easier to track supply. In the world of NFTs, it's really important to track how many of a particular token are in circulation, and using a distribution account achieves this goal.
 
 ### On the metadata specification
+Since not all issuers will use `ipfshash`, which already provides integrity by including the hash within the CID, we need the `hash` field to further NFT authenticity.
+
 While `ipfs://cid` is a type of URI, we allow `type: ipfshash` for compatibility with existing ecosystem conventions as well as to highlight the popularity of IPFS as a storage mechanism in the NFT ecosystem.
 
 The field `uri` was chosen in preference to `url` in order to emphasize that data does not have to live on the traditional Web. Since URLs are a subset of URIs, this should not pose a problem to Web-centric platforms, and the specification still allows `url` for ecosystem compatibility.

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -13,15 +13,15 @@ Discussion: TBD
 ```
 
 ## Simple Summary
-This SEP defines a standard interface to describe non-fungible tokens (NFTs) on the Stellar network, including a distribution mechanism and metadata fields. It draws inspiration from the [EIP-721 standard](https://eips.ethereum.org/EIPS/eip-721).
+This SEP defines a standard interface for non-fungible tokens (NFTs) on the Stellar network, including an issuance model and metadata fields. It draws inspiration from the [EIP-721 standard](https://eips.ethereum.org/EIPS/eip-721).
 
 
 ## Motivation
-A standard interface for NFTs allows ecosystem applications (such as wallets or marketplaces) to create, view, or otherwise work with any NFT on Stellar.
+A standard interface for NFTs that makes NFTs issued by any ecosystem application (such as a wallet or marketplace) accessible and interoperable with any other ecosystem application supporting NFTs.
 
 
 ## Abstract
-Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. We should also define a standard issuance model to explain how NFTs can and should be issued on the network. In order to maintain compatibility across the Stellar ecosystem and beyond, we need a standard way to describe and define them that is agnostic of what the NFT actually describes.
+Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. This protocol defines a standard series of steps that NFT creators should use to issue NFTs on the Stellar network, defines metadata to describe an NFT, and specifies how the metadata is linked to the NFT asset on Stellar.
 
 
 ## Specification

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -45,7 +45,7 @@ This SEP defines an [issuance model](#issuance-model) that defines how NFT asset
 Standard issuance of NFTs must take the following steps:
 
   1. Create an account to represent the NFT: `CreateAccountOp(A, <reserve>)`
-  2. Configure the NFT's metadata pointer, as described [below](#nft-account-description): `ManageDataOp("type", "...")`
+  2. Store a reference to the NFT's [metadata](#nft-account-description) inside account A: `ManageDataOp("type", "...")`
   3. Form an asset describing your NFT: `Code:Issuer` (where issuer is `A`)
   4. Create a distribution account: `B = CreateAccountOp()` and `ChangeTrust("Code:Issuer", <limit>)`
   5. Issue the tokens: `PaymentOp(B, "Code:Issuer", <amount>)`

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -1,0 +1,160 @@
+## Preamble
+
+```
+SEP: To Be Assigned
+Title: Non-Fungible Token Standard
+Author: George Kudrayvtsev <george@stellar.org>
+Track: Standard
+Status: Draft
+Created: 2021-01-31
+Updated: 2021-01-31
+Version: 0.1.0
+Discussion: TBD
+```
+
+## Simple Summary
+This SEP defines a standard interface to describe non-fungible tokens (NFTs) on the Stellar network, including a distribution mechanism and metadata fields. It draws inspiration from the [EIP-721 standard](https://eips.ethereum.org/EIPS/eip-721).
+
+
+## Motivation
+A standard interface for NFTs allows ecosystem applications (such as wallets or marketplaces) to create, view, or otherwise work with any NFT on Stellar.
+
+
+## Abstract
+Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. We should also define a standard issuance model to explain how NFTs can and should be issued on the network. In order to maintain compatibility across the Stellar ecosystem and beyond, we need a standard way to describe and define them that is agnostic of what the NFT actually describes.
+
+
+## Specification
+We begin with the [issuance model](#issuance-model) and then cover the NFT [metadata specification](#nft-metadata-specification).
+
+### Issuance Model
+Given an arbitrary digital asset, here's how issuance typically works:
+
+  1. An account is created specifically to represent the NFT in the Stellar ledger.
+  2. The account configures itself with metadata describing the NFT.
+  3. The account issues a new Stellar asset representing ownership over said NFT.
+  4. Any account holding that asset lays claim to the NFT.
+
+Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as locking down the issuing account to avoid supply increases, ownership transfers via payments, etc. are built on top of this basic model and are thus extraneous to this SEP.
+
+Note also that this SEP does not address concerns around immutability. While there is an optional checksum component (addressed later), the account itself is free to modify the data at-will if it is not locked.
+
+### NFT Specification
+This specification is partially inspired by Ethereum's [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721#specification) on NFTs; however, it is generalized to arbitrary asset types (i.e. not necessarily images).
+
+In order to minimize the costs of on-chain storage, we have multiple levels of indirection of NFT metadata. The only thing the NFT account stores on-chain is a description of where to find the metadata.
+
+#### NFT Account Description
+A proper NFT account should specify its `homedomain`. It should also configure the asset in its domain's `stellar.toml` file (see [SEP-1](https://stellar.org/sep-1#currency-documentation)) if appropriate.
+
+There's only one required field on the account itself:
+
+| Field       | Purpose |
+| ----------- | ------- |
+| `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `stellar` |
+
+The two possible values for the `type` field describe two standard ways to store the metadata, and the details will be in a data entry corresponding to this value. In other words, `type: ipfshash` means that you should look under the `ipfshash` key data entry which further defines how to find the metadata.
+
+All other values for the `type` are considered non-standard until they are approved for inclusion within this SEP.
+
+Fields should be stored as simple key-value pairs within an account's data entries. The standard limitations of `ManageDataOp` apply: field names and their values can only be 64 bytes each. Most metadata attributes should be stored at the NFT reference location itself.
+
+**Backward Compatibility:** Existing NFT platforms essentially default to `type: ipfshash`. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with existing conventions that developed organically. To do so, **if you see an account with a lone `ipfshash` data entry, you may treat it as an NFT account with `type: ipfshash`**.
+
+##### IPFS Storage
+If the `type` is `ipfshash`, the `ipfshash` key must point to an [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata.
+
+If you are the issuer, make sure you understand the implications of using IPFS. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service. If you're the issuer, you must also ensure that IPFS actually stores your data (by running your own node or entrusting a provider).
+
+##### Stellar Storage
+If the `type` is `stellar`, the `stellar` key must point to a Stellar account ID. That account will store the metadata within its data entries. Refer to the unofficial [SEP-39](https://github.com/stellar/stellar-protocol/pull/1090) specification for details on how to read an account's data entries for the NFT metadata.
+
+#### Standard Metadata Specification
+This section describes the metadata itself rather than how to find it. 
+
+The metadata must be valid JSON and must contain three **required** fields:
+
+| Field       | Description |
+| ----------- | ----------- |
+| name | a short name or title for the NFT |
+| description | a longer, more-detailed description of the NFT |
+| type | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
+| url  | a [well-formed](https://url.spec.whatwg.org/#urls) URL pointing to the actual NFT contents |
+| issuer | a [well-formed](https://stellar.org/protocol/sep-23) Stellar public key (`G...`) corresponding to the account which issued this NFT |
+| code | the NFT's asset code |
+
+For example,
+
+```json
+{
+  "name": "A demonstration of NFT metadata",
+  "type": "image/png",
+  "url": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
+  "issuer": "GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO",
+  "code": "DEMOASSET"
+}
+```
+
+There are other fields which are **optional** but standardized:
+
+| Field       | Description |
+| ----------- | ----------- |
+| fulldescription | an *even longer* description of the NFT than afforded by the `description` field, encoded in base64 |
+| supply | an integer denoting how many of this NFT exist |
+| image | a URI pointing to an image representation of the NFT |
+| video | a URI pointing to a video representation of the NFT |
+| audio | a URI pointing to a audio representation of the NFT |
+| domain | a [domain name](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1) corresponding to a place that owns or renders this NFT | 
+
+These fields should be self-explanatory.
+
+
+### A Full Example
+
+We start with an official SDF NFT: the [Meridian 2021 hat NFT](https://www.litemint.com/items/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/MERIDIAN2021). It's issued by [this account](https://horizon.stellar.org/accounts/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/) and stores the following entry in its `data` field:
+
+```json
+{
+  "ipfshash": "UW1heWRHRXNoYkw3SE1Ra0Q2RlpQY01lRXQ2bzE1YUM0cDRQODJWeFE3YW1qeQ=="
+}
+```
+
+Upon decoding the value from base64 (since a `ManageDataOp`'s value is just raw bytes), we get an IPFS CID:
+
+    QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy
+
+Looking this up on IPFS [via CloudFlare](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) gives us the full metadata:
+
+```json
+{
+  "name": "Meridian 2021: Hat",
+  "description": "Virtual swag from Meridian 2021!  Find out more about Meridian at https://meridian.stellar.org",
+  "image": "ipfs://QmTAQ1e5zD4rxEspDgSZNgqXb73LBEj2wpQkDTj1UvCmv6",
+  "url": "https://ipfs.io/ipfs/QmTAQ1e5zD4rxEspDgSZNgqXb73LBEj2wpQkDTj1UvCmv6",
+  "code": "MERIDIAN2021",
+  "issuer": "GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC",
+  "domain": "meridian.litemint.store",
+  "supply": 50,
+  "video": "ipfs://QmeDxfvNpoizLxP4xLNrx1QuykPSqXEyZL8tVceZGudcvs"
+}
+```
+
+We can see that this account [really does](https://horizon.stellar.org/operations/164563600389443587) own and issue this asset, meaning the NFT is genuine.
+
+## Design Rationale
+TODO.
+
+
+## Security Concerns
+While there are no direct security concerns to the network introduced by this SEP, the trust model of NFTs deserves some clarification.
+
+Digital assets are infinitely and perfectly reproduceable by virtue of being digital. Thus, the goal of an NFT should **not** be to represent ownership or possession of a particular digital asset, but rather to represent the existence of a particular _relationship_ with the issuer.
+
+Those processing an NFT should take care to ensure that the `issuer` field matches the account referencing the NFT, and that the `code` is in fact an asset issued by said account. Without these two links, you cannot make any conclusions about the NFT.
+
+There is another trust issue worth nothing: **supply**. This metadata field _should not be trusted_, and should instead be cross-referenced with the account's distribution operations. Unless an account is completely locked, nothing inherently prevents it from ignoring this `supply` field and issuing new tokens.
+
+
+## Changelog
+
+- `v0.1.0`: Initial draft ([#1000](https://github.com/stellar/stellar-protocol/pulls/1000)).

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -141,8 +141,16 @@ Looking this up on IPFS [via CloudFlare](https://cloudflare-ipfs.com/ipfs/QmaydG
 
 We can see that this account [really does](https://horizon.stellar.org/operations/164563600389443587) own and issue this asset, meaning the NFT is genuine.
 
+
 ## Design Rationale
-TODO.
+
+### On the issuance model
+The issuance model follows Stellar's [standard model for issuing assets](https://developers.stellar.org/docs/issuing-assets/how-to-issue-an-asset/): there's an _issuing account_ and a _distribution account_. The benefits of this model are described in the linked document, but the most important one is this: it makes it easier to track supply. In the world of NFTs, it's really important to track how many of a particular token are in circulation, and 
+
+### On the metadata specification
+While `ipfs://cid` is a type of URI, we allow `type: ipfshash` for compatibility with existing ecosystem conventions as well as to highlight the popularity of IPFS as a storage mechanism in the NFT ecosystem.
+
+The field `uri` was chosen instead of `url` in order to emphasize that data does not have to live on the traditional Web. Since URLs are a subset of URIs, this should not pose a problem to Web-centric platforms.
 
 
 ## Security Concerns

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -51,7 +51,7 @@ There's only one required field on the account itself:
 
 | Field       | Purpose |
 | ----------- | ------- |
-| `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `stellar` |
+| `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `uri` |
 
 The two possible values for the `type` field describe two standard ways to store the metadata, and the details will be in a data entry corresponding to this value. In other words, `type: ipfshash` means that you should look under the `ipfshash` key data entry which further defines how to find the metadata.
 
@@ -59,28 +59,30 @@ All other values for the `type` are considered non-standard until they are appro
 
 Fields should be stored as simple key-value pairs within an account's data entries. The standard limitations of `ManageDataOp` apply: field names and their values can only be 64 bytes each. Most metadata attributes should be stored at the NFT reference location itself.
 
-**Backward Compatibility:** Existing NFT platforms essentially default to `type: ipfshash`. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with existing conventions that developed organically. To do so, **if you see an account with a lone `ipfshash` data entry, you may treat it as an NFT account with `type: ipfshash`**.
+**Backward Compatibility:** Existing NFT platforms essentially default to `type: ipfshash`. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with existing conventions that developed organically. To do so, **if you see an account with a lone `ipfshash` data entry, you may treat it as equivalent to an NFT account with `type: ipfshash`**.
 
 ##### IPFS Storage
 If the `type` is `ipfshash`, the `ipfshash` key must point to an [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata.
 
 If you are the issuer, make sure you understand the implications of using IPFS. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service. If you're the issuer, you must also ensure that IPFS actually stores your data (by running your own node or entrusting a provider).
 
-##### Stellar Storage
-If the `type` is `stellar`, the `stellar` key must point to a Stellar account ID. That account will store the metadata within its data entries. Refer to the unofficial [SEP-39](https://github.com/stellar/stellar-protocol/pull/1090) specification for details on how to read an account's data entries for the NFT metadata.
+##### URL Storage
+If the `type` is `uri`, the corresponding `uri` key must point to a [valid URI](https://datatracker.ietf.org/doc/html/rfc3986) containing the NFT's metadata. 
+
+_Note_: While you could technically describe metadata living on the IPFS with a URL by pointing to a specific node or a URI prefixing the CID with `ipfs://`, we recommend describing _only_ its CID to leave lookups to the users.
 
 #### Standard Metadata Specification
 This section describes the metadata itself rather than how to find it. 
 
-The metadata must be valid JSON and must contain three **required** fields:
+The metadata must be valid JSON and must contain the following **required** fields:
 
 | Field       | Description |
 | ----------- | ----------- |
 | name | a short name or title for the NFT |
 | description | a longer, more-detailed description of the NFT |
 | type | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
-| url  | a [well-formed](https://url.spec.whatwg.org/#urls) URL pointing to the actual NFT contents |
-| issuer | a [well-formed](https://stellar.org/protocol/sep-23) Stellar public key (`G...`) corresponding to the account which issued this NFT |
+| uri  | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to the actual NFT contents |
+| issuer | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
 | code | the NFT's asset code |
 
 For example,
@@ -88,8 +90,9 @@ For example,
 ```json
 {
   "name": "A demonstration of NFT metadata",
+  "description": "This is a description of the cool NFT used in this demo.",
   "type": "image/png",
-  "url": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
+  "uri": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
   "issuer": "GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO",
   "code": "DEMOASSET"
 }
@@ -100,17 +103,14 @@ There are other fields which are **optional** but standardized:
 | Field       | Description |
 | ----------- | ----------- |
 | fulldescription | an *even longer* description of the NFT than afforded by the `description` field, encoded in base64 |
-| supply | an integer denoting how many of this NFT exist |
-| image | a URI pointing to an image representation of the NFT |
-| video | a URI pointing to a video representation of the NFT |
-| audio | a URI pointing to a audio representation of the NFT |
+| image | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to an image representation of the NFT |
+| video | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to a video representation of the NFT |
+| audio | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to a audio representation of the NFT |
 | domain | a [domain name](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1) corresponding to a place that owns or renders this NFT | 
 
 These fields should be self-explanatory.
 
-
 ### A Full Example
-
 We start with an official SDF NFT: the [Meridian 2021 hat NFT](https://www.litemint.com/items/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/MERIDIAN2021). It's issued by [this account](https://horizon.stellar.org/accounts/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/) and stores the following entry in its `data` field:
 
 ```json
@@ -152,9 +152,6 @@ Digital assets are infinitely and perfectly reproduceable by virtue of being dig
 
 Those processing an NFT should take care to ensure that the `issuer` field matches the account referencing the NFT, and that the `code` is in fact an asset issued by said account. Without these two links, you cannot make any conclusions about the NFT.
 
-There is another trust issue worth nothing: **supply**. This metadata field _should not be trusted_, and should instead be cross-referenced with the account's distribution operations. Unless an account is completely locked, nothing inherently prevents it from ignoring this `supply` field and issuing new tokens.
-
 
 ## Changelog
-
 - `v0.1.0`: Initial draft ([#1000](https://github.com/stellar/stellar-protocol/pulls/1000)).

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -21,13 +21,13 @@ A standard interface for NFTs that makes NFTs issued by any ecosystem applicatio
 
 
 ## Abstract
-Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. This protocol defines a standard series of steps that NFT creators should use to issue NFTs on the Stellar network, defines metadata to describe an NFT, and specifies how the metadata is linked to the NFT asset on Stellar.
+Non-fungible tokens (NFTs) can describe many types of assets, from digital collectibles to physical items. This protocol defines a standard series of steps that NFT creators should use to issue NFTs on the Stellar network, defines metadata to describe an NFT, and specifies how the metadata is linked to the NFT asset defined in this SEP.
 
 The issuance model involves four steps:
 
   1. An account is created specifically to represent the NFT in the Stellar ledger.
   2. The account configures itself with metadata describing the NFT.
-  3. The account issues a new Stellar asset representing ownership over said NFT.
+  3. The account issues a new Stellar asset representing ownership over said NFT to a distribution account.
   4. Any account holding that asset lays claim to the NFT.
 
 The NFT model involves two levels of indirection in order to minimize on-chain storage:
@@ -42,16 +42,35 @@ The NFT model involves two levels of indirection in order to minimize on-chain s
 This SEP defines an [issuance model](#issuance-model) that defines how NFT assets are issued on Stellar and a [metadata specification](#nft-metadata-specification) that defines how data about the NFT is captured. The metadata is stored in a way such that the Stellar network guarantee its authenticity.
 
 ### Issuance Model
-Standard issuance of NFTs must take the following steps:
+Standard issuance of NFTs involves the following components:
 
-  1. Create an account to represent the NFT: `CreateAccountOp(A, <reserve>)`
-  2. Store a reference to the NFT's [metadata](#nft-account-description) inside account A: `ManageDataOp("type", "...")`
-  3. Form an asset describing your NFT: `Code:Issuer` (where issuer is `A`)
-  4. Create a distribution account: `B = CreateAccountOp()` and `ChangeTrust("Code:Issuer", <limit>)`
-  5. Issue the tokens: `PaymentOp(B, "Code:Issuer", <amount>)`
-  6. (Optional) Lock the issuing account: `SetOptionsOp(MasterWeight: 0)`
+  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `I`.
+  - A **token**: This is an asset issued by the issuing account. Its _asset code_ should be descriptive. We'll refer to this asset token as `T`.
+  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `I` and initially holds the entire supply of `T`. We'll refer to it as `D`
 
-Note that without this final step, there are concerns around both immutability and supply: an account may modify its NFT metadata pointer or issue more tokens unless it's locked down. Thus, Step 6 is recommended.
+The parties must take the following steps:
+
+  1. Someone creates the issuing account `A` to represent the NFT.
+  2. `A` stores a reference to the NFT's [metadata](#nft-account-description) pointer.
+  4. `A` creates a distribution account, `B`.
+  5. `B` creates a trustline to `T`.
+  6. `A` issues the full supply of tokens `T` to `B`.
+  7. (Optional) `A` locks itself out of its account.
+  8. `B` distributes `T` to the world.
+
+This corresponds to the following series of (pseudocode) operations:
+
+```
+A = CreateAccountOp(...)
+ManageDataOp(source: A, key: "type", value: "...")
+T = "AssetCode:A"
+B = CreateAccountOp(source: A, ...)
+ChangeTrustOp(source: B, asset: T, limit: <supply>)
+PaymentOp(source: A, destination: B, asset: T, amount: <supply>)
+SetOptionsOp(source: A, masterWeight: 0)
+```
+
+Note that Step 7 _permanently_ locks the issuing account which makes it immutable, meaning that the issuer can neither modify the NFT metadata pointer it stored nor issue more tokens. For fixed supply tokens and tokens intended to be immutable, Step 7 is recommended.
 
 Ownership of the token directly conveys ownership of a unit of the NFT, however that may be defined. Other scenarios such as ownership transfers via payments are built on top of this basic issuance model and are thus extraneous to this SEP.
 
@@ -60,46 +79,43 @@ Other issuance models may exist and may be compatible with the following specifi
 ### NFT Specification
 This specification is partially inspired by Ethereum's [EIP-721 specification](https://eips.ethereum.org/EIPS/eip-721#specification) on NFTs; however, it is generalized to arbitrary asset types (i.e. not necessarily images).
 
-In order to minimize the costs of on-chain storage, we have multiple levels of indirection of NFT metadata. The only thing the NFT account stores on-chain is a description of where to find the metadata.
+In order to minimize the costs of creating an NFT (i.e. on-chain storage), the issuing account only stores a reference to the NFT metadata which is stored off-chain.
 
 #### NFT Account Description
-A proper NFT account should specify its `homedomain`. It should also configure the asset in its domain's `stellar.toml` file (see [SEP-1](https://stellar.org/sep-1#currency-documentation)) if appropriate.
+An issuing account should specify its `homedomain` (via `SetOptionsOp`). It should also configure the token in its domain's `stellar.toml` file (see [SEP-1](https://stellar.org/sep-1#currency-documentation)) if appropriate. This ensures compatibility with the existing ecosystem (for example, rendering it in wallets).
 
+There are two ways to configure an account for an NFT and both involve storing data entries within the account. These are simple key-value pairs configured with `ManageDataOp`. Its standard limitations apply: field names and their values can only be 64 bytes each.
+
+##### 1. URL Storage
 There are two **required** fields on the account itself:
 
-| Field       | Purpose |
-| ----------- | ------- |
-| `type`      | Describes how the "first hop" of metadata is defined, standard values include `ipfshash` and `uri` |
-| `hash`      | The [SHA3](https://csrc.nist.gov/publications/detail/fips/202/final) hash of the metadata contents |
+| Field  | Purpose |
+| ------ | ------- |
+| `url`  | A [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to the "first hop" of metadata about the NFT |
+| `hash` | A [SHA-256](https://datatracker.ietf.org/doc/html/rfc4634#section-4.1) digest of the metadata referenced by the `url` |
 
-
-##### `type`
-The two possible values for the `type` field describe two standard ways to store the metadata, and the details will be in a data entry corresponding to this value. In other words, `type: ipfshash` means that you should look under the `ipfshash` key data entry which further defines how to find the metadata.
-
-All other values for the `type` are considered non-standard until they are approved for inclusion within this SEP.
-
-##### `hash`
 The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer.
 
-If it is excluded, the NFT **must not be considered genuine**, _unless_ the `type` is `ipfshash`, since the IPFS CID includes an integrity check on the data it points to. 
+**Warning**: If the hash does not match the metadata content, you should carefully consider the NFT's authenticity.
 
-##### Storage
-Fields should be stored as simple key-value pairs within an account's data entries. The standard limitations of `ManageDataOp` apply: field names and their values can only be 64 bytes each. Most metadata attributes should be stored at the NFT reference location itself.
+##### 2. IPFS Content ID (Legacy Method)
+Existing ecosystem solutions lean heavily on IPFS to store NFT content. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with these existing, organic conventions.
 
-**Backward Compatibility:** Existing NFT platforms essentially default to `type: ipfshash`. While this standard aims to free up the ecosystem from dependence on IPFS, it should also work with existing conventions that developed organically. To do so, **if you see an account with a lone `ipfshash` data entry, you may treat it as equivalent to an NFT account with `type: ipfshash`**.
+For the legacy variant, there is only one **required** field on the account itself:
 
-##### IPFS Storage
-If the `type` is `ipfshash`, the `ipfshash` key must point to an [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata.
+| Field      | Purpose |
+| ---------- | ------- |
+| `ipfshash` | An [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata |
 
-If you are the issuer, make sure you understand the implications of using IPFS. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service. If you're the issuer, you must also ensure that the resource is addressable and accessible on the IPFS network by running your own IPFS node or entrusting a provider to do so.
+#### IPFS Storage
+If you are issuing a new token and plan to use IPFS, you should use [Method 1](#url-storage) and use an IPFS URL (`ipfs://...`) rather than the legacy method.
 
-##### URL Storage
-If the `type` is `uri`, the corresponding `uri` key must point to a [valid URI](https://datatracker.ietf.org/doc/html/rfc3986) containing the NFT's metadata. 
+If you are the issuer and decide to use IPFS, make sure you understand its implications. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service.
 
-_Note_: While you could technically describe metadata living on the IPFS with a URL by pointing to a specific node or a URI prefixing the CID with `ipfs://`, we recommend describing _only_ its CID to leave lookups to the users.
+If you're the issuer, you must also ensure that the resource is addressable and accessible on the IPFS network by running your own IPFS node or entrusting a provider to do so.
 
 #### Standard Metadata Specification
-This section describes the metadata itself rather than how to find it. 
+This section describes the metadata itself rather than how to find it.
 
 The metadata must be valid JSON and must contain the following **required** fields:
 
@@ -108,11 +124,9 @@ The metadata must be valid JSON and must contain the following **required** fiel
 | `name` | a short name or title for the NFT |
 | `description` | a longer, more-detailed description of the NFT |
 | `type` | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
-| `uri` **or** `url`  | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to the actual NFT contents |
+| `url`  | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to the actual NFT contents |
 | `issuer` | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
 | `code` | the NFT's asset code |
-
-We allow either `uri` or `url` to maintain compatibility with existing ecosystem conventions. If _both_ are present, prefer the `uri`.
 
 For example,
 
@@ -127,22 +141,22 @@ For example,
 }
 ```
 
-Means that the `DEMOASSET:GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO` asset represents [this image](https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg).
+means that the `DEMOASSET:GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO` asset represents [this image](https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg).
 
 There are other fields which are **optional** but standardized:
 
 | Field       | Description |
 | ----------- | ----------- |
 | fulldescription | an *even longer* description of the NFT than afforded by the `description` field, encoded in base64 |
-| image | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to an image representation of the NFT |
-| video | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to a video representation of the NFT |
-| audio | a [URI](https://datatracker.ietf.org/doc/html/rfc3986) pointing to a audio representation of the NFT |
+| image | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to an image representation of the NFT |
+| video | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to a video representation of the NFT |
+| audio | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to a audio representation of the NFT |
 | domain | a [domain name](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1) corresponding to a place that owns or renders this NFT | 
 
 These fields should be self-explanatory.
 
 ### A Full Example
-We start with an official SDF NFT: the [Meridian 2021 hat NFT](https://www.litemint.com/items/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/MERIDIAN2021). It's issued by [this account](https://horizon.stellar.org/accounts/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/) and stores the following entry in its `data` field:
+We start with an official SDF NFT: the [Meridian 2021 hat NFT](https://www.litemint.com/items/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/MERIDIAN2021). It's issued by [this account](https://horizon.stellar.org/accounts/GDOA2FECYKBVG2RQYG5JQO6EBLCDBWZ7MFBEZY6AIBJ4NDXV3XEVCVBC/) and has the following data entry:
 
 ```json
 {
@@ -179,11 +193,9 @@ We can see that this account [really does](https://horizon.stellar.org/operation
 The issuance model follows Stellar's [standard model for issuing assets](https://developers.stellar.org/docs/issuing-assets/how-to-issue-an-asset/): there's an _issuing account_ and a _distribution account_. The benefits of this model are described in the linked document, but the most important one is this: it makes it easier to track supply. In the world of NFTs, it's really important to track how many of a particular token are in circulation, and using a distribution account achieves this goal.
 
 ### On the metadata specification
-Since not all issuers will use `ipfshash`, which already provides integrity by including the hash within the CID, we need the `hash` field to further NFT authenticity.
+  * The recommended metadata pointer method is via `url` since we don't want to enforce reliance on IPFS. Since not all issuers will use `ipfshash`, which already provides integrity by including the hash within the CID, this method needs the `hash` field alongside it to further NFT authenticity.
 
-While `ipfs://cid` is a type of URI, we allow `type: ipfshash` for compatibility with existing ecosystem conventions as well as to highlight the popularity of IPFS as a storage mechanism in the NFT ecosystem.
-
-The field `uri` was chosen in preference to `url` in order to emphasize that data does not have to live on the traditional Web. Since URLs are a subset of URIs, this should not pose a problem to Web-centric platforms, and the specification still allows `url` for ecosystem compatibility.
+  * While `ipfs://cid` _is_ a URL, we allow `ipfshash` for backward compatibility with existing ecosystem conventions. It also highlights the popularity of IPFS as a storage mechanism in the NFT ecosystem.
 
 
 ## Security Concerns

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -6,8 +6,8 @@ Title: Non-Fungible Token Standard
 Author: George Kudrayvtsev <george@stellar.org>
 Track: Standard
 Status: Draft
-Created: 2021-01-31
-Updated: 2021-01-31
+Created: 2022-01-31
+Updated: 2022-02-02
 Version: 0.1.0
 Discussion: TBD
 ```
@@ -44,9 +44,9 @@ This SEP defines an [issuance model](#issuance-model) that defines how NFT asset
 ### Issuance Model
 Standard issuance of NFTs involves the following components:
 
-  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `I`.
+  - An **issuing account**: This is an account which represents the NFT itself. It is responsible for minting the supply of tokens as well as storing information about how to find the NFT asset. We'll refer to it as `A`.
   - A **token**: This is an asset issued by the issuing account. Its _asset code_ should be descriptive. We'll refer to this asset token as `T`.
-  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `I` and initially holds the entire supply of `T`. We'll refer to it as `D`
+  - A **distribution account**: This is an account which will actually distribute the tokens. Its funded by `A` and initially holds the entire supply of `T`. We'll refer to it as `B`
 
 The parties must take the following steps:
 
@@ -60,15 +60,13 @@ The parties must take the following steps:
 
 This corresponds to the following series of (pseudocode) operations:
 
-```
-A = CreateAccountOp(...)
-ManageDataOp(source: A, key: "type", value: "...")
-T = "AssetCode:A"
-B = CreateAccountOp(source: A, ...)
-ChangeTrustOp(source: B, asset: T, limit: <supply>)
-PaymentOp(source: A, destination: B, asset: T, amount: <supply>)
-SetOptionsOp(source: A, masterWeight: 0)
-```
+    A = CreateAccountOp(...)
+    ManageDataOp(source: A, key: "type", value: "...")
+    T = "AssetCode:A"
+    B = CreateAccountOp(source: A, ...)
+    ChangeTrustOp(source: B, asset: T, limit: <supply>)
+    PaymentOp(source: A, destination: B, asset: T, amount: <supply>)
+    SetOptionsOp(source: A, masterWeight: 0)
 
 Note that Step 7 _permanently_ locks the issuing account which makes it immutable, meaning that the issuer can neither modify the NFT metadata pointer it stored nor issue more tokens. For fixed supply tokens and tokens intended to be immutable, Step 7 is recommended.
 
@@ -91,7 +89,7 @@ There are two **required** fields on the account itself:
 
 | Field  | Purpose |
 | ------ | ------- |
-| `url`  | A [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to the "first hop" of metadata about the NFT |
+| `url`  | A [URL][url] pointing to the "first hop" of metadata about the NFT |
 | `hash` | A [SHA-256](https://datatracker.ietf.org/doc/html/rfc4634#section-4.1) digest of the metadata referenced by the `url` |
 
 The `hash` is provided to ensure integrity of the metadata that the account is pointing to. This prevents the data at the destination from being modified without explicit knowledge and approval by the issuer.
@@ -105,14 +103,12 @@ For the legacy variant, there is only one **required** field on the account itse
 
 | Field      | Purpose |
 | ---------- | ------- |
-| `ipfshash` | An [IPFS Content IDentifier](https://docs.ipfs.io/concepts/content-addressing/) corresponding to the location of the metadata |
+| `ipfshash` | An [IPFS Content IDentifier][cid] corresponding to the location of the metadata |
 
 #### IPFS Storage
 If you are issuing a new token and plan to use IPFS, you should use [Method 1](#url-storage) and use an IPFS URL (`ipfs://...`) rather than the legacy method.
 
-If you are the issuer and decide to use IPFS, make sure you understand its implications. You must use an IPFS lookup service to actually resolve to the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via the Cloudflare IPFS service.
-
-If you're the issuer, you must also ensure that the resource is addressable and accessible on the IPFS network by running your own IPFS node or entrusting a provider to do so.
+If you are the issuer and decide to use IPFS, make sure you understand its implications. You must ensure that the resource is addressable and accessible on the IPFS network by running your own IPFS node or entrusting a provider to do so. Even to look up the NFT, users must use an IPFS lookup service to actually resolve the metadata. For example, [this URL](https://cloudflare-ipfs.com/ipfs/QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy) resolves to the Meridian 2021 Hat NFT via Cloudflare's IPFS node.
 
 #### Standard Metadata Specification
 This section describes the metadata itself rather than how to find it.
@@ -123,8 +119,8 @@ The metadata must be valid JSON and must contain the following **required** fiel
 | ----------- | ----------- |
 | `name` | a short name or title for the NFT |
 | `description` | a longer, more-detailed description of the NFT |
-| `type` | a [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) describing the NFT's primary format (pointed to by `url`) |
-| `url`  | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to the actual NFT contents |
+| `type` | a [Media Type][mediatype] describing the NFT's primary format (pointed to by `url`) |
+| `url`  | a [URL][url] pointing to the actual NFT contents |
 | `issuer` | a Stellar public key ([`G...`](https://stellar.org/protocol/sep-23)) corresponding to the account which issued this NFT |
 | `code` | the NFT's asset code |
 
@@ -148,9 +144,9 @@ There are other fields which are **optional** but standardized:
 | Field       | Description |
 | ----------- | ----------- |
 | fulldescription | an *even longer* description of the NFT than afforded by the `description` field, encoded in base64 |
-| image | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to an image representation of the NFT |
-| video | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to a video representation of the NFT |
-| audio | a [URL](https://www.ietf.org/rfc/rfc1738.txt) pointing to a audio representation of the NFT |
+| image | a [URL][url] pointing to an image representation of the NFT |
+| video | a [URL][url] pointing to a video representation of the NFT |
+| audio | a [URL][url] pointing to a audio representation of the NFT |
 | domain | a [domain name](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1) corresponding to a place that owns or renders this NFT | 
 
 These fields should be self-explanatory.
@@ -164,7 +160,7 @@ We start with an official SDF NFT: the [Meridian 2021 hat NFT](https://www.litem
 }
 ```
 
-Upon decoding the value from base64 (since a `ManageDataOp`'s value is just raw bytes), we get an IPFS CID:
+Upon decoding the value from base64 (since a `ManageDataOp`'s value is just raw bytes), we get an [IPFS CID][cid]:
 
     QmaydGEshbL7HMQkD6FZPcMeEt6o15aC4p4P82VxQ7amjy
 
@@ -193,7 +189,7 @@ We can see that this account [really does](https://horizon.stellar.org/operation
 The issuance model follows Stellar's [standard model for issuing assets](https://developers.stellar.org/docs/issuing-assets/how-to-issue-an-asset/): there's an _issuing account_ and a _distribution account_. The benefits of this model are described in the linked document, but the most important one is this: it makes it easier to track supply. In the world of NFTs, it's really important to track how many of a particular token are in circulation, and using a distribution account achieves this goal.
 
 ### On the metadata specification
-  * The recommended metadata pointer method is via `url` since we don't want to enforce reliance on IPFS. Since not all issuers will use `ipfshash`, which already provides integrity by including the hash within the CID, this method needs the `hash` field alongside it to further NFT authenticity.
+  * The recommended metadata pointer method is via `url` since we don't want to enforce reliance on IPFS. Since not all issuers will use `ipfshash`, which already provides integrity by including the hash within the [CID][cid], this method needs the `hash` field alongside it to further NFT authenticity.
 
   * While `ipfs://cid` _is_ a URL, we allow `ipfshash` for backward compatibility with existing ecosystem conventions. It also highlights the popularity of IPFS as a storage mechanism in the NFT ecosystem.
 
@@ -208,3 +204,7 @@ Those processing an NFT should take care to ensure that the `issuer` field match
 
 ## Changelog
 - `v0.1.0`: Initial draft ([#1111](https://github.com/stellar/stellar-protocol/pulls/1111)).
+
+[cid]: https://docs.ipfs.io/concepts/content-addressing/
+[url]: https://www.ietf.org/rfc/rfc1738.txt
+[mediatype]: https://www.iana.org/assignments/media-types/media-types.xhtml


### PR DESCRIPTION
This is an effort to create a specification for describing NFTs. The spec leans heavily on both the [EIP-721 standard](https://eips.ethereum.org/EIPS/eip-721) (which offers some basic metadata) and the existing Litemint model (which offers a lot more).

In summary, there are three main parts:

 - defining a standard NFT issuance model
 - defining the NFTs themselves, which involves:
   * defining how to reference their metadata from an account, and
   * defining the metadata format itself

There's much more to do, and I've yet to elaborate on the _Design Rationale_ portion, but I think it's a good starting point for discussion.

Tagging some minimum interested parties, based on the last discussion: 

@leighmcculloch @tyvdh @tomerweller 
@FredericRezeau @grempe 