### PR TITLE
CAP-21: Add extra auth

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -365,10 +365,10 @@ index 3895ce9a..9ef87ad7 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index d97b0cb3..9613ab4d 100644
+index d97b0cb3..76ae6701 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -532,6 +532,58 @@ struct TimeBounds
+@@ -532,6 +532,86 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -403,10 +403,38 @@ index d97b0cb3..9613ab4d 100644
 +    uint32 minSeqLedgerGap;
 +
 +    // For the transaction to be valid, there must be a signature
-+    // corresponding to every Signer in this array, even if the
++    // corresponding to every auth in this array, even if the
 +    // signature is not otherwise required by the sourceAccount or
 +    // operations.
-+    SignerKey extraSigners<2>;
++    ExtraAuth extraAuths<2>;
++};
++
++enum ExtraAuthType {
++    EXTRA_AUTH_SIGNER_KEY = 0,
++    EXTRA_AUTH_ACCOUNT_WEIGHT = 1,
++    EXTRA_AUTH_ACCOUNT_THRESHOLD = 2
++};
++
++union ExtraAuth switch (ExtraAuthType type) {
++    case EXTRA_AUTH_SIGNER_KEY:
++        SignerKey signerKey;
++    case EXTRA_AUTH_ACCOUNT_WEIGHT:
++        struct {
++            AccountID accountId;
++            uint32 weight;
++        } accountWeight;
++    case EXTRA_AUTH_ACCOUNT_WEIGHT:
++        struct {
++            AccountID accountId;
++            ExtraAuthAccountThreshold threshold;
++        } accountThreshold;
++};
++
++enum ExtraAuthAccountThreshold
++{
++    EXTRA_AUTH_ACCOUNT_THRESHOLD_LOW = 0,
++    EXTRA_AUTH_ACCOUNT_THRESHOLD_MED = 1,
++    EXTRA_AUTH_ACCOUNT_THRESHOLD_HIGH = 2
 +};
 +
 +enum PreconditionType {
@@ -427,7 +455,7 @@ index d97b0cb3..9613ab4d 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -583,8 +635,8 @@ struct Transaction
+@@ -583,8 +663,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  


### PR DESCRIPTION
### What
Add extra auth in place of extra signers that embeds extra signers as one type of extra auth.

### Why
During the development of Starlight we have identified that there is a larger variety of additional auth that might be required. The immediate one is signers for hash locks and to support CAP-40 with single keyed accounts. The broader use is accounts with weights or thresholds which will, with modifications to CAP-40 or a CAP-40-like proposal, provide support for the same disclosure properties but for multi-signature accounts without needing to hardcode the signatures for the accounts into the transaction.