### PR TITLE
CAP-40: Expand payload max to 64 bytes

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -270,9 +270,14 @@ signature for any other use. However, this has limited use to only signatures of
 ed25519 keys as specified.
 
 The use of the payload signer in these other applications could require a
-variety of different payload sizes, some of which would be impractical for
-permitting without changes to Stellar's fee participation. However, a payload up
-to 64 bytes would likely be required for some hashing algorithms.
+variety of different payload sizes. It would be impractical to permit large
+payloads without changes to Stellar's fee participation because the sizes of
+transactions and account sub-entries in the ledger could explode.
+
+A payload with a maximum length of 64 bytes, rather than 32 bytes, would support
+payloads that are hashes for most hashing algorithms defined today – e.g.
+SHA-384, SHA-512 – which may support future cross-chain applications that choose
+to use ed25519 signatures of hashes.
 
 ## Protocol Upgrade Transition
 

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -69,9 +69,9 @@ create highly usable products
 This patch of XDR changes is based on the XDR files in tag `v17.2.0` of
 [stellar-core].
 
-```diff mddiffcheck.base=v17.2.0
+```diff mddiffcheck.base=v17.3.0
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c20..3301ca17 100644
+index 8f7d5c20..03149f3d 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -19,6 +19,7 @@ enum CryptoKeyType
@@ -101,18 +101,19 @@ index 8f7d5c20..3301ca17 100644
 +        /* Public key that must sign the payload. */
 +        uint256 ed25519;
 +        /* Payload to be raw signed by ed25519. */
-+        opaque payload<32>;
++        opaque payload<64>;
 +    } ed25519SignedPayload;
  };
  
  // variable size as the size depends on the signature scheme used
+
 ```
 
 ### Semantics
 
 This proposal introduces one new type of signer, the ed25519 signed payload
 signer, that is defined as a variable length opaque payload with a maximum size
-of 32 bytes and an ed25519 public key. A signature for the signer is the result
+of 64 bytes and an ed25519 public key. A signature for the signer is the result
 of signing the payload with the private key that the public key is derived.
 
 The ed25519 signed payload signer is usable everywhere existing signers may be
@@ -255,14 +256,23 @@ signature for C_i, the sender who is watching the network may see D_i be
 submitted, extract the signature for C_i from the signatures on D_i, attach the
 signature to C_i, and submit C_i.
 
+The use of the payload signer in CAP-21's payment channel requires a payload of
+32 bytes to store the hash of another Stellar transaction. 32 bytes are required
+because Stellar transaction hashes utilize the SHA-256 algorithm.
+
 ### Other Uses
 
 This new signer is likely to have other applications in scenarios similar to
 where HASH_X signers are currently used, except that the data revealed would not
 only be a hash shared by multiple transactions across multiple chains, but could
-be a signature for a transaction on another chain, or a siganture for any other
-use. However, this has limited use to only signatures of ed25519 keys as
-specified.
+be a signature for a hash validated by a smart contract on another chain, or a
+siganture for any other use. However, this has limited use to only signatures of
+ed25519 keys as specified.
+
+The use of the payload signer in these other applications could require a
+variety of different payload sizes, some of which would be impractical for
+permitting without changes to Stellar's fee participation. However, a payload up
+to 64 bytes would likely be required for some hashing algorithms.
 
 ## Protocol Upgrade Transition
 
@@ -279,7 +289,7 @@ The size of signatures, and therefore transactions, remain the same.
 The effort to verify the signature is equivalent to the effort to verify an
 ed25519 signature.
 
-The size of signers stored in the ledger would be twice the size, at 64 bytes,
+The size of signers stored in the ledger will be 3x the size, at 96 bytes,
 for ed25519 signed payload signers compared to 32 bytes for all other signers.
 
 ## Test Cases

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -266,7 +266,7 @@ This new signer is likely to have other applications in scenarios similar to
 where HASH_X signers are currently used, except that the data revealed would not
 only be a hash shared by multiple transactions across multiple chains, but could
 be a signature for a hash validated by a smart contract on another chain, or a
-siganture for any other use. However, this has limited use to only signatures of
+signature for any other use. However, this has limited use to only signatures of
 ed25519 keys as specified.
 
 The use of the payload signer in these other applications could require a


### PR DESCRIPTION
### What
Expand payload max to 64 bytes.

### Why
See updated proposal. This was suggested by @stanford-scs.