### PR TITLE
CAP-43: Add a benchmark for compressed vs uncompressed

### DIFF
--- a/core/cap-0043.md
+++ b/core/cap-0043.md
@@ -190,7 +190,9 @@ decompress the key each time. Compressed form would not reduce the size of ECDSA
 signatures, and so would have no impact on the largest dimension of scale that
 the network has, transactions. The choice to use uncompressed form in the XDR
 does not limit whether the strkey definition uses compressed form, and so the
-use of uncompressed form in the protocol does not impact the UX.
+use of uncompressed form in the protocol does not impact the UX. See [Appendix:
+Compressed vs Uncompressed
+Benchmark](#appendix-compressed-vs-uncompressed-benchmark) for an example.
 
 The raw r and s points that form the ECDSA signature are stored as is, as this
 is the most raw and convenient format. Some standard libraries may prefer to
@@ -269,3 +271,91 @@ the proposal.
 - [IBM Cloud HSM](https://cloud.ibm.com/docs/hardware-security-modules?topic=hardware-security-modules-faqs-ibm-cloud-hsm#how-many-keys-can-be-stored-with-ibm-cloud-hsm-7.0)
 
 [SEP-23 Strkeys]: ../ecosystem/sep-0023.md
+
+## Appendix: Compressed vs Uncompressed Benchmark
+
+The following benchmark uses Go to compare the cost of reconstructing a public
+key from bytes and verifying a signature using ECDSA P-256. The first benchmark
+uses as an input the x and y points as raw bytes. The second benchmark uses as
+input the x and y points in their compressed form.
+
+The result of this benchmark shows that uncompressing introduces significant
+allocations and CPU time. These benchmarks are Go code, and the reference
+implementation of the Stellar protocol is in c++, however it illustrates there
+is some non-trivial cost with using the compressed format.
+
+```
+goos: darwin
+goarch: arm64
+BenchmarkCompressed
+BenchmarkCompressed-10      	   13016	     91060 ns/op	    4978 B/op	     141 allocs/op
+BenchmarkUncompressed
+BenchmarkUncompressed-10    	   21513	     55848 ns/op	     848 B/op	      16 allocs/op
+```
+
+<details>
+<summary>Benchmark Go Code</summary>
+
+```go
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"math/big"
+	"testing"
+)
+
+func BenchmarkUncompressed(b *testing.B) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	pk := k.PublicKey
+
+	d := [32]byte{}
+	dp := d[:]
+	r, s, err := ecdsa.Sign(rand.Reader, k, dp)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	x := pk.X.Bytes()
+	y := pk.Y.Bytes()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		x := new(big.Int).SetBytes(x)
+		y := new(big.Int).SetBytes(y)
+		pk := ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+		ecdsa.Verify(&pk, dp, r, s)
+	}
+}
+
+func BenchmarkCompressed(b *testing.B) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	pk := k.PublicKey
+
+	d := [32]byte{}
+	dp := d[:]
+	r, s, err := ecdsa.Sign(rand.Reader, k, dp)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pkc := elliptic.MarshalCompressed(elliptic.P256(), pk.X, pk.Y)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		x, y := elliptic.UnmarshalCompressed(elliptic.P256(), pkc)
+		pk := ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+		ecdsa.Verify(&pk, dp, r, s)
+	}
+}
+```
+
+</details>


### PR DESCRIPTION
### What
Add a benchmark for compressed vs uncompressed format for storing public keys.

### Why
@stanford-scs suggested it would be helpful to run a quick benchmark to see if the design rationale is sound. May as well capture that benchmark in the CAP itself.