### PR TITLE
Transfer SEPS: deprecate `refunded` boolean, add `refunds` object to transaction records

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -987,8 +987,8 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
-`refund` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 `claimable_balance_id` | string | (optional) ID of the Claimable Balance used to send the asset initially requested. Only relevant for deposit transactions.
@@ -1016,14 +1016,14 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `type` | string | One of `partial` or `full`
-`total_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
 
 Name | Type | Description
 -----|------|------------
-`refund_payment_id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
 
@@ -1068,12 +1068,12 @@ Example response:
       "completed_at": "2017-03-20T17:09:58Z",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "refund": {
+      "refunds": {
         "type": "partial",
-        "total_refunded": "10",
+        "amount_refunded": "10",
         "payments": [
             {
-                "refund_payment_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+                "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
                 "id_type": "stellar",
                 "amount": "10"
             }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -987,7 +987,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
 `refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.
@@ -1015,7 +1015,6 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`type` | string | One of `partial` or `full`
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -988,7 +988,7 @@ Name | Type | Description
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
 `refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
-`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 `claimable_balance_id` | string | (optional) ID of the Claimable Balance used to send the asset initially requested. Only relevant for deposit transactions.
@@ -1011,7 +1011,7 @@ Name | Type | Description
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.
 * `error` -- catch-all for any error not enumerated above.
 
-### Refund Object Schema
+### Refunds Object Schema
 
 Name | Type | Description
 -----|------|------------
@@ -1025,7 +1025,7 @@ Name | Type | Description
 -----|------|------------
 `id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
-`amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
+`amount` | string | The amount sent back to the user for the payment identified by `id`.
 
 Example response:
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1079,7 +1079,7 @@ Example response:
       "kind": "withdrawal",
       "status": "completed",
       "amount_in": "510",
-      "amount_out": "495",
+      "amount_out": "490",
       "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
@@ -1087,13 +1087,13 @@ Example response:
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
       "refunds": {
         "amount_refunded": "10",
-        "amount_fee": "0",
+        "amount_fee": "5",
         "payments": [
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
             "id_type": "stellar",
             "amount": "10",
-            "fee": "0"
+            "fee": "5"
           }
         ]
       }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1017,7 +1017,7 @@ Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
-`payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
+`payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 
 #### Refund Payment Object Schema
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1016,6 +1016,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
@@ -1024,7 +1025,8 @@ Name | Type | Description
 -----|------|------------
 `id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
-`amount` | string | The amount sent back to the user for the payment identified by `id`.
+`amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
+`fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
 
 Example response:
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1238,3 +1238,7 @@ If the information was malformed, or if the sender tried to update data that isn
 * PHP SDK: https://github.com/Soneso/stellar-php-sdk/blob/main/examples/sep-0006-transfer.md
 
 [SEP-38]: sep-0038.md
+
+## Changelog
+
+* `v3.10.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1070,14 +1070,15 @@ Example response:
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
       "refunds": {
-        "type": "partial",
         "amount_refunded": "10",
+        "total_fee": "0",
         "payments": [
-            {
-                "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
-                "id_type": "stellar",
-                "amount": "10"
-            }
+          {
+            "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+            "id_type": "stellar",
+            "amount": "10",
+            "fee": "0"
+          }
         ]
       }
     },

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1084,7 +1084,10 @@ Example response:
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
-      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "external_transaction_id": "1238234",
+      "withdraw_anchor_account": "GBANAGOAXH5ONSBI2I6I5LHP2TCRHWMZIAMGUQH2TNKQNCOGJ7GC3ZOL",
+      "withdraw_memo": "186384",
+      "withdraw_memo_type": "id",
       "refunds": {
         "amount_refunded": "10",
         "amount_fee": "5",
@@ -1092,6 +1095,32 @@ Example response:
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
             "id_type": "stellar",
+            "amount": "10",
+            "fee": "5"
+          }
+        ]
+      }
+    },
+    {
+      "id": "72fhs729f63dh0v1",
+      "kind": "deposit",
+      "status": "completed",
+      "amount_in": "510",
+      "amount_out": "490",
+      "amount_fee": "5",
+      "started_at": "2017-03-20T17:00:02Z",
+      "completed_at": "2017-03-20T17:09:58Z",
+      "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
+      "external_transaction_id": "1238234",
+      "from": "AJ3845SAD",
+      "to": "GBITQ4YAFKD2372TNAMNHQ4JV5VS3BYKRK4QQR6FOLAR7XAHC3RVGVVJ",
+      "refunds": {
+        "amount_refunded": "10",
+        "amount_fee": "5",
+        "payments": [
+          {
+            "id": "104201",
+            "id_type": "external",
             "amount": "10",
             "fee": "5"
           }

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1041,7 +1041,7 @@ refunds.amount_refunded = sum(refunds.payments[].amount)
 ```
 
 ```
-refunds.total_fee = sum(refunds.payments[].fee)
+refunds.amount_fee = sum(refunds.payments[].fee)
 ```
 
 Example response:

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1258,4 +1258,4 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
-* `v3.10.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
+* `v3.10.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1023,7 +1023,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated. This id is not guaranteed to be unique.
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1015,7 +1015,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If a full refund was issued, this amount should match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1016,7 +1016,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
@@ -1027,6 +1027,22 @@ Name | Type | Description
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
+
+### Amount Formulas
+
+The following should hold true for all transaction records, assuming `amount_in_asset` and `amount_out_asset` are the same. If they are different, the following should still hold true after converting all amounts to units of one of the assets.
+
+```
+amount_out = amount_in - amount_fee - refunds.amount_refunded - refunds.amount_fee
+```
+
+```
+refunds.amount_refunded = sum(refunds.payments[].amount)
+```
+
+```
+refunds.total_fee = sum(refunds.payments[].fee)
+```
 
 Example response:
 
@@ -1071,7 +1087,7 @@ Example response:
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
       "refunds": {
         "amount_refunded": "10",
-        "total_fee": "0",
+        "amount_fee": "0",
         "payments": [
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
 Updated: 2021-10-22
-Version 3.9.1
+Version 3.10.0
 ```
 
 ## Simple Summary
@@ -987,7 +987,8 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (optional) Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund_info` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refund` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 `claimable_balance_id` | string | (optional) ID of the Claimable Balance used to send the asset initially requested. Only relevant for deposit transactions.
@@ -1009,6 +1010,22 @@ Name | Type | Description
 * `too_small` -- deposit/withdrawal size less than `min_amount`.
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.
 * `error` -- catch-all for any error not enumerated above.
+
+### Refund Object Schema
+
+Name | Type | Description
+-----|------|------------
+`type` | string | One of `partial` or `full`
+`total_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
+
+#### Refund Transactions Object Schema
+
+Name | Type | Description
+-----|------|------------
+`refund_payment_id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id_type` | string | `stellar` or `external`.
+`amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
 
 Example response:
 
@@ -1044,13 +1061,24 @@ Example response:
       "id": "82fhs729f63dh0v4",
       "kind": "withdrawal",
       "status": "completed",
-      "amount_in": "500",
+      "amount_in": "510",
       "amount_out": "495",
-      "amount_fee": "3",
+      "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
-      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093"
+      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "refund": {
+        "type": "partial",
+        "total_refunded": "10",
+        "payments": [
+            {
+                "refund_payment_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+                "id_type": "stellar",
+                "amount": "10"
+            }
+        ]
+      }
     },
     {
       "id": "52fys79f63dh3v1",

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1019,7 +1019,7 @@ Name | Type | Description
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
-#### Refund Transactions Object Schema
+#### Refund Payment Object Schema
 
 Name | Type | Description
 -----|------|------------

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -987,7 +987,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund_info` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. Should be true if the transaction was refunded. Not including this field means the transaction was not refunded.
 `refund` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1016,7 +1016,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 
 #### Refund Payment Object Schema

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -987,7 +987,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded in full. False if the transaction was partially refunded or not refunded. For more details about any refunds, see the `refunds` object.
 `refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the user.
 `required_info_updates` | object | (optional) A set of fields that require update from the user described in the same format as [/info](#info).  This field is only relevant when `status` is `pending_transaction_info_update`.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -834,7 +834,7 @@ Example response:
             "id": "1937103",
             "id_type": "external",
             "amount": "10",
-            "fee": "0"
+            "fee": "5"
           }
         ]
       }

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -740,7 +740,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`.. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 
 #### Refund Payment Object Schema
@@ -790,8 +790,8 @@ Example response:
       "id": "82fhs729f63dh0v4",
       "kind": "withdrawal",
       "status": "completed",
-      "amount_in": "500",
-      "amount_out": "495",
+      "amount_in": "510",
+      "amount_out": "490",
       "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
@@ -801,7 +801,7 @@ Example response:
       "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
       "refunds": {
         "amount_refunded": "10",
-        "amount_fee": "0",
+        "amount_fee": "5",
         "payments": [
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -740,7 +740,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
@@ -785,7 +785,7 @@ Example response:
       "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
       "refunds": {
         "amount_refunded": "10",
-        "total_fee": "0",
+        "amount_fee": "0",
         "payments": [
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -784,14 +784,15 @@ Example response:
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
       "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
       "refunds": {
-        "type": "partial",
         "amount_refunded": "10",
+        "total_fee": "0",
         "payments": [
-            {
-                "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
-                "id_type": "stellar",
-                "amount": "10"
-            }
+          {
+            "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+            "id_type": "stellar",
+            "amount": "10",
+            "fee": "0"
+          }
         ]
       }
     }

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active
 Created: 2019-09-18
 Updated: 2021-12-01
-Version 2.1.1
+Version 2.2.0
 ```
 
 ## Simple Summary
@@ -693,7 +693,8 @@ Name | Type | Description
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | True if the transaction was refunded, false otherwise.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. True if the transaction was refunded, false otherwise.
+`refund` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 
 
 ### Fields for deposit transactions
@@ -734,6 +735,22 @@ Name | Type | Description
 
 ![Status Diagram](../contents/sep-0024/state_diagram.png?raw=true)
 
+### Refund Object Schema
+
+Name | Type | Description
+-----|------|------------
+`type` | string | One of `partial` or `full`
+`total_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
+
+#### Refund Transactions Object Schema
+
+Name | Type | Description
+-----|------|------------
+`refund_payment_id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id_type` | string | `stellar` or `external`.
+`amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
+
 Example response:
 
 ```json
@@ -758,13 +775,24 @@ Example response:
       "status": "completed",
       "amount_in": "500",
       "amount_out": "495",
-      "amount_fee": "3",
+      "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
       "more_info_url": "https://youranchor.com/tx/242523523",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
-      "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea"
+      "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
+      "refund": {
+        "type": "partial",
+        "total_refunded": "10",
+        "payments": [
+            {
+                "refund_payment_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+                "id_type": "stellar",
+                "amount": "10"
+            }
+        ]
+      }
     }
   ]
 }

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -693,8 +693,8 @@ Name | Type | Description
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. True if the transaction was refunded, false otherwise.
-`refund` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded, false otherwise.
+`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 
 
 ### Fields for deposit transactions
@@ -740,14 +740,14 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `type` | string | One of `partial` or `full`
-`total_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
 
 Name | Type | Description
 -----|------|------------
-`refund_payment_id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
 
@@ -782,12 +782,12 @@ Example response:
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
       "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
-      "refund": {
+      "refunds": {
         "type": "partial",
-        "total_refunded": "10",
+        "amount_refunded": "10",
         "payments": [
             {
-                "refund_payment_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+                "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
                 "id_type": "stellar",
                 "amount": "10"
             }

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -765,7 +765,8 @@ refunds.amount_refunded = sum(refunds.payments[].amount)
 ```
 
 ```
-refunds.total_fee = sum(refunds.payments[].fee)
+refunds.amount_fee = sum(refunds.payments[].fee)
+```
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -798,7 +798,6 @@ Example response:
       "more_info_url": "https://youranchor.com/tx/242523523",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "1941491",
-      "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
       "withdraw_anchor_account": "GBANAGOAXH5ONSBI2I6I5LHP2TCRHWMZIAMGUQH2TNKQNCOGJ7GC3ZOL",
       "withdraw_memo": "186384",
       "withdraw_memo_type": "id",

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -693,7 +693,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded, false otherwise.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
 `refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 
 
@@ -739,7 +739,6 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`type` | string | One of `partial` or `full`
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -889,3 +889,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * Demo wallet client for development of an anchor server: https://sep24.stellar.org
 * Anchor server implementation example and reuseable app in Python: https://github.com/stellar/django-polaris
 * Solar wallet: https://solarwallet.io
+
+## Changelog
+
+* `v2.2.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -747,7 +747,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
+`id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated. This id is not guaranteed to be unique.
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -740,6 +740,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
 #### Refund Transactions Object Schema
@@ -748,7 +749,8 @@ Name | Type | Description
 -----|------|------------
 `id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
-`amount` | string | The amount sent back to the user for the payment identified by `id`.
+`amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
+`fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -740,7 +740,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`.. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 
 #### Refund Payment Object Schema
@@ -797,8 +797,11 @@ Example response:
       "completed_at": "2017-03-20T17:09:58Z",
       "more_info_url": "https://youranchor.com/tx/242523523",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
-      "external_transaction_id": "2dd16cb409513026fbe7defc0c6f826c2d2c65c3da993f747d09bf7dafd31093",
+      "external_transaction_id": "1941491",
       "claimable_balance_id": "00000000c2d8c89264288dbde8488364fd3fd30850fd4e7fbf6d1e9809702558afa4fdea",
+      "withdraw_anchor_account": "GBANAGOAXH5ONSBI2I6I5LHP2TCRHWMZIAMGUQH2TNKQNCOGJ7GC3ZOL",
+      "withdraw_memo": "186384",
+      "withdraw_memo_type": "id",
       "refunds": {
         "amount_refunded": "10",
         "amount_fee": "5",
@@ -806,6 +809,31 @@ Example response:
           {
             "id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
             "id_type": "stellar",
+            "amount": "10",
+            "fee": "0"
+          }
+        ]
+      }
+    },
+    {
+      "id": "92fhs729f63dh0v3",
+      "kind": "deposit",
+      "status": "completed",
+      "amount_in": "510",
+      "amount_out": "490",
+      "amount_fee": "5",
+      "started_at": "2017-03-20T17:00:02Z",
+      "completed_at": "2017-03-20T17:09:58Z",
+      "more_info_url": "https://youranchor.com/tx/242523526",
+      "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
+      "external_transaction_id": "1947101",
+      "refunds": {
+        "amount_refunded": "10",
+        "amount_fee": "5",
+        "payments": [
+          {
+            "id": "1937103",
+            "id_type": "external",
             "amount": "10",
             "fee": "0"
           }

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -743,7 +743,7 @@ Name | Type | Description
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
 
-#### Refund Transactions Object Schema
+#### Refund Payment Object Schema
 
 Name | Type | Description
 -----|------|------------
@@ -751,6 +751,21 @@ Name | Type | Description
 `id_type` | string | `stellar` or `external`.
 `amount` | string | The amount sent back to the user for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
+
+### Amount Formulas
+
+The following should hold true for all transaction records, assuming `amount_in_asset` and `amount_out_asset` are the same. If they are different, the following should still hold true after converting all amounts to units of one of the assets.
+
+```
+amount_out = amount_in - amount_fee - refunds.amount_refunded - refunds.amount_fee
+```
+
+```
+refunds.amount_refunded = sum(refunds.payments[].amount)
+```
+
+```
+refunds.total_fee = sum(refunds.payments[].fee)
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -741,7 +741,7 @@ Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
-`payments` | array | A list of objects containing information on the individual payments made back to the user. The schema for these objects is defined in the section below.
+`payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 
 #### Refund Payment Object Schema
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -694,7 +694,7 @@ Name | Type | Description
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
 `refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded, false otherwise.
-`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 
 
 ### Fields for deposit transactions
@@ -735,7 +735,7 @@ Name | Type | Description
 
 ![Status Diagram](../contents/sep-0024/state_diagram.png?raw=true)
 
-### Refund Object Schema
+### Refunds Object Schema
 
 Name | Type | Description
 -----|------|------------
@@ -749,7 +749,7 @@ Name | Type | Description
 -----|------|------------
 `id` | string | The payment ID that can be used to identify the refund payment. This is either a Stellar transaction hash or an off-chain payment identifier, such as a reference number provided to the user when the refund was initiated.
 `id_type` | string | `stellar` or `external`.
-`amount` | string | The amount sent back to the user for the payment identified by `refund_payment_id`.
+`amount` | string | The amount sent back to the user for the payment identified by `id`.
 
 Example response:
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -693,7 +693,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded in full. False if the transaction was partially refunded or not refunded. For more details about any refunds, see the `refunds` object.
 `refunds` | object | (optional) An object describing any on or off-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -739,7 +739,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the user, in units of `amount_in_asset`. If a full refund was issued, this amount should match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the user as refunds. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -908,4 +908,4 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
-* `v2.2.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
+* `v2.2.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -8,7 +8,7 @@ Author: SDF
 Status: Active
 Created: 2020-04-07
 Updated: 2021-10-22
-Version 1.4.0
+Version 1.5.0
 ```
 
 ## Simple Summary
@@ -238,8 +238,6 @@ Name | Type | Description
 `quotes_supported` | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.
 `quotes_required` | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.
 
-
-
 #### `sep12` Object Schema
 
 Name | Type | Description
@@ -449,7 +447,8 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (optional) Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
+`refund` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 
@@ -464,6 +463,21 @@ Name | Type | Description
 * `completed` -- funds have been delivered to the Receiving Client.
 * `error` -- catch-all for any error not enumerated above.
 
+#### Refund Object Schema
+
+Name | Type | Description
+-----|------|------------
+`type` | string | One of `partial` or `full`
+`total_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
+
+##### Refund Transactions Object Schema
+
+Name | Type | Description
+-----|------|------------
+`refund_payment_id` | string | The Stellar transaction hash of the transaction that included the refund payment.
+`amount` | string | The amount sent back to the Sending Anchor for the payment identified by `refund_payment_id`.
+
 Example response:
 
 ```json
@@ -472,7 +486,11 @@ Example response:
       "id": "82fhs729f63dh0v4",
       "status": "pending_external",
       "status_eta": 3600,
+      "stellar_transaction_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
       "external_transaction_id": "ABCDEFG1234567890",
+      "stellar_account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+      "stellar_memo": "123456789",
+      "stellar_memo_type": "id",
       "amount_in": "18.34",
       "amount_out": "18.24",
       "amount_fee": "0.1",
@@ -487,10 +505,14 @@ Example response:
       "id": "82fhs729f63dh0v4",
       "status": "pending_transaction_info_update",
       "status_eta": 3600,
+      "stellar_transaction_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
       "external_transaction_id": "ABCDEFG1234567890",
       "amount_in": "18.34",
       "amount_out": "18.24",
       "amount_fee": "0.1",
+      "stellar_account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+      "stellar_memo": "123456789",
+      "stellar_memo_type": "id",
       "started_at": "2017-03-20T17:05:32Z",
       "required_info_message": "The bank reported an incorrect account number for the receiver, please ensure the account matches legal documents",
       "required_info_updates": {
@@ -499,6 +521,33 @@ Example response:
                "description": "The receiver's bank account number"
             }
          }
+      }
+    }
+}
+```
+
+```json
+{
+  "transaction": {
+      "id": "82fhs729f63dh0v4",
+      "status": "completed",
+      "amount_in": "110",
+      "amount_out": "95",
+      "amount_fee": "5",
+      "started_at": "2017-03-20T17:05:32Z",
+      "stellar_transaction_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
+      "stellar_account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+      "stellar_memo": "123456789",
+      "stellar_memo_type": "id",
+      "refund": {
+        "type": "partial",
+        "total_refunded": "10",
+        "payments": [
+          {
+            "refund_payment_id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",
+            "amount": "10"
+          }
+        ]
       }
     }
 }

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -447,7 +447,7 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. True if the transaction was refunded in full. False if the transaction was partially refunded or not refunded. For more details about any refunds, see the `refunds` object.
 `refunds` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -631,4 +631,4 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
-* `v1.5.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
+* `v1.5.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -610,3 +610,8 @@ If the information was malformed, or if the sender tried to update data that isn
 {
    "error": "Supplied fields do not allow updates, please only try to updates the fields requested"
 }
+```
+
+## Changelog
+
+* `v1.5.0`: deprecate refunded boolean, add refund object to transaction records ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -468,6 +468,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
 
 ##### Refund Transactions Object Schema
@@ -475,7 +476,8 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `id` | string | The Stellar transaction hash of the transaction that included the refund payment.
-`amount` | string | The amount sent back to the Sending Anchor for the payment identified by `id`.
+`amount` | string | The amount sent back to the Sending Anchor for the payment identified by `id`, in units of `amount_in_asset`.
+`fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
 
 Example response:
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -467,7 +467,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If a full refund was issued, this amount should match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor as refunds. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -468,7 +468,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`total_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
 
 ##### Refund Transactions Object Schema
@@ -478,6 +478,21 @@ Name | Type | Description
 `id` | string | The Stellar transaction hash of the transaction that included the refund payment.
 `amount` | string | The amount sent back to the Sending Anchor for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
+
+#### Amount Formulas
+
+The following should hold true for all transaction records, assuming `amount_in_asset` and `amount_out_asset` are the same. If they are different, the following should still hold true after converting all amounts to units of one of the assets.
+
+```
+amount_out = amount_in - amount_fee - refunds.amount_refunded - refunds.amount_fee
+```
+
+```
+refunds.amount_refunded = sum(refunds.payments[].amount)
+```
+
+```
+refunds.total_fee = sum(refunds.payments[].fee)
 
 Example response:
 
@@ -542,7 +557,7 @@ Example response:
       "stellar_memo_type": "id",
       "refunds": {
         "amount_refunded": "10",
-        "total_fee": "0",
+        "amount_fee": "0",
         "payments": [
           {
             "id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -541,12 +541,13 @@ Example response:
       "stellar_memo": "123456789",
       "stellar_memo_type": "id",
       "refunds": {
-        "type": "partial",
         "amount_refunded": "10",
+        "total_fee": "0",
         "payments": [
           {
             "id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",
-            "amount": "10"
+            "amount": "10",
+            "fee": "0"
           }
         ]
       }

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -447,8 +447,8 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refund` object. Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
-`refund` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
+`refunds` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 
@@ -468,14 +468,14 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `type` | string | One of `partial` or `full`
-`total_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
+`amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
 
 ##### Refund Transactions Object Schema
 
 Name | Type | Description
 -----|------|------------
-`refund_payment_id` | string | The Stellar transaction hash of the transaction that included the refund payment.
+`id` | string | The Stellar transaction hash of the transaction that included the refund payment.
 `amount` | string | The amount sent back to the Sending Anchor for the payment identified by `refund_payment_id`.
 
 Example response:
@@ -539,12 +539,12 @@ Example response:
       "stellar_account_id": "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
       "stellar_memo": "123456789",
       "stellar_memo_type": "id",
-      "refund": {
+      "refunds": {
         "type": "partial",
-        "total_refunded": "10",
+        "amount_refunded": "10",
         "payments": [
           {
-            "refund_payment_id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",
+            "id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",
             "amount": "10"
           }
         ]

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -448,7 +448,7 @@ Name | Type | Description
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
 `refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
-`refunds` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refund Object Schema](#refund-object-schema) section below.
+`refunds` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
 
@@ -463,7 +463,7 @@ Name | Type | Description
 * `completed` -- funds have been delivered to the Receiving Client.
 * `error` -- catch-all for any error not enumerated above.
 
-#### Refund Object Schema
+#### Refunds Object Schema
 
 Name | Type | Description
 -----|------|------------
@@ -476,7 +476,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `id` | string | The Stellar transaction hash of the transaction that included the refund payment.
-`amount` | string | The amount sent back to the Sending Anchor for the payment identified by `refund_payment_id`.
+`amount` | string | The amount sent back to the Sending Anchor for the payment identified by `id`.
 
 Example response:
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -447,7 +447,7 @@ Name | Type | Description
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
-`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded. Refunded transactions should also have their `status` set to `error`. Not including this field means the transaction was not refunded.
+`refunded` | boolean | (**deprecated**, optional) This field is deprecated in favor of the `refunds` object. Should be true if the transaction was refunded in full. Partial refunds can still be expressed using the `refunds` object.
 `refunds` | object | (optional) An object describing any on-chain refund associated with this transaction. The schema for this object is defined in the [Refunds Object Schema](#refunds-object-schema) section below.
 `required_info_message` | string | (optional) A human-readable message indicating any errors that require updated information from the sender.
 `required_info_updates` | object | (optional) A set of fields that require update values from the Sending Anchor, in the same format as described in [GET /info](#get-info).  This field is only relevant when `status` is `pending_transaction_info_update`.
@@ -467,7 +467,6 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`type` | string | One of `partial` or `full`
 `amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -493,6 +493,7 @@ refunds.amount_refunded = sum(refunds.payments[].amount)
 
 ```
 refunds.total_fee = sum(refunds.payments[].fee)
+```
 
 Example response:
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -469,7 +469,7 @@ Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
-`payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
+`payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor as refunds. The schema for these objects is defined in the section below.
 
 ##### Refund Payment Object Schema
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -492,7 +492,7 @@ refunds.amount_refunded = sum(refunds.payments[].amount)
 ```
 
 ```
-refunds.total_fee = sum(refunds.payments[].fee)
+refunds.amount_fee = sum(refunds.payments[].fee)
 ```
 
 Example response:

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -468,7 +468,7 @@ Name | Type | Description
 Name | Type | Description
 -----|------|------------
 `amount_refunded` | string | The total amount refunded to the Sending Anchor, in units of `amount_in_asset`. If `type` is `full`, this amount must match `amount_in`.
-`amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
+`amount_fee` | string | The total amount charged in fees for processing all refund payments, in units of `amount_in_asset`. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor as refunds. The schema for these objects is defined in the section below.
 
 ##### Refund Payment Object Schema

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -471,7 +471,7 @@ Name | Type | Description
 `amount_fee` | string | The total amount charged in fees for processing all refund payments. The sum of all `fee` values in the `payments` object list should equal this value.
 `payments` | array | A list of objects containing information on the individual payments made back to the Sending Anchor. The schema for these objects is defined in the section below.
 
-##### Refund Transactions Object Schema
+##### Refund Payment Object Schema
 
 Name | Type | Description
 -----|------|------------

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -549,7 +549,7 @@ Example response:
       "id": "82fhs729f63dh0v4",
       "status": "completed",
       "amount_in": "110",
-      "amount_out": "95",
+      "amount_out": "90",
       "amount_fee": "5",
       "started_at": "2017-03-20T17:05:32Z",
       "stellar_transaction_id": "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020",
@@ -558,12 +558,12 @@ Example response:
       "stellar_memo_type": "id",
       "refunds": {
         "amount_refunded": "10",
-        "amount_fee": "0",
+        "amount_fee": "5",
         "payments": [
           {
             "id": "54321ab047a193c6fda1c47f5962cbcca8708d79b87089ababd57532c21c5402",
             "amount": "10",
-            "fee": "0"
+            "fee": "5"
           }
         ]
       }

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -475,7 +475,7 @@ Name | Type | Description
 
 Name | Type | Description
 -----|------|------------
-`id` | string | The Stellar transaction hash of the transaction that included the refund payment.
+`id` | string | The Stellar transaction hash of the transaction that included the refund payment. This id is not guaranteed to be unique.
 `amount` | string | The amount sent back to the Sending Anchor for the payment identified by `id`, in units of `amount_in_asset`.
 `fee` | string | The amount charged as a fee for processing the refund, in units of `amount_in_asset`.
 


### PR DESCRIPTION
resolves #1122 

Deprecates the `refunded` attribute included in objects returned from `GET /transaction(s)` endpoints for SEP-6, 24, & 31 in favor of adding a `refund` object.

This refund object contains information about the type of refund, total amount refunded, and the individual payments made back to the sender / user. 

Note that SEP-31 refunds are assumed to be made via Stellar (since funds are always delivered to receiving anchors via Stellar).