### PR TITLE
CAP-40: Make some text clearer

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -117,23 +117,27 @@ of 64 bytes and an ed25519 public key. A signature for the signer is the result
 of signing the payload with the private key that the public key is derived.
 
 The ed25519 signed payload signer is usable everywhere existing signers may be
-used, including in `extraSigners<1>` added in [CAP-21].
+used, including in the `extraSigners` transaction precondition added in
+[CAP-21].
 
 #### Signature
 
-The signature of a ed25519 signed payload signer is the raw ed25519 signature of
-the signer's payload using the private key that derives the signer's ed25519
+The signature of an ed25519 signed payload signer is the raw ed25519 signature
+of the signer's payload using the private key that derives the signer's ed25519
 public key.
 
-Unlike other signatures in the Stellar protocol, the payload is not combined
-with the network ID or hashed before passing it to the ed25519 signing
-algorithm.
+For example, given:
+- A private key `Ks` and its derived public key `Kp`.
+- A ed25519 signed payload signer `S` that contains:
+  - Payload `P`.
+  - Public key `Kp`.
 
-To represent another Stellar transaction as the the payload field of a Ed25519
-signed payload signer, you must first place the transaction in a
-`TransactionSignaturePayload` and hash that. The resulting signature will be a
-ed25519 signature of the other Stellar transaction that could be attached to the
-other transaction.
+A signature that satisfies signer `S` is produced by:
+- Ed25519 signing `P` with `Ks`.
+
+Unlike transaction signatures in the Stellar protocol, the payload of this
+signer is not combined with the network ID or hashed before passing it to the
+ed25519 signing algorithm.
 
 #### Signature Hint
 
@@ -163,10 +167,17 @@ This proposal provides a primitive that makes it possible to construct a set
 of transactions where all transactions can be authorized and submitted if the
 first transaction is authorized and submitted.
 
-This proposal makes this possible when the signer is used with the
-`extraSigners` precondition introduced in [CAP-21], and does so without
-introducing any new state to be stored on the ledger, allowing the signing
-dependency to exist without creating ledger entries.
+This proposal makes this possible since a Stellar transaction hash can be
+specified as the payload of an ed25519 signed payload signer. A Stellar
+transaction hash is the SHA-256 hash of the `TransactionSignaturePayload`
+containing the Stellar transaction. A signature for the signer will also be an
+ed25519 signature of the other Stellar transaction that could be attached to the
+other transaction.
+
+An ed25519 signed payload signer can be constructed for each subsequent
+transaction that needs authorizing, and included in the `extraSigners`
+precondition of the first transadction. This will require the signatures of all
+subsequent transactions to be disclosed on the first transaction.
 
 While it is possible to achieve a similar effect of this proposal with the
 existing protocol by using the preauth transaction signer, use of that signer

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -170,9 +170,9 @@ first transaction is authorized and submitted.
 This proposal makes this possible since a Stellar transaction hash can be
 specified as the payload of an ed25519 signed payload signer. A Stellar
 transaction hash is the SHA-256 hash of the `TransactionSignaturePayload`
-containing the Stellar transaction. A signature for the signer will also be an
-ed25519 signature of the other Stellar transaction that could be attached to the
-other transaction.
+containing the Stellar transaction. A valid signature for the signer will also
+be a valid signature of the other Stellar transaction if the ed25519 key used to
+sign the payload is also required to sign the other transaction.
 
 An ed25519 signed payload signer can be constructed for each subsequent
 transaction that needs authorizing, and included in the `extraSigners`


### PR DESCRIPTION
### What
Removed the discussion about how a transaction hash is produced from the semantics, and moved it to the design rationale.

### Why
Feedback from @Shaptic highlighted that the section in the semantics section about how the transaction hash was constructed was confusing as it was presented like a new process that takes place, when in fact this is just the regular process all transaction hashes go through.

I moved it to the design rationale because that content relates more to how the changes will be used, and it is not really semantics of the change itself.