### PR TITLE
Correction to the argument supporting the liquidity pool's trading rule

### DIFF
--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -355,9 +355,8 @@ Y' = (pX + Y) / (2 - F)
     < (Y + (1 - F)Y) / (2 - F)
     = Y
 ```
-,
 
-so the liquidity pool, as expected, sells `Y` and purchases `X`.
+Thus, the liquidity pool, as expected, sells `Y` and purchases `X`.
 
 Next, suppose that `(1/p) < (1 - F) X/Y`.
 Then the liquidity pool sells `X` and buys `Y` until
@@ -380,9 +379,8 @@ Y' = (pX + Y) (1 - F) / (2 - F)
     > (Y + (1 - F)Y) / (2 - F)
     = Y
 ```
-,
 
-so the liquidity pool, as expected, sells `X` and purchases `Y`.
+Thus, the liquidity pool, as expected, sells `X` and purchases `Y`.
 
 ### Demand from an order
 Tatonnement does not handle discontinuities well. The demand from an order is

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -354,7 +354,8 @@ and
 Y' = (pX + Y) / (2 - F)
     < (Y + (1 - F)Y) / (2 - F)
     = Y
-```,
+```
+,
 
 so the liquidity pool, as expected, sells `Y` and purchases `X`.
 
@@ -378,7 +379,8 @@ and
 Y' = (pX + Y) (1 - F) / (2 - F)
     > (Y + (1 - F)Y) / (2 - F)
     = Y
-```,
+```
+,
 
 so the liquidity pool, as expected, sells `X` and purchases `Y`.
 

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -334,17 +334,17 @@ Y' = Y .
 ```
 
 We will now show that the liquidity pool does take the actions described above.
-First, suppose that `p (1 - F) > Y/X`.
-Then the liquidity pool sells `X` and buys `Y` until
-`p (1 - F) = Y'/X'`.  Combining this equation with the budget constraint gives
-`pX + Y = pX' + p(1 - F)X'`.
-Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (2 - F)`.
-
-Next, suppose that `(1/p) (1 - F) > X/Y`.  
+First, suppose that `p < (1 - F) Y/X`.  
 Then the liquidity pool sells `Y` and buys `X` until
-`(1/p) (1 - F) = X'/Y'`.  Combining this equation with the budget constraint gives
+`p = (1 - F) Y'/X'`.  Combining this equation with the budget constraint gives
 `pX + Y = Y' + (1 - F)Y'`.
 Rearranging gives `Y' = (pX + Y) / (2 - F)` and `X' = (pX + Y) (1 - F) / (p * (2 - F))`.
+
+Next, suppose that `(1/p) < (1 - F) X/Y`.
+Then the liquidity pool sells `X` and buys `Y` until
+`(1/p) = (1 - F) X'/Y'`.  Combining this equation with the budget constraint gives
+`pX + Y = pX' + p(1 - F)X'`.
+Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (2 - F)`.
 
 ### Demand from an order
 Tatonnement does not handle discontinuities well. The demand from an order is

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -183,8 +183,8 @@ the total amount of an asset demanded by all market participants at given
 prices. The demand aggregator sums the demand for every asset over liquidity
 pools and orders. A liquidity pool holding assets `X` and `Y` has demand
 ```
-X' = { (pX + Y) (1 - F) / (2 - F) / p   :   p < (1 - F) Y/X
-     { (pX + Y) / (2 - F) / p           :   1/p < (1 - F) X/Y
+X' = { (pX + Y) (1 - F) / (p * (2 - F)) :   p < (1 - F) Y/X
+     { (pX + Y) / (p * (2 - F))         :   1/p < (1 - F) X/Y
      { X                                :   otherwise
 
 Y' = { (pX + Y) / (2 - F)               :   p < (1 - F) Y/X
@@ -195,7 +195,7 @@ where `p = p(X) / p(Y)` is the market price ratio. An offer selling `X` for `Y`
 at a minimum price ratio of `P` has demand
 ```
 X' = { 0                       :   P / (1 - S) <= p
-     { X - (p - P) X / S / p   :   P < p < P / (1 - S)
+     { X - (p - P) X / (S * p) :   P < p < P / (1 - S)
      { X                       :   p <= P
 
 Y' = { pX              :   P / (1 - S) <= p
@@ -319,12 +319,12 @@ the liquidity pool will sell `X` and buy `Y` until `1/p = (1 - F) X'/Y'`.
 The budget constraint and marginal price constraint can be combined. If
 `p < (1 - F) Y/X` then
 ```
-X' = (pX + Y) (1 - F) / (2 - F) / p
+X' = (pX + Y) (1 - F) / ((2 - F) * p)
 Y' = (pX + Y) / (2 - F) .
 ```
 If `1/p < (1 - F) X/Y` then
 ```
-X' = (pX + Y) / (2 - F) / p
+X' = (pX + Y) / ((2 - F) * p)
 Y' = (pX + Y) (1 - F) / (2 - F) .
 ```
 In all other cases, the liquidity pool does not trade so
@@ -334,34 +334,17 @@ Y' = Y .
 ```
 
 We will now show that the liquidity pool does take the actions described above.
-If `p < (1 - F) Y/X` then
-```
-X' = (pX + Y) (1 - F) / (2 - F) / p
-   = X (1 - F) / (2 - F) + Y (1 - F) / (2 - F) / p
-   > X (1 - F) / (2 - F) + Y (1 - F) / (2 - F) / ((1 - F) Y / X)
-   = X (1 - F) / (2 - F) + X / (2 - F)
-   = X
-Y' = (pX + Y) / (2 - F)
-   = pX / (2 - F) + Y / (2 - F)
-   < (1 - F) Y / (2 - F) + Y / (2 - F)
-   = Y
-```
-as expected based on the description that the liquidity pool buys `X` and sells
-`Y`. If `1/p < (1 - F) X/Y` then
-```
-X' = (pX + Y) / (2 - F) / p
-   = X / (2 - F) + Y / (2 - F) / p
-   < X / (2 - F) + Y / (2 - F) * ((1 - F) X / Y)
-   = X / (2 - F) + X (1 - F) / (2 - F)
-   = X
-Y' = (pX + Y) (1 - F) / (2 - F)
-   = pX (1 - F) / (2 - F) + Y (1 - F) / (2 - F)
-   > X (1 - F) / (2 - F) / ((1 - F) X / Y) + Y (1 - F) / (2 - F)
-   = Y / (2 - F) + Y (1 - F) / (2 - F)
-   = Y
-```
-as expected based on the description that the liquidity pool sells `X` and buys
-`Y`.
+First, suppose that `p (1 - F) > Y/X`.
+Then the liquidity pool sells `X` and buys `Y` until
+`p (1 - F) = Y'/X'`.  Combining this equation with the budget constraint gives
+`pX + Y = pX' + p(1 - F)X'`.
+Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (2 - F)`.
+
+Next, suppose that `(1/p) (1 - F) > X/Y`.  
+Then the liquidity pool sells `Y` and buys `X` until
+`(1/p) (1 - F) = X'/Y'`.  Combining this equation with the budget constraint gives
+`pX + Y = Y' + (1 - F)Y'`.
+Rearranging gives `Y' = (pX + Y) / (2 - F)` and `X' = (pX + Y) (1 - F) / (p * (2 - F))`.
 
 ### Demand from an order
 Tatonnement does not handle discontinuities well. The demand from an order is

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -340,11 +340,31 @@ Then the liquidity pool sells `Y` and buys `X` until
 `pX + Y = Y' + (1 - F)Y'`.
 Rearranging gives `Y' = (pX + Y) / (2 - F)` and `X' = (pX + Y) (1 - F) / (p * (2 - F))`.
 
+Observe that in this case, 
+`X' = (pX + Y) (1 - F) / (p * (2 - F))
+    > (pX (1 - F) + pX) / (p * (2 - F))
+    = X`
+and
+`Y' = (pX + Y) / (2 - F)
+    < (Y + (1 - F)Y) / (2 - F)
+    = Y`,
+so the liquidity pool, as expected, sells `Y` and purchases `X`.
+
 Next, suppose that `(1/p) < (1 - F) X/Y`.
 Then the liquidity pool sells `X` and buys `Y` until
 `(1/p) = (1 - F) X'/Y'`.  Combining this equation with the budget constraint gives
 `pX + Y = pX' + p(1 - F)X'`.
 Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (2 - F)`.
+
+Observe that in this case, 
+`X' = (pX + Y) / (p * (2 - F))
+    < (pX + pX (1 - F)) / (p * (2 - F))
+    = X`
+and
+`Y' = (pX + Y) (1 - F) / (2 - F)
+    > (Y + (1 - F)Y) / (2 - F)
+    = Y`,
+so the liquidity pool, as expected, sells `X` and purchases `Y`.
 
 ### Demand from an order
 Tatonnement does not handle discontinuities well. The demand from an order is

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -342,16 +342,20 @@ Rearranging gives `Y' = (pX + Y) / (2 - F)` and `X' = (pX + Y) (1 - F) / (p * (2
 
 Observe that in this case, 
 
-`X' = (pX + Y) (1 - F) / (p * (2 - F))
+```
+X' = (pX + Y) (1 - F) / (p * (2 - F))
     > (pX (1 - F) + pX) / (p * (2 - F))
-    = X`
+    = X
+```
 
 and
 
-`Y' = (pX + Y) / (2 - F)
+```
+Y' = (pX + Y) / (2 - F)
     < (Y + (1 - F)Y) / (2 - F)
-    = Y`,
-    
+    = Y
+```,
+
 so the liquidity pool, as expected, sells `Y` and purchases `X`.
 
 Next, suppose that `(1/p) < (1 - F) X/Y`.
@@ -362,15 +366,19 @@ Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (
 
 Observe that in this case, 
 
-`X' = (pX + Y) / (p * (2 - F))
+```
+X' = (pX + Y) / (p * (2 - F))
     < (pX + pX (1 - F)) / (p * (2 - F))
-    = X`
+    = X
+```
 
 and
 
-`Y' = (pX + Y) (1 - F) / (2 - F)
+```
+Y' = (pX + Y) (1 - F) / (2 - F)
     > (Y + (1 - F)Y) / (2 - F)
-    = Y`,
+    = Y
+```,
 
 so the liquidity pool, as expected, sells `X` and purchases `Y`.
 

--- a/core/cap-0045.md
+++ b/core/cap-0045.md
@@ -341,13 +341,17 @@ Then the liquidity pool sells `Y` and buys `X` until
 Rearranging gives `Y' = (pX + Y) / (2 - F)` and `X' = (pX + Y) (1 - F) / (p * (2 - F))`.
 
 Observe that in this case, 
+
 `X' = (pX + Y) (1 - F) / (p * (2 - F))
     > (pX (1 - F) + pX) / (p * (2 - F))
     = X`
+
 and
+
 `Y' = (pX + Y) / (2 - F)
     < (Y + (1 - F)Y) / (2 - F)
     = Y`,
+    
 so the liquidity pool, as expected, sells `Y` and purchases `X`.
 
 Next, suppose that `(1/p) < (1 - F) X/Y`.
@@ -357,13 +361,17 @@ Then the liquidity pool sells `X` and buys `Y` until
 Rearranging gives `X' = (pX + Y) / (p * (2 - F))` and `Y' = (pX + Y) (1 - F) / (2 - F)`.
 
 Observe that in this case, 
+
 `X' = (pX + Y) / (p * (2 - F))
     < (pX + pX (1 - F)) / (p * (2 - F))
     = X`
+
 and
+
 `Y' = (pX + Y) (1 - F) / (2 - F)
     > (Y + (1 - F)Y) / (2 - F)
     = Y`,
+
 so the liquidity pool, as expected, sells `X` and purchases `Y`.
 
 ### Demand from an order


### PR DESCRIPTION
The argument as written does not fully justify the protocol's choice of liquidity pool trading rule (there are quite a few formulae that would satisfy the earlier argument).  Namely, it shows that using the specified formula, the liquidity pool trades in the expected directions, but does not justify trade amounts.

I also switched notation of the form a / b / c to a / (b * c), which is (in my view) easier to read.