### PR TITLE
CAP-21: Improve clarity around when seqTime and seqLedger are set

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -59,11 +59,15 @@ transaction to execute when the `sourceAccount` is within some range.
 
 `AccountEntryExtensionV2`'s `ext` field is extended to keep track of
 `seqLedger` and `seqTime`--the ledger number and time at which the
-sequence number was set to its present value.  These values are
-updated for the `sourceAccount` of every executed transaction, and
-also for the `sourceAccount` of every successfully executed
-`BumpSequenceOp` operation (regardless of whether the `BumpSequenceOp`
-actually increased the sequence number).
+sequence number was set to its present value. These values are updated
+in two situations:
+
+1. Transaction: For the `sourceAccount` of every executed transaction.
+
+2. `BumpSequenceOp` operation: For the `sourceAccount` of every
+successfully executed `BumpSequenceOp` operation, regardless of whether
+the `BumpSequenceOp` actually increased or modified the sequence number
+of the account.
 
 If an account does not have an `AccountEntryExtensionV3` because it
 hasn't been upgraded yet, then it behaves as if `seqLedger` and


### PR DESCRIPTION
### What
Reformat the section of the specification that talks about when sepTime and seqLedger get set so that it is visually harder to miss the two situations.

### Why
It is easy to miss and pass over when reading the specification that the bump sequence operation also resets seqTime and seqLedger when it is successful, regardless of whether the sequence changes. The text already says this relatively clearly, but this makes it harder to miss.