### PR TITLE
CAP-21: Rename TxConditionsV2 to PreconditionsV2

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -143,7 +143,7 @@ struct LedgerBounds {
     uint32 maxLedger;
 };
 
-struct TxConditionsV2 {
+struct PreconditionsV2 {
     TimeBounds *timeBounds;
 
     // Transaciton only valid for ledger numbers n such that
@@ -186,7 +186,7 @@ union Preconditions switch (PreconditionType type) {
     case PRECOND_TIME:
         TimeBounds timeBounds;
     case PRECOND_V2:
-        TxConditionsV2 v2;
+        PreconditionsV2 v2;
 };
 ```
 
@@ -297,7 +297,7 @@ fail the second validation, for instance if a `BUMP_SEQUENCE`
 operation made the sequence number invalid.  Whenever a transaction
 fails validation during execution, the `sourceAccount` loses the fee.
 
-Because `TxConditionsV2` specifies multiple pre-conditions, there may
+Because `PreconditionsV2` specifies multiple pre-conditions, there may
 be multiple reasons why a transaction is invalid.  If any of the
 reasons is permanent---namely the `maxTime` or `maxLedger` has been
 exceeded--then the transaction is rejected with
@@ -369,7 +369,7 @@ index 3895ce9a..9ef87ad7 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index d97b0cb3..9613ab4d 100644
+index d97b0cb3..789e0ba4 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
 @@ -532,6 +532,58 @@ struct TimeBounds
@@ -382,7 +382,7 @@ index d97b0cb3..9613ab4d 100644
 +    uint32 maxLedger;
 +};
 +
-+struct TxConditionsV2 {
++struct PreconditionsV2 {
 +    TimeBounds *timeBounds;
 +
 +    // Transaciton only valid for ledger numbers n such that
@@ -425,7 +425,7 @@ index d97b0cb3..9613ab4d 100644
 +    case PRECOND_TIME:
 +        TimeBounds timeBounds;
 +    case PRECOND_V2:
-+        TxConditionsV2 v2;
++        PreconditionsV2 v2;
 +};
 +
  // maximum number of operations per transaction


### PR DESCRIPTION
### What
Rename `TxConditionsV2` to `PreconditionsV2`.

### Why
In the XDR changes of CAP-21 two new concepts are introduced, preconditions and txconditions. The inclusion of two concepts is unnecessary as there is really only one new concept being introduced, preconditions. Introducing new concepts when we don't need them makes it harder to understand an interface, and there's value in developing a [ubiquitous language](https://martinfowler.com/bliki/UbiquitousLanguage.html) for the concepts in the XDR so that the ubiquitous language bleeds into all downstream systems.

cc @MonsieurNicolas @stanford-scs @sisuresh @jonjove 