### PR TITLE
SEP-1: Allow externalization of currency metadata to other URLs.

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -153,13 +153,15 @@ Note: `fixed_number`, `max_number`, and `is_unlimited` are mutually exclusive is
 
 
 ### External Currency Specification
-There are two ways to "outsource" currency entries to external files: via the `toml` key and via the top-level `CURRENCY_TOMLS` list.
+There are two ways to reference currency entries in separate files:
+- The `CURRENCIES` `toml` key.
+- The top-level `CURRENCY_TOMLS` list.
 
-#### Via the `toml` key
+#### `CURRENCIES` `toml` Key
 `stellar.toml` can link out to a separate TOML file for each currency by specifying `toml="https://DOMAIN/.well-known/CURRENCY.toml"` as the currency's only field.
 
-#### Via the top-level list
-We also allow a top-level `CURRENCY_TOMLS` field, which must be an array of URLs to TOML files that follow the above [currency specification](#currency-documentation).
+#### `CURRENCY_TOMLS` List
+A top-level `CURRENCY_TOMLS` field may be specified as an array of URLs to TOML files that contain fields as defined in the [currency specification](#currency-documentation). These additional fields are interpreted as if their contents exist in the `stellar.toml`.
 
 Example usage:
 
@@ -171,9 +173,7 @@ CURRENCY_TOMLS = [
 ]
 ```
 
-Then, the `https://example.com/CURRENCIES_3.toml`-like files would contain ``[[CURRENCIES]]` entries as defined above.
-
-This field must be completely compatible with having existing `[[CURRENCIES]]` table entries within the `stellar.toml` file. The externalized TOML files must **only** include `[[CURRENCIES]]` entries. All other fields should be considered invalid.
+This files referenced must contain only `[[CURRENCIES]]` table entries.
 
 
 ### Validator Information

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -6,8 +6,8 @@ Title: Stellar Info File
 Author: stellar.org
 Status: Active
 Created: 2017-10-30
-Updated: 2021-05-17
-Version: 2.4.1
+Updated: 2022-03-07
+Version: 2.5.0
 ```
 
 ## Simple Summary
@@ -153,15 +153,23 @@ Note: `fixed_number`, `max_number`, and `is_unlimited` are mutually exclusive is
 
 
 ### External Currency Specification
-There are two ways to reference currency entries in separate files:
-- The `CURRENCIES` `toml` key.
-- The top-level `CURRENCY_TOMLS` list.
+There are two (compatible) ways to reference currency entries in separate files:
+
+  1. The `CURRENCIES` `toml` key.
+  2. The top-level `CURRENCY_TOMLS` list.
 
 #### `CURRENCIES` `toml` Key
-`stellar.toml` can link out to a separate TOML file for each currency by specifying `toml="https://DOMAIN/.well-known/CURRENCY.toml"` as the currency's only field.
+`stellar.toml` can link out to a separate TOML file for each currency by specifying the URL in the `toml` key as the currency's only field.
+
+Example usage:
+
+```toml
+[[CURRENCIES]]
+toml = "https://example.com/SPECIFIC_CURRENCY.toml"
+```
 
 #### `CURRENCY_TOMLS` List
-A top-level `CURRENCY_TOMLS` field may be specified as an array of URLs to TOML files that contain fields as defined in the [currency specification](#currency-documentation). These additional fields are interpreted as if their contents exist in the `stellar.toml`.
+A top-level `CURRENCY_TOMLS` field may be specified as an array of URLs to TOML files that contain [currency entries](#currency-documentation). These additional fields are interpreted as if their contents exist in the `stellar.toml`. These files referenced must contain only `[[CURRENCIES]]` table entries.
 
 Example usage:
 
@@ -169,11 +177,24 @@ Example usage:
 CURRENCY_TOMLS = [
   "https://example.com/.well-known/CURRENCIES_1.toml",
   "https://example.com/assets/CURRENCIES_2.toml",
-  "https://example.com/CURRENCIES_3.toml"
+  "https://anotherexample.com/CURRENCIES_3.toml"
 ]
 ```
 
-This files referenced must contain only `[[CURRENCIES]]` table entries.
+Then, within `CURRENCIES_1.toml`, you could have:
+
+```toml
+[[CURRENCIES]]
+code="USD"
+issuer="GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM"
+
+[[CURRENCIES]]
+code="BTC"
+issuer="GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U"
+
+[[CURRENCIES]]
+toml = "https://example.com/SPECIFIC_CURRENCY.toml"
+```
 
 
 ### Validator Information

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -158,7 +158,7 @@ The `stellar.toml` file may store some or all of its `CURRENCIES` in separate fi
   1. A `CURRENCIES` entry's `toml` key.
   2. A top-level `CURRENCIES_TOMLS` list of URLs.
 
-Both of these methods can be used together.
+Both of these methods can be used together. In both cases, the external files must adhere to the same size restrictions as the `stellar.toml` itself (see [above](#specification): 100 KB each.
 
 #### `CURRENCIES` `toml` Key
 `stellar.toml` can link out to a separate TOML file for each currency by specifying the URL in the `toml` key as the currency's only field.

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -153,10 +153,12 @@ Note: `fixed_number`, `max_number`, and `is_unlimited` are mutually exclusive is
 
 
 ### External Currency Specification
-There are two (compatible) ways to reference currency entries in separate files:
+The `stellar.toml` file may store some or all of its `CURRENCIES` in separate files. There are two methods to reference separate `CURRENCIES` entries:
 
-  1. The `CURRENCIES` `toml` key.
-  2. The top-level `CURRENCY_TOMLS` list.
+  1. A `CURRENCIES` entry's `toml` key.
+  2. A top-level `CURRENCIES_TOMLS` list of URLs.
+
+Both of these methods can be used together.
 
 #### `CURRENCIES` `toml` Key
 `stellar.toml` can link out to a separate TOML file for each currency by specifying the URL in the `toml` key as the currency's only field.
@@ -168,13 +170,13 @@ Example usage:
 toml = "https://example.com/SPECIFIC_CURRENCY.toml"
 ```
 
-#### `CURRENCY_TOMLS` List
-A top-level `CURRENCY_TOMLS` field may be specified as an array of URLs to TOML files that contain [currency entries](#currency-documentation). These additional fields are interpreted as if their contents exist in the `stellar.toml`. These files referenced must contain only `[[CURRENCIES]]` table entries.
+#### `CURRENCIES_TOMLS` List
+A top-level `CURRENCIES_TOMLS` field may be specified as an array of URLs to TOML files that contain [currency entries](#currency-documentation). These additional files are interpreted as if their contents exist in the `stellar.toml`. These files must only contain `[[CURRENCIES]]` table entries.
 
 Example usage:
 
 ```toml
-CURRENCY_TOMLS = [
+CURRENCIES_TOMLS = [
   "https://example.com/.well-known/CURRENCIES_1.toml",
   "https://example.com/assets/CURRENCIES_2.toml",
   "https://anotherexample.com/CURRENCIES_3.toml"

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -151,7 +151,30 @@ Replace `$PUBLIC_KEY` with the account's public key, `$CODE` with your asset cod
 
 Note: `fixed_number`, `max_number`, and `is_unlimited` are mutually exclusive issuance policies. Include exactly one of those fields.
 
-Alternately, `stellar.toml` can link out to a separate TOML file for each currency by specifying `toml="https://DOMAIN/.well-known/CURRENCY.toml"` as the currency's only field.
+
+### External Currency Specification
+There are two ways to "outsource" currency entries to external files: via the `toml` key and via the top-level `CURRENCY_TOMLS` list.
+
+#### Via the `toml` key
+`stellar.toml` can link out to a separate TOML file for each currency by specifying `toml="https://DOMAIN/.well-known/CURRENCY.toml"` as the currency's only field.
+
+#### Via the top-level list
+We also allow a top-level `CURRENCY_TOMLS` field, which must be an array of URLs to TOML files that follow the above [currency specification](#currency-documentation).
+
+Example usage:
+
+```toml
+CURRENCY_TOMLS = [
+  "https://example.com/.well-known/CURRENCIES_1.toml",
+  "https://example.com/assets/CURRENCIES_2.toml",
+  "https://example.com/CURRENCIES_3.toml"
+]
+```
+
+Then, the `https://example.com/CURRENCIES_3.toml`-like files would contain ``[[CURRENCIES]]` entries as defined above.
+
+This field must be completely compatible with having existing `[[CURRENCIES]]` table entries within the `stellar.toml` file. The externalized TOML files must **only** include `[[CURRENCIES]]` entries. All other fields should be considered invalid.
+
 
 ### Validator Information
 

--- a/ecosystem/sep-0014.md
+++ b/ecosystem/sep-0014.md
@@ -2,133 +2,60 @@
 
 ```
 SEP: 0014
-Title: Dynamic Asset Metadata
-Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>
+Title: External Asset Metadata
+Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>, George Kudrayvtsev <george@stellar.org>
 Track: Standard
 Status: Draft
 Created: 2018-09-30
-Updated: 2019-03-12
+Updated: 2022-03-03
 Discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/stellar-dev/-S7FIXJAi2A
-Version 0.2.1
+Version: 0.3.0
 ```
 
 ## Simple Summary
 
-This SEP extends [SEP-0001](../ecosystem/sep-0001.md) and adds the support of
-the dynamic asset metadata resolution. It describes a standard way to query
-asset metadata, thereby allowing the issuer to deal with an unlimited number
-of assets without defining each of them in `stellar.toml` file.
+This SEP extends [SEP-1][sep1] and adds the support of the dynamic asset
+metadata resolution. It describes a standard way to query asset metadata,
+thereby allowing the issuer to deal with an unlimited number of assets without
+defining each of them in the `stellar.toml` file.
 
 ## Motivation
 
-Current [SEP-0001](../ecosystem/sep-0001.md) specification works excellent for
-issuers that manage only a few assets. However, `stellar.toml` has a size
-limit of 100 KB, effectively reducing the maximum possible number of assets
-to ~300 per file. At present time there is no standard way for the anchor to
-provide metadata for a large number of assets issued by the same anchor.
-There are plenty of use-cases that require issuing thousands of assets:
-bonds, securities, futures, non-fungible tokens.
+The current [SEP-1][sep1] specification works excellently for issuers that
+manage only a few assets. However, `stellar.toml` has a size limit of 100 KB,
+effectively reducing the maximum possible number of assets to ~300 per file. At
+present time, there is no standard way for the anchor to provide metadata for a
+large number of assets issued by the same anchor. There are plenty of use-cases
+that require issuing thousands of assets: bonds, securities, futures,
+non-fungible tokens.
 
 ## Specification
 
-To allow dynamic asset properties resolution, the issuer implements the
-described REST API endpoint and advertises the existence of a
-Dynamic Asset Metadata Service through the `stellar.toml` file.
-Top-level parameter `ASSET_METADATA_SERVER` should contain a fully-qualified
-URL of a metadata resolution service.
+To allow assets to be stored externally, we extend [SEP-1][sep1] to introduce the `CURRENCY_TOMLS` field, which must be an array of URLs to TOML files that follow the [SEP-1 currency specification][sep1-currency].
 
-Example of `stellar.toml`:
+Example usage:
 
-```
-ASSET_METADATA_SERVER="https://anchor.com/assets"
-...
-```
-
-### Asset Metadata Resolution Flow
-
-- The client discovers the `home_domain` for the asset issuing account and
-downloads `stellar.toml`.
-- Once the file is downloaded and parsed, the client searches for the asset
-by its code in `[[CURRENCIES]]` section.
-- If the metadata for the asset was not found in `[[CURRENCIES]]` section,
-the client checks for the top-level `ASSET_METADATA_SERVER` parameter.
-- If present, the client pulls a metadata from the remote server using the URL
-defined in `ASSET_METADATA_SERVER` parameter.
-
-### API Endpoints
-
-Dynamic Asset Metadata Service exposes a single REST API endpoint.
-
-    GET <ASSET_METADATA_SERVER>
-
-This API endpoint returns the metadata for all assets issued by the anchor.
-It follows Horizon REST API format convention.
-
-**Request**
-
-Request query parameters:
-
-- **code** - Filters assets by the asset code.
-- **issuer** - Filters assets by the issuer account.
-- **cursor** - Asset code from which to continue the search (referred also as
-`paging_token` in a result set).
-- **order** - Results ordering - `"asc"`(default) or `"desc"`.
-- **limit** - Data page size. Default `10`, maximum `200`.
-
-Example:
-
-    curl https://example.com/?issuer=GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=asc&limit=2
-
-**Response**
-
-On success, the endpoint should return `200 OK` HTTP status code and
-JSON-encoded object containing the list of the issued assets' metadata.
-A response result should contain records and navigation links following
-Horizon response convention.
-
-Example:
-
-```
-{
-  "_links": {
-    "self": {
-      "href": "https://example.com/?order=asc&limit=2"
-    },
-    "prev": {
-      "href": "https://example.com/?cursor=BRL-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=desc&limit=2"
-    },
-    "next": {
-      "href": "https://example.com/?cursor=BSD-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=asc&limit=2"
-    }
-  },
-  "_embedded": {
-    "records": [
-      {
-        "code": "BRL",
-        "issuer": "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
-        "name": "Brazil Real",
-        "paging_token": "BRL-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
-      },
-      {
-        "code": "BSD",
-        "issuer": "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
-        "name": "Bahamas Dollar",
-        "paging_token": "BSD-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
-      }
-    ]
-  }
-}
+```toml
+CURRENCY_TOMLS = [
+  "https://example.com/.well-known/CURRENCIES_1.toml",
+  "https://example.com/assets/CURRENCIES_2.toml",
+  "https://example.com/CURRENCIES_3.toml"
+]
 ```
 
-####  CORS headers
+Then, the `https://example.com/CURRENCIES_3.toml` could contain:
 
-In order to comply with browser cross-origin access policies, the service
-should provide wildcard CORS response HTTP header. The following HTTP header
-must be set for both API endpoints:
+```toml
+[[CURRENCIES]]
+issuer="GAKZGD5BFXZ7P7P45WHTM6DODMOEWWJUSCAIPGYIVIPYQSVR6MM6YR7M"
+code="DEMOASSET"
+name="A nice demo currency for SEP-14"
+```
 
-```
-Access-Control-Allow-Origin: *
-```
+This new field must be completely compatible with having existing `[[CURRENCIES]]` table entries within the `stellar.toml` file. The externalized TOML files must only include `[[CURRENCIES]]` entries. All other fields must be considered invalid.
+
+Handling duplicate entries (i.e. colliding `issuer` and `code` fields) is left to the discretion of the parser.
+
 
 ## Design Rationale
 
@@ -137,9 +64,11 @@ wallets, infrastructure apps, and external services.
 
 ## Security Concerns
 
-N/A
+Asset issuers should encourage user trust by putting their `stellar.toml` and
+any externalized asset descriptions under the same domain. Placing them under
+separate domains may call into question control and integrity of the currency
+metadata therein.
 
-## Implementation
 
-Reference implementation of the Dynamic Asset Metadata Service for NodeJS can
-be found [here](https://github.com/orbitlens/stellar-dynamic-asset-metadata-server).
+[sep1]: ../ecosystem/sep-0001.md
+[sep1-currency]: ../ecosystem/sep-0001.md#currency-documentation

--- a/ecosystem/sep-0014.md
+++ b/ecosystem/sep-0014.md
@@ -2,60 +2,133 @@
 
 ```
 SEP: 0014
-Title: External Asset Metadata
-Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>, George Kudrayvtsev <george@stellar.org>
+Title: Dynamic Asset Metadata
+Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>
 Track: Standard
 Status: Draft
 Created: 2018-09-30
-Updated: 2022-03-03
+Updated: 2019-03-12
 Discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/stellar-dev/-S7FIXJAi2A
-Version: 0.3.0
+Version 0.2.1
 ```
 
 ## Simple Summary
 
-This SEP extends [SEP-1][sep1] and adds the support of the dynamic asset
-metadata resolution. It describes a standard way to query asset metadata,
-thereby allowing the issuer to deal with an unlimited number of assets without
-defining each of them in the `stellar.toml` file.
+This SEP extends [SEP-0001](../ecosystem/sep-0001.md) and adds the support of
+the dynamic asset metadata resolution. It describes a standard way to query
+asset metadata, thereby allowing the issuer to deal with an unlimited number
+of assets without defining each of them in `stellar.toml` file.
 
 ## Motivation
 
-The current [SEP-1][sep1] specification works excellently for issuers that
-manage only a few assets. However, `stellar.toml` has a size limit of 100 KB,
-effectively reducing the maximum possible number of assets to ~300 per file. At
-present time, there is no standard way for the anchor to provide metadata for a
-large number of assets issued by the same anchor. There are plenty of use-cases
-that require issuing thousands of assets: bonds, securities, futures,
-non-fungible tokens.
+Current [SEP-0001](../ecosystem/sep-0001.md) specification works excellent for
+issuers that manage only a few assets. However, `stellar.toml` has a size
+limit of 100 KB, effectively reducing the maximum possible number of assets
+to ~300 per file. At present time there is no standard way for the anchor to
+provide metadata for a large number of assets issued by the same anchor.
+There are plenty of use-cases that require issuing thousands of assets:
+bonds, securities, futures, non-fungible tokens.
 
 ## Specification
 
-To allow assets to be stored externally, we extend [SEP-1][sep1] to introduce the `CURRENCY_TOMLS` field, which must be an array of URLs to TOML files that follow the [SEP-1 currency specification][sep1-currency].
+To allow dynamic asset properties resolution, the issuer implements the
+described REST API endpoint and advertises the existence of a
+Dynamic Asset Metadata Service through the `stellar.toml` file.
+Top-level parameter `ASSET_METADATA_SERVER` should contain a fully-qualified
+URL of a metadata resolution service.
 
-Example usage:
+Example of `stellar.toml`:
 
-```toml
-CURRENCY_TOMLS = [
-  "https://example.com/.well-known/CURRENCIES_1.toml",
-  "https://example.com/assets/CURRENCIES_2.toml",
-  "https://example.com/CURRENCIES_3.toml"
-]
+```
+ASSET_METADATA_SERVER="https://anchor.com/assets"
+...
 ```
 
-Then, the `https://example.com/CURRENCIES_3.toml` could contain:
+### Asset Metadata Resolution Flow
 
-```toml
-[[CURRENCIES]]
-issuer="GAKZGD5BFXZ7P7P45WHTM6DODMOEWWJUSCAIPGYIVIPYQSVR6MM6YR7M"
-code="DEMOASSET"
-name="A nice demo currency for SEP-14"
+- The client discovers the `home_domain` for the asset issuing account and
+downloads `stellar.toml`.
+- Once the file is downloaded and parsed, the client searches for the asset
+by its code in `[[CURRENCIES]]` section.
+- If the metadata for the asset was not found in `[[CURRENCIES]]` section,
+the client checks for the top-level `ASSET_METADATA_SERVER` parameter.
+- If present, the client pulls a metadata from the remote server using the URL
+defined in `ASSET_METADATA_SERVER` parameter.
+
+### API Endpoints
+
+Dynamic Asset Metadata Service exposes a single REST API endpoint.
+
+    GET <ASSET_METADATA_SERVER>
+
+This API endpoint returns the metadata for all assets issued by the anchor.
+It follows Horizon REST API format convention.
+
+**Request**
+
+Request query parameters:
+
+- **code** - Filters assets by the asset code.
+- **issuer** - Filters assets by the issuer account.
+- **cursor** - Asset code from which to continue the search (referred also as
+`paging_token` in a result set).
+- **order** - Results ordering - `"asc"`(default) or `"desc"`.
+- **limit** - Data page size. Default `10`, maximum `200`.
+
+Example:
+
+    curl https://example.com/?issuer=GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=asc&limit=2
+
+**Response**
+
+On success, the endpoint should return `200 OK` HTTP status code and
+JSON-encoded object containing the list of the issued assets' metadata.
+A response result should contain records and navigation links following
+Horizon response convention.
+
+Example:
+
+```
+{
+  "_links": {
+    "self": {
+      "href": "https://example.com/?order=asc&limit=2"
+    },
+    "prev": {
+      "href": "https://example.com/?cursor=BRL-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=desc&limit=2"
+    },
+    "next": {
+      "href": "https://example.com/?cursor=BSD-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U&order=asc&limit=2"
+    }
+  },
+  "_embedded": {
+    "records": [
+      {
+        "code": "BRL",
+        "issuer": "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
+        "name": "Brazil Real",
+        "paging_token": "BRL-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
+      },
+      {
+        "code": "BSD",
+        "issuer": "GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
+        "name": "Bahamas Dollar",
+        "paging_token": "BSD-GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWC6L7U"
+      }
+    ]
+  }
+}
 ```
 
-This new field must be completely compatible with having existing `[[CURRENCIES]]` table entries within the `stellar.toml` file. The externalized TOML files must only include `[[CURRENCIES]]` entries. All other fields must be considered invalid.
+####  CORS headers
 
-Handling duplicate entries (i.e. colliding `issuer` and `code` fields) is left to the discretion of the parser.
+In order to comply with browser cross-origin access policies, the service
+should provide wildcard CORS response HTTP header. The following HTTP header
+must be set for both API endpoints:
 
+```
+Access-Control-Allow-Origin: *
+```
 
 ## Design Rationale
 
@@ -64,11 +137,9 @@ wallets, infrastructure apps, and external services.
 
 ## Security Concerns
 
-Asset issuers should encourage user trust by putting their `stellar.toml` and
-any externalized asset descriptions under the same domain. Placing them under
-separate domains may call into question control and integrity of the currency
-metadata therein.
+N/A
 
+## Implementation
 
-[sep1]: ../ecosystem/sep-0001.md
-[sep1-currency]: ../ecosystem/sep-0001.md#currency-documentation
+Reference implementation of the Dynamic Asset Metadata Service for NodeJS can
+be found [here](https://github.com/orbitlens/stellar-dynamic-asset-metadata-server).


### PR DESCRIPTION
This is a follow-up to the discussion on the [mailing list](https://groups.google.com/g/stellar-dev/c/-S7FIXJAi2A) to extend SEP-1 by introducing a new top-level `CURRENCY_TOMLS` array in stellar.toml which must be a list of URLs pointing to `[[CURRENCIES]]` table entries.