### PR TITLE
SEP-38: make SEP-10 token optional for some endpoints

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -32,7 +32,7 @@ An anchor must define the location of their `ANCHOR_QUOTE_SERVER` in their [`ste
 
 This protocol's endpoints use authentication in the form of a [SEP-10](sep-0010.md) JSON Web Token (JWT) in the `Authorization` header of the request.
 
-While it is mandatory for [`POST /quote`](#post-quote) and [`GET /quote/:id`](#get-quote), it is optional for the remaining endpoints. When optional, the JWT token can be used to personalize the respective responses.
+Authentication is mandatory for [`POST /quote`](#post-quote) and [`GET /quote/:id`](#get-quote), but optional for the remaining endpoints. When optional, if authentication is provided it can be used to personalize the respective responses.
 
 ```
 Authorization: Bearer <jwt>

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -30,7 +30,9 @@ An anchor must define the location of their `ANCHOR_QUOTE_SERVER` in their [`ste
 
 ### Authentication
 
-All endpoints require authentication in the form of a [SEP-10](sep-0010.md) JSON Web Token (JWT) in the `Authorization` header of the request. 
+This protocol's endpoints use authentication in the form of a [SEP-10](sep-0010.md) JSON Web Token (JWT) in the `Authorization` header of the request.
+
+While it is mandatory for [`POST /quote`](#post-quote) and [`GET /quote/:id`](#get-quote), it is optional for the remaining endpoints. When optional, the JWT token can be used to personalize the respective responses.
 
 ```
 Authorization: Bearer <jwt>

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,9 +7,9 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2021-11-08
+Updated: 2022-03-08
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.5.0
+Version 1.6.0
 ```
 
 ## Summary
@@ -460,3 +460,7 @@ GET /quote/de762cda-a193-4961-861e-57b31fed6eb3
 ```
 
 [`SEP-10`]: #authentication
+
+## Changelog
+
+* `v1.6.0`: Make [`SEP-10`] authentication token optional for the `GET /info`, `GET /price` and `GET /prices` endpoints. ([#1144](https://github.com/stellar/stellar-protocol/pull/1144))

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -115,6 +115,10 @@ iso4217:USD
 
 This endpoint describes the supported Stellar assets and off-chain assets available for trading. Note that the anchor may not support a trading pair between every Stellar asset and off-chain asset listed. Use the [`GET /prices`](#get-prices) endpoint to see which pairs are supported.
 
+#### Authentication
+
+Optional [`SEP-10`]. If authentication is provided it can be used to personalize the response.
+
 #### Request
 
 No request arguments required.
@@ -201,6 +205,10 @@ These prices are indicative. The actual price will be calculated at conversion t
 
 The prices returned include any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, delivery method, country code, or other factors.
 
+#### Authentication
+
+Optional [`SEP-10`]. If authentication is provided it can be used to personalize the response.
+
 #### Request
 
 Name | Type | Description
@@ -270,6 +278,10 @@ The client must provide either `sell_amount` or `buy_amount`, but not both.
 These prices are indicative. The actual price will be calculated at conversion time once the Anchor receives the funds from a User.
 
 The price returned includes any margin that the provider may keep as a service fee, and this margin may vary depending on the directional flow of funds, amount, delivery method, country code, or other factors.
+
+#### Authentication
+
+Optional [`SEP-10`]. If authentication is provided it can be used to personalize the response.
 
 #### Request
 
@@ -366,6 +378,10 @@ If the client requests some amount of an off-chain asset for providing some amou
 
 In the reverse scenario, the anchor will submit a Stellar transaction to deliver funds to the client as long as the client delivered off-chain funds to the anchor before the expiration. In this case, the anchor will likely increase their margin to cover the cost of submitting the transaction.
 
+#### Authentication
+
+[`SEP-10`].
+
 #### Request
 
 The client must provide either `sell_amount` or `buy_amount`, but not both. 
@@ -400,6 +416,10 @@ Name | Type | Description
 ### GET Quote
 
 This endpoint can be used to fetch a previously-provided firm quote. Quotes referenced in other protocols must be available at this endpoint past the `expires_at` expiration for the quote.
+
+#### Authentication
+
+[`SEP-10`].
 
 #### Request
 
@@ -438,3 +458,5 @@ GET /quote/de762cda-a193-4961-861e-57b31fed6eb3
   "buy_amount": "92.25"
 }
 ```
+
+[`SEP-10`]: #authentication


### PR DESCRIPTION
### What

Make SEP-10 token optional for the endpoints:
* `GET /info`
* `GET /price`
* `GET /prices`

### Why

Client applications may want to show rates from multiple liquidity providers to a user, or simply display the exchange rates of an anchor's pairs before the user has indicated they want to start a transaction.

Closes #1086.