### PR TITLE
CAP-0021 and CAP-0040 updates

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -367,24 +367,25 @@ index c870fe09a..68d10bb1d 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 1a4e491a1..131382b76 100644
+index 1a4e491a1..f8a2710e8 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -576,6 +576,58 @@ struct TimeBounds
+@@ -576,6 +576,59 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
 +struct LedgerBounds
 +{
 +    uint32 minLedger;
-+    uint32 maxLedger;
++    uint32 maxLedger; // 0 here means no maxLedger
 +};
 +
 +struct PreconditionsV2 {
 +    TimeBounds *timeBounds;
 +
-+    // Transaciton only valid for ledger numbers n such that
-+    // minLedger <= n < maxLedger
++    // Transaction only valid for ledger numbers n such that
++    // minLedger <= n < maxLedger (if maxLedger == 0, then
++    // only minLedger is checked)
 +    LedgerBounds *ledgerBounds;
 +
 +    // If NULL, only valid when sourceAccount's sequence number
@@ -429,7 +430,7 @@ index 1a4e491a1..131382b76 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -627,8 +679,8 @@ struct Transaction
+@@ -627,8 +680,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  

--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -312,15 +312,13 @@ transaction fails with `txBAD_AUTH`.
 
 ```diff mddiffcheck.base=v17.3.0
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 3895ce9a..9ef87ad7 100644
+index c870fe09a..68d10bb1d 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -12,7 +12,8 @@ typedef opaque Thresholds[4];
- typedef string string32<32>;
+@@ -13,6 +13,7 @@ typedef string string32<32>;
  typedef string string64<64>;
  typedef int64 SequenceNumber;
--typedef uint64 TimePoint;
-+typedef int64 TimePoint;
+ typedef uint64 TimePoint;
 +typedef int64 Duration;
  typedef opaque DataValue<64>;
  typedef Hash PoolID; // SHA256(LiquidityPoolParameters)
@@ -354,7 +352,7 @@ index 3895ce9a..9ef87ad7 100644
      }
      ext;
  };
-@@ -354,10 +370,10 @@ case CLAIM_PREDICATE_OR:
+@@ -368,10 +384,10 @@ case CLAIM_PREDICATE_OR:
  case CLAIM_PREDICATE_NOT:
      ClaimPredicate* notPredicate;
  case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
@@ -369,10 +367,10 @@ index 3895ce9a..9ef87ad7 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index d97b0cb3..789e0ba4 100644
+index 1a4e491a1..131382b76 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -532,6 +532,58 @@ struct TimeBounds
+@@ -576,6 +576,58 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -431,7 +429,7 @@ index d97b0cb3..789e0ba4 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -583,8 +635,8 @@ struct Transaction
+@@ -627,8 +679,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  
@@ -443,7 +441,7 @@ index d97b0cb3..789e0ba4 100644
      Memo memo;
  
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c20..caa41d7f 100644
+index 8f7d5c206..caa41d7f1 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -14,6 +14,14 @@ typedef int int32;
@@ -781,8 +779,7 @@ Previously signed transactions containing time points greater than
 the number 0 already represents no time bounds, this is unlikely to
 cause problems in practice.
 
-Transactions with extreme `TimePoint` values notwithstanding, the
-binary XDR of any other previously valid transactions will unmarshal
+The binary XDR of any other previously valid transactions will unmarshal
 to a valid transaction under the current proposal.  Obviously legacy
 software will not be able to parse transactions with the new
 preconditions, however.

--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -161,6 +161,11 @@ Ed25519 signed payload signer signatures are verified by performing ed25519
 signature verification using the signature, the payload from the signer, and the
 ed25519 public key from the signer.
 
+#### SetOptionsOp
+
+`SetOptionsOp` will fail validation with `SET_OPTIONS_BAD_SIGNER` if the new
+signed payload signer is used prior to the protocol upgrade.
+
 ## Design Rationale
 
 This proposal provides a primitive that makes it possible to construct a set


### PR DESCRIPTION
This PR makes three changes - 
1. Specifies a failure case when the CAP-0040 signer is used prior to the protocol upgrade.
2. Removes the `TimePoint` change because this is what was agreed upon in the protocol meeting (link to the [Discord](https://discord.com/channels/897514728459468821/946566916783357972/953389257739878421) discussion with more context).
3. Update the `maxLedger == 0` scenario to disable the `maxLedger` check (link to [Discord](https://discord.com/channels/897514728459468821/946566916783357972/951637761767657492) discussion with more context).