### PR TITLE
SEP-6: add firm quote withdrawal mermaid diagram

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2021-10-22
-Version 3.10.0
+Updated: 2022-03-16
+Version 3.10.1
 ```
 
 ## Simple Summary
@@ -29,6 +29,73 @@ This proposal defines a standard protocol enabling the following features direct
 * View history of deposits and withdrawals involving the user
 
 To support this protocol an anchor acts as a server and implements the specified REST API endpoints, while a wallet implements a client that consumes the API. The goal is interoperability, so a wallet implements a single client according to the protocol, and will be able to interact with any compliant anchor. Similarly, an anchor that implements the API endpoints according to the protocol will work with any compliant wallet.
+
+## Diagrams
+
+The diagrams provided offer a detailed view of various flows that are possible using this protocol. Note that these diagrams are opinionated. Variations of the these flows may also be sufficient.
+
+### Completing a Withdrawal Transaction with a Firm Quote
+
+This diagram demonstrates the interactions between the entities involved in a successful transaction. Specifically it uses the [Asset Conversions Using a Firm Quote](#asset-conversions-using-a-firm-quote) strategy.
+
+```mermaid
+sequenceDiagram 
+    participant User
+    participant Wallet
+    participant Stellar
+    participant Anchor
+    User->>Wallet: initiates withdrawal to <br> User's country
+    Wallet-->>Wallet: maps country to Anchor
+
+    Wallet->>+Anchor: GET /.well-known/stellar.toml
+    Anchor-->>-Wallet: SEP-10, 12, 6, & 38 URLs
+    Wallet->>+Anchor: GET [SEP-6]/info
+    Anchor-->>-Wallet: Stellar assets, customer types, fees
+    Wallet->>+Anchor: GET [SEP-38]/prices
+    Anchor-->>-Wallet: pairs and est. rates for Stellar asset
+
+    Wallet->>+User: provides pair <br> est. rates & fees
+    User-->>-Wallet: selects asset pair
+
+    Wallet->>+Anchor: GET [SEP-10]
+    Anchor-->>-Wallet: challenge transaction
+    Wallet-->>Wallet: signs challenge
+    Wallet->>+Anchor: POST [SEP-10]
+    Anchor-->>Anchor: verifies challenge
+    Anchor-->>-Wallet: authentication token
+
+    
+    note right of Wallet: If User has already <br> been accepted, <br> KYC is unnecessary.
+    Wallet->>+Anchor: GET [SEP-12]/customer?type=
+    Anchor-->>-Wallet: fields required
+    Wallet->>+User: requests fields
+    User-->>-Wallet: provides field values
+    Wallet->>+Anchor: PUT [SEP-12]/customer?type=
+    Anchor-->>Anchor: validates KYC values
+    Anchor-->>-Wallet: id, ACCEPTED
+
+    Wallet->>+Anchor: GET [SEP-38]/price
+    Anchor-->>-Wallet: exchange rate
+    Wallet->>+User: provides estimated rate
+    User-->>-Wallet: continues
+    Wallet->>+Anchor: POST [SEP-38]/quote
+    Anchor-->>Wallet: quote id, rate, expiration
+    
+    Wallet->>+Anchor: GEt [SEP-6]/withdraw
+    Anchor-->>Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
+    Anchor-->>-Wallet: transaction id, receiving account & memo
+
+    Wallet->>+Stellar: submit Stellar payment
+    Stellar->>+Anchor: receives payment, matches w/ transaction
+    Anchor-->>Anchor: updates transaction status
+    Stellar-->>-Wallet: success response
+
+    Anchor->>User: Sends off-chain payment to user
+    Anchor-->>Anchor: updates transaction to complete
+    Wallet->>+Anchor: GET /transactions?id=
+    Anchor-->>-Wallet: transaction complete
+    Wallet->>User: notifies User
+```
 
 ## Prerequisites
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -81,7 +81,7 @@ sequenceDiagram
     Wallet->>+Anchor: POST [SEP-38]/quote
     Anchor-->>Wallet: quote id, rate, expiration
     
-    Wallet->>+Anchor: GEt [SEP-6]/withdraw
+    Wallet->>+Anchor: GET [SEP-6]/withdraw
     Anchor-->>Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
     Anchor-->>-Wallet: transaction id, receiving account & memo
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -86,9 +86,9 @@ sequenceDiagram
     Anchor-->>-Wallet: transaction id, receiving account & memo
 
     Wallet->>+Stellar: submit Stellar payment
+    Stellar-->>-Wallet: success response
     Stellar->>+Anchor: receives payment, matches w/ transaction
     Anchor-->>Anchor: updates transaction status
-    Stellar-->>-Wallet: success response
 
     Anchor->>User: Sends off-chain payment to user
     Anchor-->>Anchor: updates transaction to complete

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1354,4 +1354,5 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.10.1`: Add firm quote withdrawal sequence diagram. ([#1147](https://github.com/stellar/stellar-protocol/pull/1147))
 * `v3.10.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))


### PR DESCRIPTION
Adds a sequence diagram to the SEP-6 protocol documenting a withdrawal flow, specifically for using SEP-38 firm quotes.

This flow is very similar to the SEP-31 diagram added in #1145.