### PR TITLE
SEP-38: Add note about expires_at and expires_after and their relationship

### DIFF
--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -9,7 +9,7 @@ Status: Draft
 Created: 2021-04-09
 Updated: 2022-03-08
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
-Version 1.6.0
+Version 1.6.1
 ```
 
 ## Summary
@@ -394,7 +394,7 @@ Name | Type | Description
 `buy_asset` | string | Same as the definition of `buy_asset` in `GET /price`.
 `sell_amount` | string | Same as the definition of `sell_amount` in `GET /price`.
 `buy_amount` | string | The same definition of `buy_amount` in `GET /price`.
-`expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
+`expire_after` | [UTC ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string | (optional) The client's desired `expires_at` date and time for the quote. Anchors may choose an `expires_at` that occurs after the `expire_after`. Anchors should return `400 Bad Request` if the an expiration on or after the requested value cannot be provided.
 `sell_delivery_method` | string | (optional) One of the `name` values specified by the `sell_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user is delivering an off-chain asset to the anchor unless no more than one method is specified in the `GET /info` response.
 `buy_delivery_method` | string | (optional) One of the `name` values specified by the `buy_delivery_methods` array for the associated asset returned from [`GET /info`](#info). Must be provided if the user intends to receive an off-chain asset from the anchor unless no more than one method is specified in the `GET /info` response.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. Should be provided if there are two or more country codes available for the desired asset in [`GET /info`](#get-info).
@@ -463,4 +463,5 @@ GET /quote/de762cda-a193-4961-861e-57b31fed6eb3
 
 ## Changelog
 
+* `v1.6.1`: Add note about `expires_at` and `expires_after` and their relationship. ([#1147](https://github.com/stellar/stellar-protocol/pull/1147))
 * `v1.6.0`: Make [`SEP-10`] authentication token optional for the `GET /info`, `GET /price` and `GET /prices` endpoints. ([#1144](https://github.com/stellar/stellar-protocol/pull/1144))

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -7,7 +7,7 @@ Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
 Status: Draft
 Created: 2021-04-09
-Updated: 2022-03-08
+Updated: 2022-03-16
 Discussion: https://github.com/stellar/stellar-protocol/issues/901
 Version 1.6.1
 ```


### PR DESCRIPTION
### What
Add note to SEP-38 about the `expires_at` and `expire_after` fields and their relationship, and how `expires_at` can occur after `expire_after`.

### Why
This is pre-existing behavior and intent, but on reading the table it wasn't completely obvious to me that was the intent. Adding this additional note might help prevent someone else from missing this.