### PR TITLE
Add on-stellar asset for receiving client.

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -700,6 +700,6 @@ If the information was malformed, or if the sender tried to update data that isn
 ```
 
 ## Changelog
-
+* `v1.5.2`: Add a use case when the receiving client may receive on-stellar asset. ([#1149](https://github.com/stellar/stellar-protocol/pull/1149))
 * `v1.5.1`: Add a sequence diagram for successful transactions using firm quotes. ([#1145](https://github.com/stellar/stellar-protocol/pull/1145))
 * `v1.5.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-03-08
-Version 1.5.1
+Updated: 2022-03-16
+Version 1.5.2
 ```
 
 ## Simple Summary
@@ -28,7 +28,7 @@ At a high level, the following steps are performed to complete a transaction:
 
 1. The Sending Client sends funds from their financial account to the Sending Anchor's financial account (off/on-Stellar)
 2. The Sending Anchor sends the funds to the Receiving Anchor's Stellar account (on-Stellar)
-3. The Receiving Anchor sends funds to the Receiving Client's financial account (off-Stellar)
+3. The Receiving Anchor sends funds to the Receiving Client's financial account (off/on-Stellar)
 
 Typically, the Sending and Receiving Clients reside in different regulatory jurisdictions and therefore a payment between their financial accounts must be facilitated by two business entities, the Sending and Receiving Anchors, who have the necessary licenses in their respective jurisdictions.
 


### PR DESCRIPTION
In the following scenario, the receiving client may receive on-stellar asset. 

Sending client --off-stellar --> Sending Anchor
Sending Anchor --on-stellar --> Receiving Anchor
Receiving Anchor--on-stellar --> Receiving Client

In this use case, the sending customer does not have a Stellar account and Receiving Client has a Stellar account. We should add on-stellar asset to the receiving client. 