### PR TITLE
CAP-21: Add a note in security concerns about the presence of free-options in multi-party protocols

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -845,6 +845,16 @@ Fortunately, it appears that in most useful protocols time-delayed
 non-NULL `minSeqNum` are "disclosure" transactions intended to be
 valid at any time.
 
+The design rationale includes several multi-party protocols that
+require all parties to sign a transaction for it to be valid.
+This section does not discuss all possible security concerns with
+these protocols. It is at least worth noting that like most
+multi-party protocols there exists a period of time where a
+free-option may exist, where one party has authorized a transaction
+and another party can wait some period of time to decide if they
+also will authorize it, or fallback to some previously valid
+transaction.
+
 ## Test Cases
 
 None yet.


### PR DESCRIPTION
### What
Add a note in security concerns of CAP-21 about the presence of free-options in multi-party protocols.

### Why
@jonjove highlighted the presence of a free-option in the protocols defined in the design rationale. This is not unique to these protocols, not unique to CAP-21, and not unique to Stellar, and plagues many multi-party protocols, especially payment channel protocols.

I was on the fence if we should even mention it, since it is not really a security concern of CAP-21 itself, and more an educational warning of something to keep in mind when building the types of protocols that CAP-21 makes more possible. To be clear too this problem can arise with protocols that do not use any of CAP-21's features. However, the problem's relevance to the topic and design rationale feels too intense to ignore.

There are probably other security concerns that protocol authors will need to address or consider, as is evident by the long list of security concerns in the [Starlight documentation](https://github.com/stellar/starlight/blob/main/specifications/starlight-payment-channel-mechanics.md#security-concerns).

Related to https://github.com/stellar/starlight/pull/444