### PR TITLE
CAP-0021: Minor fixes

### DIFF
--- a/core/cap-0021.md
+++ b/core/cap-0021.md
@@ -146,16 +146,16 @@ struct LedgerBounds {
 struct PreconditionsV2 {
     TimeBounds *timeBounds;
 
-    // Transaciton only valid for ledger numbers n such that
-    // minLedger <= n < maxLedger
+    // Transaction only valid for ledger numbers n such that
+    // minLedger <= n < maxLedger (if maxLedger == 0, then
+    // only minLedger is checked)
     LedgerBounds *ledgerBounds;
 
     // If NULL, only valid when sourceAccount's sequence number
     // is seqNum - 1.  Otherwise, valid when sourceAccount's
     // sequence number n satisfies minSeqNum <= n < tx.seqNum.
     // Note that after execution the account's sequence number
-    // is always raised to tx.seqNum, and a transaction is not
-    // valid if tx.seqNum is too high to ensure replay protection.
+    // is always raised to tx.seqNum.
     SequenceNumber *minSeqNum;
 
     // For the transaction to be valid, the current ledger time must
@@ -305,14 +305,14 @@ exceeded--then the transaction is rejected with
 unsatisfied preconditions are based on values that could later be
 valid, then the transaction is rejected with `txTOO_EARLY`.  If
 neither of the above conditions holds (`txTOO_EARLY` and `txTOO_LATE`
-do not apply), but on of the `extraSigners` is unsatisfied, then the
+do not apply), but one of the `extraSigners` is unsatisfied, then the
 transaction fails with `txBAD_AUTH`.
 
 ### XDR diff
 
 ```diff mddiffcheck.base=v17.3.0
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index c870fe09a..68d10bb1d 100644
+index 3895ce9a..9b9a61cf 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
 @@ -13,6 +13,7 @@ typedef string string32<32>;
@@ -352,7 +352,7 @@ index c870fe09a..68d10bb1d 100644
      }
      ext;
  };
-@@ -368,10 +384,10 @@ case CLAIM_PREDICATE_OR:
+@@ -354,10 +370,10 @@ case CLAIM_PREDICATE_OR:
  case CLAIM_PREDICATE_NOT:
      ClaimPredicate* notPredicate;
  case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
@@ -367,10 +367,10 @@ index c870fe09a..68d10bb1d 100644
  
  enum ClaimantType
 diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
-index 1a4e491a1..f8a2710e8 100644
+index d97b0cb3..f67a0c55 100644
 --- a/src/xdr/Stellar-transaction.x
 +++ b/src/xdr/Stellar-transaction.x
-@@ -576,6 +576,59 @@ struct TimeBounds
+@@ -532,6 +532,58 @@ struct TimeBounds
      TimePoint maxTime; // 0 here means no maxTime
  };
  
@@ -392,8 +392,7 @@ index 1a4e491a1..f8a2710e8 100644
 +    // is seqNum - 1.  Otherwise, valid when sourceAccount's
 +    // sequence number n satisfies minSeqNum <= n < tx.seqNum.
 +    // Note that after execution the account's sequence number
-+    // is always raised to tx.seqNum, and a transaction is not
-+    // valid if tx.seqNum is too high to ensure replay protection.
++    // is always raised to tx.seqNum.
 +    SequenceNumber *minSeqNum;
 +
 +    // For the transaction to be valid, the current ledger time must
@@ -430,7 +429,7 @@ index 1a4e491a1..f8a2710e8 100644
  // maximum number of operations per transaction
  const MAX_OPS_PER_TX = 100;
  
-@@ -627,8 +680,8 @@ struct Transaction
+@@ -583,8 +635,8 @@ struct Transaction
      // sequence number to consume in the account
      SequenceNumber seqNum;
  
@@ -442,7 +441,7 @@ index 1a4e491a1..f8a2710e8 100644
      Memo memo;
  
 diff --git a/src/xdr/Stellar-types.x b/src/xdr/Stellar-types.x
-index 8f7d5c206..caa41d7f1 100644
+index 8f7d5c20..caa41d7f 100644
 --- a/src/xdr/Stellar-types.x
 +++ b/src/xdr/Stellar-types.x
 @@ -14,6 +14,14 @@ typedef int int32;


### PR DESCRIPTION
This fixes a few typos in CAP-0021, fixes a comment that was out-of-sync between diff and text, and corrects an error about replay protection.