### PR TITLE
CAP-40: Add rationale for how hint is derived

### DIFF
--- a/core/cap-0040.md
+++ b/core/cap-0040.md
@@ -194,6 +194,16 @@ more than the maximum number of `extraSigners` specified in [CAP-21], currently
 two, and can be increased past three if the maximum size of `extraSigners` is
 changed.
 
+The hint is specified as an XOR of the last 4 bytes of all elements of the
+signer – the ed25519 public key and the payload – so as to reduce the number of
+decorated signatures validators must verify in full. If the hint for the signed
+payload used only the ed25519 public key as input, like an ed25519 signer does,
+a transaction that requires signatures by an ed25519 key for a signed payload
+signer and an ed25519 signer would have two decorated signatures with the same
+hint. Validators would be required to compare the full signature twice for both
+signers, rather than once if the hint allows for pruning signers of the
+different type.
+
 ### Payment Channels
 
 In the payment channel designs specified in [CAP-21] this proposal simplifies


### PR DESCRIPTION
### What
Add design rationale paragraph about how hint is derived for the signed payload signer.

### Why
@Shaptic pointed out that this isn't explained in the document, but there was specific intent to the hints design.