### PR TITLE
Change SpeedexSolutionComparisonHeuristic to squared l2 norm

### DIFF
--- a/core/cap-0044.md
+++ b/core/cap-0044.md
@@ -60,7 +60,7 @@ index c870fe09..cb91c48d 100644
  
 +enum SpeedexSolutionComparisonHeuristic
 +{
-+    PRICE_WEIGHTED_L2_NORM = 0
++    PRICE_WEIGHTED_SQUARED_L2_NORM = 0
 +};
 +
 +struct SpeedexSolverConfiguration


### PR DESCRIPTION
Discussed with @jonjove earlier as part of CAP-45 refinement (https://github.com/stellar/stellar-protocol/pull/1152), the objective function we will be using is the squared l2 norm of the priced weighted demand, instead of the l2 norm. 