### PR TITLE
SEP31: clarify `sender_id` and `receiver_id` request attributes

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-03-16
-Version 1.5.2
+Updated: 2022-03-31
+Version 1.5.3
 ```
 
 ## Simple Summary
@@ -427,8 +427,8 @@ Name | Type | Description
 `asset_issuer` | string | (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
 `destination_asset` | string | (optional) The off-chain asset the Receiving Anchor will deliver to the Receiving Client. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?sell_asset=stellar:<asset_code>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). If neither this field nor `quote_id` are set, it's assumed that [Sending Anchor Asset Conversions](#sending-anchor-asset-conversion) was used.
 `quote_id` | string | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this attribute is specified, the values for the fields defined above must match the values associated with the quote. 
-`sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Only required if the `GET /info` response's `sep12.sender.types` object is non-empty.
-`receiver_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Receiving Client. Only required if the `GET /info` response's `sep12.receiver.types` object is non-empty. 
+`sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Required if the Receiving Anchor requires SEP-12 KYC on the Sending Client.
+`receiver_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Receiving Client. Required if the Receiving Anchor requires SEP-12 KYC on the Receiving Client.
 `fields` | object | An object containing the values requested by the Receiving Anchor in the `GET /info` endpoint.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human-readable error codes or field descriptions will be returned in this language.
 
@@ -700,6 +700,7 @@ If the information was malformed, or if the sender tried to update data that isn
 ```
 
 ## Changelog
+* `v1.5.3`: Clarify when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. ([#]())
 * `v1.5.2`: Add a use case when the receiving client may receive on-stellar asset. ([#1149](https://github.com/stellar/stellar-protocol/pull/1149))
 * `v1.5.1`: Add a sequence diagram for successful transactions using firm quotes. ([#1145](https://github.com/stellar/stellar-protocol/pull/1145))
 * `v1.5.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -700,7 +700,7 @@ If the information was malformed, or if the sender tried to update data that isn
 ```
 
 ## Changelog
-* `v1.5.3`: Clarify when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. ([#]())
+* `v1.5.3`: Clarify when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. ([#1158](https://github.com/stellar/stellar-protocol/pull/1158))
 * `v1.5.2`: Add a use case when the receiving client may receive on-stellar asset. ([#1149](https://github.com/stellar/stellar-protocol/pull/1149))
 * `v1.5.1`: Add a sequence diagram for successful transactions using firm quotes. ([#1145](https://github.com/stellar/stellar-protocol/pull/1145))
 * `v1.5.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))


### PR DESCRIPTION
Clarifies when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. 

Instead of referencing the body of `GET /info` responses, states that these parameters are be required if KYC is required.