### PR TITLE
GHA fix: Install `mddiffcheck` outside of a module context

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -15,5 +15,5 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.16
-    - run: go get github.com/stellar/mddiffcheck
+    - run: go install github.com/stellar/mddiffcheck@latest
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md


### PR DESCRIPTION
Note the tiny delta in whitespace relative to #1160:

```diff
-    - run: go install github.com/stellar/mddiffcheck @latest
+    - run: go install github.com/stellar/mddiffcheck@latest
```

This also aligns with `mddiffcheck`'s installation instructions, [here](https://github.com/stellar/mddiffcheck#usage).