### PR TITLE
Update and clarify PATCH /transactions description

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-03-31
-Version 1.5.4
+Updated: 2022-04-04
+Version 1.5.5
 ```
 
 ## Simple Summary
@@ -685,7 +685,7 @@ PATCH DIRECT_PAYMENT_SERVER/transactions/82fhs729f63dh0v4
 
 #### Success 200 OK
 
-If the information was successfully updated, respond with a 200 status code, and return a response body matching `GET /transactions/:id`. The transaction should return to `pending_receiver`, though it is possible that the information could still need to be updated again.
+If the information was successfully updated and all fields required for the transaction are patched, respond with a 200 status code, and return a response body matching `GET /transactions/:id`. The transaction should return to `pending_receiver`, though it is possible that the information could still need to be updated again.
 
 #### Not Found 404
 
@@ -702,6 +702,7 @@ If the information was malformed, or if the sender tried to update data that isn
 ```
 
 ## Changelog
+* `v1.5.5`: Updated the description of `PATCH /transactions`. ([#1166](https://github.com/stellar/stellar-protocol/pull/1166))
 * `v1.5.4`: Add the state diagram of a SEP-31 transaction.  ([#1164](https://github.com/stellar/stellar-protocol/pull/1164))
 * `v1.5.3`: Clarify when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. ([#1158](https://github.com/stellar/stellar-protocol/pull/1158))
 * `v1.5.2`: Add a use case when the receiving client may receive on-stellar asset. ([#1149](https://github.com/stellar/stellar-protocol/pull/1149))


### PR DESCRIPTION
The current description `The transaction should return to pending_receiver, though it is possible that the information could still need to be updated again.` implies all fields required by the transaction must be updated. 

It is less confusing to make that explicit.