### PR TITLE
SEP-10: Fix typo in challenge & token uri example

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -81,7 +81,7 @@ The flow achieves several things:
 
 ## Authentication Endpoint
 
-The organization with a **Home Domain** indicates that it supports authentication via this protocol by specifying `WEB_AUTH_ENDPOINT` in their [`stellar.toml`](sep-0001.md) file. This is how a wallet knows where to find the **Server**. A **Server** is required to implement the following behavior for the web authentication endpoint:
+The organization with a **Home Domain** indicates that it supports authentication via this protocol by specifying `WEB_AUTH_ENDPOINT` in their [`stellar.toml`](sep-0001.md) file. Ideally wallets take the `WEB_AUTH_ENDPOINT` and use it without making any alterations. This is how a wallet knows where to find the **Server**. A **Server** is required to implement the following behavior for the web authentication endpoint:
 
 * [`GET <WEB_AUTH_ENDPOINT>`](#challenge): request a challenge (step 1)
 * [`POST <WEB_AUTH_ENDPOINT>`](#token): exchange a signed challenge for session JWT (step 2)

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -115,10 +115,12 @@ Name      | Type          | Description
 `home_domain` | string | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.
 `client_domain` | string | (optional) a **Client Domain**. Supplied by **Clients** that intend to verify their domain in addition to the **Client Account**. See [Verifying the Client Domain](#verifying-the-client-domain). **Servers** should ignore this parameter if the **Server** does not support **Client Domain** verification, or the **Server** does not support verification for the specific **Client Domain** included in the request.
 
+
+
 Example:
 
 ```
-GET https://auth.example.com/?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
+GET https://auth.example.com?account=GCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDITBK2LCVBYW7HUQ
 ```
 
 #### Response
@@ -232,7 +234,7 @@ Name          | Type   | Description
 Example:
 
 ```
-POST https://auth.example.com/
+POST https://auth.example.com
 Content-Type: application/json
 
 {"transaction": "AAAAAgAAAADIiRu2BrqqeOcP28PWCkD4D5Rjjsqh71HwvqFX+F4VXAAAAGQAAAAAAAAAAAAAAAEAAAAAXzrUcQAAAABfOtf1AAAAAAAAAAEAAAABAAAAAEEB8rhqNa70RYjaNnF1ARE2CbL50iR9HPXST/fImJN1AAAACgAAADB0aGlzaXNhdGVzdC5zYW5kYm94LmFuY2hvci5hbmNob3Jkb21haW4uY29tIGF1dGgAAAABAAAAQGdGOFlIQm1zaGpEWEY0L0VJUFZucGVlRkxVTDY2V0tKMVBPYXZuUVVBNjBoL09XaC91M2Vvdk54WFJtSTAvQ2UAAAAAAAAAAvheFVwAAABAheKE1HjGnUCNwPbX8mz7CqotShKbA+xM2Hbjl6X0TBpEprVOUVjA6lqMJ1j62vrxn1mF3eJzsLa9s9hRofG3AsiYk3UAAABArIrkvqmA0V9lIZcVyCUdja6CiwkPwsV8BfI4CZOyR1Oq7ysvNJWwY0G42dpxN9OP1qz4dum8apG2hqvxVWjkDQ=="}

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -115,8 +115,6 @@ Name      | Type          | Description
 `home_domain` | string | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.
 `client_domain` | string | (optional) a **Client Domain**. Supplied by **Clients** that intend to verify their domain in addition to the **Client Account**. See [Verifying the Client Domain](#verifying-the-client-domain). **Servers** should ignore this parameter if the **Server** does not support **Client Domain** verification, or the **Server** does not support verification for the specific **Client Domain** included in the request.
 
-
-
 Example:
 
 ```


### PR DESCRIPTION
Removed the extra slashes " / " since <WEB_AUTH_ENDPOINT> shouldn't have them or may not and we ran into an integration problem due to misinterpretation
Thanks!