### PR TITLE
Updated CAP 42 with refined candiate value comparator and some clarification

### DIFF
--- a/core/cap-0042.md
+++ b/core/cap-0042.md
@@ -187,7 +187,7 @@ A `v1TxSet` is validated using the following rules:
   * fee bids for any transaction satisfy the "minimum fee requirement", ie, its fee bid is greater or equal to the minimum fee derived from `ledgerHeader.baseFee`
   * `TXSET_COMP_TXS_DISCOUNTED_FEE`
     * `baseFee >= ledgerHeader.baseFee` (a corollary from the global minimum fee bid requirement).
-    * each transaction in this component has a fee bid greater than or equal to the minimum feee bid derived from `baseFee`
+    * each transaction in this component has a fee bid greater than or equal to the minimum fee bid derived from `baseFee` (for a regular transaction that would translate to `baseFee * numberOfTransactionOperations <= bidFee`)
 
 #### Effective fee computation
 
@@ -212,7 +212,8 @@ The order used by the nomination protocol's combine candidate function needs to 
 
 Values are sorted in lexicographic order by:
 * number of operations (as to favor network throughput) _unchanged_,
-* sum of all fee bids (as to maximize quality of transaction sets) _was total fee to collect_,
+* sum of all fee bids (as to maximize quality of transaction sets) _new_,
+* total fee to collect (as to make sure that bids are actually meaningful; without this sets with constant minimal base fees ignoring any surge pricng could be preferred) _unchanged_,
 * size in bytes of the XDR encoded `GeneralizedTransactionSet` _in decreasing order_ (as to reduce IO resource utilization) _new_,
 * hash as a tie-breaker _unchanged_
 
@@ -258,6 +259,10 @@ The exact strategy for picking the starting bid and increasing transaction bid i
 A possible approach for picking a good starting bid can be to use the fee stats endpoint, adjust it if rejected by core's tx endpoint (that rejects transactions based on fee bid and its local transaction queue state), and after that multiply its fee bid by 10 or 100 after each timeout.
 
 As transaction sets are transmitted over the network, the overlay network will have to be updated to support the new format.
+
+#### Surge pricing behavior change
+
+While this CAP doesn't define the candidate transaction set generation strategy, the initial approach would be to just continue using surge pricing approach described in [CAP-0005](cap-0005.md). However, using it requires slightly changing the algorithm: instead of rounding up during the [base fee computation](cap-0005.md#computation-of-the-associated-effective-base-fee) we need to round it down. The reason for doing that is to satisfy the `baseFee` validation requirement of `TXSET_COMP_TXS_DISCOUNTED_FEE` component. With rounding up it's possible to have a valid transaction that doesn't satisfy that requirement. The impact of this change should be minimal.
 
 ### Resource Utilization
 


### PR DESCRIPTION
The updates include:

* Refined candidate value comparison to break total bid ties
* Example of `baseFee` role
* Clarification of the slight surge pricing algorithm change