### PR TITLE
SEP-24: Change `completed_at` field to optional

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2021-12-01
-Version 2.2.0
+Updated: 2022-05-03
+Version 2.2.1
 ```
 
 ## Simple Summary
@@ -689,7 +689,7 @@ Name | Type | Description
 `amount_fee` | string | Amount of fee charged by anchor.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
-`completed_at` | UTC ISO 8601 string | Completion date and time of transaction.  Assigned null for in-progress transactions.
+`completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
@@ -935,5 +935,5 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * Solar wallet: https://solarwallet.io
 
 ## Changelog
-
+* `v2.2.1`: Make `completed_at` field optional. ([#1185](https://github.com/stellar/stellar-protocol/pull/1185))
 * `v2.2.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))


### PR DESCRIPTION
Closes #1184 
`completed_at` was defined as Optional fields in [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#transaction-history) and [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#get-transaction). However, the field is defined as Assigned null for in-progress transactions. in [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#shared-fields-for-both-deposits-and-withdrawals).

Suggest to make the field consistent among all protocols.