### PR TITLE
SEP-6 + SEP-31: clarify that before sending the payment, the sending party should make a GET request to retrieve the expected `amount_in`

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -105,8 +105,8 @@ sequenceDiagram
 
 ## API Endpoints
 
-* [`GET /deposit`](#deposit): required
-* [`GET /withdraw`](#withdraw): required
+* [`GET /deposit`](#deposit-2): required
+* [`GET /withdraw`](#withdraw-2): required
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
@@ -362,7 +362,7 @@ The Anchor can add this minimal funding amount to the service fee, but this requ
 
 Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account in Stellar to complete the deposit.
 
-If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
+If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit-2) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
 #### Stellar account doesn't trust asset
 
@@ -562,7 +562,7 @@ GET https://api.example.com/deposit-exchange?destination_asset=USDC&source_asset
 
 ### Response
 
-The expected response as well as the special cases are the same ones covered in the [Deposit](#deposit) section.
+The expected response as well as the special cases are the same ones covered in the [Deposit](#deposit-2) section.
 
 ## Withdraw Exchange
 
@@ -608,7 +608,7 @@ GET https://api.example.com/withdraw-exchange?source_asset=USDC&destination_asse
 
 ### Response
 
-The expected response as well as the special cases are the same ones covered in the [Withdraw](#withdraw) section.
+The expected response as well as the special cases are the same ones covered in the [Withdraw](#withdraw-2) section.
 
 ## Deposit and Withdraw shared responses
 
@@ -1252,8 +1252,8 @@ Request parameters:
 Name | Type | Description
 -----|------|------------
 `id` | string | (optional) The id of the transaction.
-`stellar_transaction_id` | (optional) string | The stellar transaction id of the transaction.
-`external_transaction_id` | (optional) string | The external transaction id of the transaction.
+`stellar_transaction_id` | string | (optional) The stellar transaction id of the transaction.
+`external_transaction_id` | string | (optional) The external transaction id of the transaction.
 
 One of `id`, `stellar_transaction_id` or `external_transaction_id` is required.
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2022-03-16
-Version 3.10.1
+Updated: 2022-04-13
+Version 3.11.0
 ```
 
 ## Simple Summary
@@ -84,6 +84,10 @@ sequenceDiagram
     Wallet->>+Anchor: GET [SEP-6]/withdraw
     Anchor-->>Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
     Anchor-->>-Wallet: transaction id, receiving account & memo
+
+    Wallet->>+Anchor: GET [SEP-6]/transaction?id=
+    Anchor-->>-Wallet: transaction object containing amount_in
+    note right of Wallet: Use the info amount_in returned <br> from GET [SEP-6]/transaction?id={id} <br> to make the stellar payment.
 
     Wallet->>+Stellar: submit Stellar payment
     Stellar-->>-Wallet: success response
@@ -225,6 +229,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 * **Make a request to `/deposit` or `/withdraw`.**
     * As a conservative measure, pass in any optional fields (including amount) that the wallet has on-hand, such as `email_address` and `account`.
     * In the `/withdraw` request, have the user enter the crypto account or bank account where they'd like their withdrawal to end up and provide that to the anchor via `dest` and `dest_extra`.
+    * Before making the payment, make a request to `[SEP-6]/transaction?id=<transaction_id>` to get the amount_in details. Although unusual and not recommended, some anchors may use additive fees, which would produce an `amount_in` different from the wallet's proposed amount.
 * **For `/deposit`**
     * If the issuer's `/deposit` endpoint immediately returns success:
         * display the deposit info that came back from the endpoint to the user, including fee. You're done! The user will execute the deposit exernally using the instructions if they want to.
@@ -403,7 +408,7 @@ Using this feature, anchors will no longer have to wait until the user's Stellar
 
 1. Make a request to `/deposit` and provide the `claimable_balance_supported=true` request parameter.
 2. Register the user's KYC information with the anchor via [SEP-12](sep-0012.md) if requested and resubmit the deposit request.
-3. Once a successful deposit request has been made and the transaction's status is `pending_user_transfer_start`, the user must send the required payment as described by the `how` attribute in the deposit success response.
+3. Once a successful deposit request has been made and the transaction's status is `pending_user_transfer_start`, the user must send the required payment as described by the `how` attribute in the deposit success response, using the `amount_in` returned from the `GET [SEP-6]/transaction?id=<transaction_id>` request.
 4. If the anchor doesn't support claimable balances, the anchor's `/transaction(s)` endpoint will contain the `pending_trust` status. In this case, use the flow described [above](#stellar-account-doesnt-trust-asset).
 5. Otherwise, detect the `claimable_balance_id` value populated in the anchor's `/transaction(s)` endpoint or poll Horizon's [/claimable_balances](https://developers.stellar.org/api/resources/claimablebalances/) endpoint for outstanding claimable balances. When a claimable balance is detected using either method, the transaction status should be `completed`.
 6. Claim the balance using the value via the `ClaimClaimableBalance` operation. See the ["Claiming Claimable Balances"](#claiming-claimable-balances) section to learn more about how to claim a balance.
@@ -1354,5 +1359,6 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.11.0`: Update instructions to enforce the Wallet needs to reach out to the `GET /transaction?id={id}` endpoint to get the payment `amount_in` before making the payment. ([#????](https://github.com/stellar/stellar-protocol/pull/????))
 * `v3.10.1`: Add firm quote withdrawal sequence diagram. ([#1147](https://github.com/stellar/stellar-protocol/pull/1147))
 * `v3.10.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -229,7 +229,7 @@ SEP-6 lays out many options for how deposit and withdrawal can work. These are r
 * **Make a request to `/deposit` or `/withdraw`.**
     * As a conservative measure, pass in any optional fields (including amount) that the wallet has on-hand, such as `email_address` and `account`.
     * In the `/withdraw` request, have the user enter the crypto account or bank account where they'd like their withdrawal to end up and provide that to the anchor via `dest` and `dest_extra`.
-    * Before making the payment, make a request to `[SEP-6]/transaction?id=<transaction_id>` to get the amount_in details. Although unusual and not recommended, some anchors may use additive fees, which would produce an `amount_in` different from the wallet's proposed amount.
+    * Before making the payment, make a request to `[SEP-6]/transaction?id=<transaction_id>` to get the amount_in details. Some anchors may use additive fees, which would produce an `amount_in` different from the wallet's proposed amount.
 * **For `/deposit`**
     * If the issuer's `/deposit` endpoint immediately returns success:
         * display the deposit info that came back from the endpoint to the user, including fee. You're done! The user will execute the deposit exernally using the instructions if they want to.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-04-04
-Version 1.5.5
+Updated: 2022-05-13
+Version 1.6.0
 ```
 
 ## Simple Summary
@@ -93,6 +93,10 @@ sequenceDiagram
     Sending Anchor->>+Receiving Anchor: POST [SEP-31]/transactions
     Receiving Anchor-->>Receiving Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
     Receiving Anchor-->>-Sending Anchor: transaction id, receiving account & memo
+
+    Sending Anchor->>+Receiving Anchor: GET [SEP-31]/transactions/:id
+    Receiving Anchor-->>-Sending Anchor: transaction object containing amount_in, amount_in_asset, stellar_account_id, etc.
+    note right of Sending Anchor: Use the info returned from <br>GET [SEP-31]/transactions/:id to <br>make the stellar payment.
 
     Sending Anchor->>+Stellar: submit Stellar payment
     Stellar->>+Receiving Anchor: receives payment, matches w/ transaction
@@ -182,9 +186,9 @@ This requires the Receiving Anchor to implement the [SEP-38 Anchor RFQ API](sep-
 1. The Sending Anchor collects all required information from the Sending Client. This includes the custom fields listed in the Receiving Anchor's `GET /info` response as well as the KYC fields described in the `GET /customer` responses for both the Sending and Recieving Clients. How the Sending Anchor collects this information from the Sending Client is out of the scope of this document, but the Receving Client should not be required to take any action in order for the Sending Client to make the payment to the Receiving Anchor.
 1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected information for each client.
 1. If the Receiving Anchor supports the [SEP-38 Anchor RFQ API](sep-0038.md), the Sending Anchor can request a quote from the Receiving Anchor. See the [Receiving Anchor Asset Conversion](#receiving-anchor-asset-conversion) section for more information.
-1. The Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction information. The response will include a `id` that will be used to check the status of the transaction.
-1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`. 
-1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `POST /transactions` response.
+1. The Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction information. The response will include a `id` that will be used to check the transaction data and status.
+1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`.
+1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `GET /transactions/:id` response.
 1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
 1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.
@@ -702,6 +706,8 @@ If the information was malformed, or if the sender tried to update data that isn
 ```
 
 ## Changelog
+
+* `v1.6.0`: Updated the "Sending Anchor Flow" so the Sending Anchor needs to reach the `GET /transactions/:id` endpoint to get the payment information before sending the payment to the Receiving Anchor. ([#????](https://github.com/stellar/stellar-protocol/pull/????))
 * `v1.5.5`: Updated the description of `PATCH /transactions`. ([#1166](https://github.com/stellar/stellar-protocol/pull/1166))
 * `v1.5.4`: Add the state diagram of a SEP-31 transaction.  ([#1164](https://github.com/stellar/stellar-protocol/pull/1164))
 * `v1.5.3`: Clarify when `sender_id` and `receiver_id` attributes are required for `POST /transactions` requests. ([#1158](https://github.com/stellar/stellar-protocol/pull/1158))


### PR DESCRIPTION
### What

Clarify that before sending the payment, the sending party should make a GET request to retrieve the expected `amount_in`.

Also added a few polishes to the text.

### Why

Some anchors could use additive fees in the transactions, which would make the amount proposed by the Wallet diverge from the one approved by the Anchor.