### PR TITLE
CAP-0046: Delete objects, add requirements, conversions and validity, adjust language.

### DIFF
--- a/core/cap-0046.md
+++ b/core/cap-0046.md
@@ -15,9 +15,9 @@ Protocol version: TBD
 
 ## Simple Summary
 
-This CAP specifies the lowest-level **code execution** and **data model** components of a WebAssembly-based (WASM) "smart contract" system for the Stellar network. These components are arranged into separate but related "host" and "guest" environments, which together comprise the "runtime environment" for smart contracts.
+This CAP specifies the lowest-level **code execution** and **data model** aspects of a WebAssembly-based (WASM) "smart contract" system for the Stellar network. WASM smart contract code runs as a **guest** inside of a virtual machine (VM) which is embedded in a **host** environment.
 
-Higher-level components of a smart contract system such as ledger entries, host functions and transactions to manage and invoke contracts will be specified in additional CAPs. This CAP focuses only on the lowest-level components.
+Higher-level components of a smart contract system such as ledger entries, host objects and host functions, and transactions to manage and invoke contracts will be specified in additional CAPs. This CAP focuses only on the lowest-level components.
 
 No new operations or ledger entries are introduced in this CAP. Nothing observably changes in the protocol available to users. This CAP is best understood as a set of building blocks for later CAPs, introducing a vocabulary of concepts, data types and implementation components.
 
@@ -35,54 +35,93 @@ The Stellar Network currently supports a rich but fixed repertoire of transactio
 
 This CAP is aligned with the following Stellar Network Goals:
 
-- The Stellar Network should make it easy for developers of Stellar projects to create highly usable products
+  - The Stellar Network should make it easy for developers of Stellar projects to create highly usable products
+
+## Requirements
+
+### Primary requirements
+
+The primary requirement for any smart contract system is to enable, within certain parameters, arbitrary new functionality to be added to a blockchain's state-transition function _by users_. This can be further decomposed to two requirements of concern in this CAP:
+
+  1. Code: stellar-core's state transition function must be extended with some means of executing, within parameters, some form of user-provided Turing-complete instruction code. Preferably in a compact form that can be stored within the ledger.
+
+  2. Data: stellar-core's model of data -- comprising transaction input, output, persistent state and temporary working memory -- must be extended to include data of concern to smart contracts: their input, output, persistent state, and temporary working memory during execution. Any transformations between each of these sorts of data must be specified, even if partially delegated to contract logic.
+### Required parameters to mitigate risks
+
+While the primary requirements seem simple enough to meet -- "just add a VM" -- there are many risks associated with a naive implementation. Therefore subsequent requirements take the form of parameters that constrain implementations in order to mitigate risks, including:
+
+  3. Secure: the smart contract system should be secure against benign or malicious smart contract code as well as contract-code input that could imperil system availability, integrity, or confidentiality (in the few cases where secret data exists). In particular at the level of this CAP, the design should guard against:
+     - The risk of resource exhaustion, leading to denial of service by validators.
+     - The risk of VM escape, leading to arbitrary Byzantine failures on validators, including data corruption or unauthorized transactions.
+     - The risk of side channels, allowing VM code to extract validator private keys or other secret data on validators.
+     - The risk of unintended contract behaviour due to invocation with malicious input data.
+     - The risk of unintended contract behaviour due to calls to or from malicious contracts.
+
+  4. Well-defined: the smart contract system should not compromise the network's bit-precise consensus or historical replay functions, and should have a well-defined and unambiguous semantics for any code or data added by users. Where possible this should be maintained by reference to existing, well-defined standards. In particular at the level of this CAP, the design should guard against:
+     - The risk of underspecified or nondeterministic VM code.
+     - The risk of underspecified or nondeterministic datatypes.
+
+  5. Performant: the smart contract system should not compromise the performance of the network, and should perform competitively with other smart contract systems. Users should not be subject to a significant performance penalty for using smart contracts instead of built-in transactions. In particular at the level of this CAP, the design should guard against:
+     - The risk of needing to load, compile, instantiate or run a large amount of VM code per transaction. Contracts should be small.
+     - The risk of contending on shared mutable data that may defeat parallel execution of transactions. Contracts should be isolated.
+     - The risk of requiring smart contract developers to do extensive optimization to achieve acceptable performance.
+
+  6. Interoperable: the smart contract system will necessarily introduce _some_ new user-defined semantics which are by definition unknown to _some_ users and 3rd parties. But beyond such _necessary_ risks, the smart contract system should avoid introducing _unnecessary_ hazards to interoperability, especially through choice of data encoding for input, output and persistent state. In particular at the level of this CAP, the design should guard against:
+     - The risk of being unable to share data between different contracts, or different versions of the same contract.
+     - The risk of being forced to write contracts in, or invoke contracts from, a single programming language.
+     - The risk of having no tools or only immature tools for working with any programming language targeting the VM.
+     - The risk of being unable to passively observe contract state for testing, debugging, diagnosis or monitoring.
+     - The risk of 3rd parties being unable to exchange data with contracts.
+
+  7. Simple: the smart contract system should be as simple as possible while achieving other requirements. It should not require excessive innovation or expensive engineering by either developers or users of stellar-core. Smart contracts are late in coming to the Stellar Network, there is plenty of prior art to draw from, and there is a limited window of time to complete the work. At the level of this CAP, the design should guard against:
+     - The risk of designing or implementing a novel VM, programming language, client library, or serializaiton format.
+     - The risk of selecting an existing platform that is incompatible with or causes major changes to stellar-core.
+     - The risk of delivering a system that is too challenging to learn for users or 3rd parties.
+
 
 ## Abstract
 
 The specification consists of three parts:
 
-  1. A general description of the concepts of host and guest environments, their relationships, constraints, and methods of implementation.
+  1. A general description of the concepts of host and guest contexts, their relationships, constraints, and methods of implementation.
 
-  2. A specification of the new components that provide the host and guest environments, their means of interaction, and their lifecycle phases.
+  2. A specification of the new components that provide the host and guest contexts, their means of interaction, and their lifecycle phases.
 
   3. A specification of the data model shared between host and guest.
 
 ## Specification
 
-### Environments
+### Context
 
-The runtime environment for smart contracts is comprised of two separate but related environments:
+This CAP specifies aspects of two separate but related contexts:
 
-  - The **host** environment: this consists of portions of the existing C++ code making up stellar-core that can be accessed by smart contracts, as well as some new C++ code implied by this CAP. New C++ code includes the implementation of a WebAssembly (WASM) virtual machine, a set of host objects, and a host context that manages the lifecycle and interaction of the host objects and virtual machines. The host environment is compiled to native code and runs with full access to its enclosing operating system environment, the ledger, the network, etc. The term "host environment" here corresponds to the term with that name in the WebAssembly specification.
+  - The **host** context: this consists of portions of the existing C++ code making up stellar-core that can be accessed by smart contracts, as well as some new C++ and Rust code implied by this CAP. New C++ and Rust code includes the implementation of a WebAssembly (WASM) virtual machine, a set of host objects, and a host environment that contains and manages the lifecycle and interaction of the host objects and virtual machines. The host environment, like the rest of stellar-core, is compiled to native code and runs with full access to its enclosing operating system environment, the ledger, the network, etc. The term "host environment" here corresponds to the term with that name in the WebAssembly specification.
 
-  - The **guest** environment: this consists of WASM code _interpreted by_ a WASM virtual machine embedded in the host. Guest code may originate in any programming language able to target WASM, and will be provided by means unspecified in this CAP. Guest code has very limited access to its enclosing host environment: it can only consume CPU and memory resources to the extent that the host environment permits, and it can only call host functions that the host environment explicitly provides access to. The purpose of the guest environment is to act as a so-called "sandbox" to attenuate potential harms caused by erroneous or malicious guest code, while allowing "just enough" programmability to satisfy the needs of users.
-
-#### Determinism
-
-Both the guest environment and any part of the host environment controlled by the guest must execute deterministically in response to inputs, and must be sufficiently well-specified that replaying historical guest code in an upgraded host environment (i.e. a new version of stellar-core) will produce observably-identical results. This includes the result of observable resource exhaustion within host-controlled CPU or memory limits, which implies the need for careful resource accounting on all guest-controlled actions.
+  - The **guest** context: this consists of WASM code _interpreted by_ a WASM virtual machine embedded in the host environment. Guest code may originate in any programming language able to target WASM, and will be provided by means unspecified in this CAP. Guest code has very limited access to its enclosing host environment: it can only consume CPU and memory resources to the extent that the host environment permits, and it can only call host functions that the host environment explicitly provides access to. The purpose of the guest context is to act as a so-called "sandbox" to attenuate potential harms caused by erroneous or malicious guest code, while allowing "just enough" programmability to satisfy the needs of users.
 
 ### Components
 
-The guest and host environments are provided by two new components added to stellar-core: a virtual machine and a host context.
+The guest and host contexts are provided by two new components added to stellar-core: a virtual machine and a host environment.
 
 #### Virtual Machine
 
-Code for a [WebAssembly 1.0](https://www.w3.org/TR/wasm-core-1/) **virtual machine** (VM) is embedded in stellar-core. The VM can be instantiated multiple times in the same stellar-core process, effectively supporting multiple separate guest environments. The VM is configured with specific limits, and **excludes** support for any subsequent WebAssembly specification revisions or proposals.
+Code for a [WebAssembly 1.0](https://www.w3.org/TR/wasm-core-1/) **virtual machine** (VM) is embedded in stellar-core. The VM can be instantiated multiple times in the same stellar-core process, effectively supporting multiple separate guest contexts. The VM is configured with specific limits, and **excludes** support for any subsequent WebAssembly specification revisions or proposals.
 
-Input guest code for a guest environment is a single WASM module in the specified WASM binary format, and guest code will pass through all 4 semantic phases defined in the WASM specification: decoding, validation, instantiation and execution. See the linked specification for details.
+Furthermore to limit potential nondeterminism risks (see below), floating point instructions are prohibited and any WASM code that includes floating point instructions will not proceed past validation, but be rejected with an error.
 
-#### Host context
+Input guest code for a guest context is a single WASM module in the specified WASM binary format, and guest code will pass through all 4 semantic phases defined in the WASM specification: decoding, validation, instantiation and execution. See the linked specification for details.
 
-A **host context** is added to the transaction-processing subsystem of stellar-core. A host context is a container carrying:
-  - Zero or more WASM VMs, providing guest environments.
-  - Any host objects that the contained guest environments can refer to.
-  - A transaction mechanism for discarding host objects on error.
-  - Any resource-accounting mechanisms for the guest environments.
-  - Any host functions that the guest environments can import.
+#### Host environment
+
+A new structure called a **host environment** is added to the transaction-processing subsystem of stellar-core. A host environment is a container carrying:
+  - Zero or more WASM VMs.
+  - Any host objects that guest code in a WASM VM can refer to.
+  - Any resource-accounting mechanisms for guest code.
+  - Any host functions that guest code in a WASM VM can import.
 
 #### Interface
 
-The **interface** between host and guest environments is very narrow and is defined by the WASM specification of embedding. A summary of some relevant aspects is repeated here:
+The **interface** between the host environment and guest code is very narrow and is defined by the WASM specification of embedding. A summary of some relevant aspects is repeated here:
 
   - Guest memory ("WASM linear memory") is separated from host memory. The host may have a mechanism to access guest memory, but **the guest has no mechanism to access host memory**.
 
@@ -90,19 +129,19 @@ The **interface** between host and guest environments is very narrow and is defi
 
   - Guest code modules carry a list of **exported** functions (that the guest provides and the host can call) and a list of **imported** functions (that the host provides and the guest can call). Both imported and exported functions can only pass a sequence of parameters of the 4 shared data types and return a single value of the 4 shared data types, or a trap.
 
-  - Various error conditions may result in a guest **trap** condition, which is a terminal state for a guest environment: no further execution can occur on a guest after it traps. A trap may be generated within a guest due to an execution error, or may be generated by a host function called from the guest. Therefore any call from guest to host or host to guest may produce a trap result rather than a value. 
+  - Various error conditions may result in a guest **trap** condition, which is a terminal state for the WASM VM running the guest code: no further VM execution can occur after it traps. A trap may be generated by guest code due to an execution error, or may be generated by a host function called from guest code. Therefore any call from guest to host or host to guest may produce a trap result rather than a value.
 
 #### Lifecycles
 
-A host context has its own **lifecycle**: it is created before any of the host objects or VMs it contains, and destroyed after any of the host objects or VMs it contains.
+A host environment has its own **lifecycle**: it is created before any of the host objects or VMs it contains, and destroyed after any of the host objects or VMs it contains.
 
-When a host context is created, it contains no host objects and no VMs.
+When a host environment is created, it contains no host objects and no VMs.
 
-Adding a WASM VM to a host context involves passing WASM code through the 4 lifecycle phases in the WASM specification. If any phase fails, no further phases will be performed on the failed WASM VM.
+Adding a WASM VM to a host environment involves passing WASM code through the 4 lifecycle phases in the WASM specification. If any phase fails, no further phases will be performed on the failed WASM VM.
 
-Multiple WASM VMs can coexist in a single host context. The intention is that one host context and one WASM VM will be created for an "outermost" invocation of a smart contract, and that "inner" contracts can be invoked by guest code calling a host function that constructs an additional VM and invokes a guest function in that new VM, within the same shared host context. The specific mechanism of calling between contracts is not specified in this CAP.
+Multiple WASM VMs can coexist in a single host environment. The intention is that one host environment and one WASM VM will be created for an "outermost" invocation of a smart contract, and that "inner" contracts can be invoked by guest code calling a host function that constructs an additional VM and invokes a guest function in that new VM, within the same shared host environment. The specific mechanism of calling between contracts is not specified in this CAP.
 
-Multiple WASM VMs in the same host context can refer to the same host objects: this is the mechanism for passing (immutable) information between different smart contracts.
+Multiple WASM VMs in the same host environment can refer to the same host objects: this is the mechanism for passing (immutable) information between different smart contracts.
 
 #### Limits
 
@@ -110,12 +149,24 @@ TBD. Implementation-defined **limits** will be specified here before finalizatio
 
 Additional implementation-defined limits will be specified to restrict the consumption of host resources by guest code. In particular, a step-counter or "gas limit" will be imposed on the number of instructions executed by guest code. Additionally any computation, memory or IO resources consumed by host functions called by guest code will be accounted-for. Any guest code that exceeds limits will terminate with an error.
 
+#### Determinism
+
+Both guest code and any part of the host environment controlled by guest code must execute deterministically in response to inputs, and must be sufficiently well-specified that replaying historical guest code in an upgraded host environment (i.e. a new version of stellar-core) will produce observably-identical results. This includes the result of observable resource exhaustion within host-controlled CPU or memory limits, which implies the need for careful resource accounting on all guest-controlled actions.
+
+The WASM spec has [carefully limited nondeterminism](https://github.com/WebAssembly/design/blob/main/Nondeterminism.md) to a small set of cases, which we consider here:
+  - New features: no WASM features beyond the 1.0 spec are supported by the smart contract system.
+  - Threads: not supported by the smart contract system.
+  - NaN-related behaviour for floating point: all floating point code is prohibited.
+  - SIMD-related behaviour: all SIMD extensions are prohibited.
+  - Environment-resource limit exhaustion: will be specified above.
+
+
 ### Data Model
 
 This CAP defines a **data model** shared between guest and host environments. It consists of a set of _values_ and a set of _objects_:
 
-  - **Values** can be packed into a 64-bit integer, and can therefore be easily passed back and forth between host and guest environments, as arguments or return values from imported or exported functions.
-  - **Objects** (also called "host objects") exist only in host memory, in the host context, and can only be _referenced_ in the guest environment by values containing **handles** that _refer to_ objects. If guest code wishes to perform an operation on a host object, it must call a host function with values containing handles that _refer to_ any host object(s) to operate on.
+  - **Values** can be packed into a 64-bit integer, and can therefore be easily passed back and forth between the host environment and guest code, as arguments or return values from imported or exported functions.
+  - **Objects** (also called "host objects") exist only in host memory, in the host context, and can only be _referenced_ by guest code through values containing **handles** that _refer to_ objects. If guest code wishes to perform an operation on a host object, it must call a host function with values containing handles that _refer to_ any host object(s) to operate on.
 
 #### Immutability
 
@@ -125,57 +176,10 @@ Values and Objects are both **immutable**: they cannot be changed once created. 
 
 The data model is specified in two separate **forms**:
 
-  - In a set of "host types", of which the "host _value_ type" is shared between host and guest.
   - In XDR, for inclusion in serial forms such as transactions and ledger entries.
+  - In a set of "host types", of which the "host _value_ type" is shared between host and guest.
 
 The rationale for the two separate forms is given below, in the rationale section.
-
-#### Host value type
-
-The **host value type** is a 64-bit integer carrying a bit-packed disjoint union of several cases:
-
-  - The least-significant bit differentiates between two _primary_ cases:
-    - If it is 0, the remaining 63 bits encode a **positive signed 64-bit integer**.
-    - If it is 1, the remaining 63 bits encode a low 3-bit **tag** and a high 60-bit **body**.
-  - The 8 tag values define an interpretation of the body, from least-significant to most-significant bits:
-    - Tag 0: a **32-bit unsigned integer** followed by 30 zero bits.
-    - Tag 1: a **32-bit signed integer** followed by 30 zero bits.
-    - Tag 2: a **static** set of 60-bit values, of which the first 3 are **void**, **true** and **false**.
-    - Tag 3: an **object reference** given by a 28-bit type code followed by a 32-bit handle.
-    - Tag 4: a **symbol** having 10 or less 6-bit character codes drawn from the character repertoire `[_0-9A-Za-z]`,  with `_` assigned code 1 and trailing positions in the symbol filled with a zero code, and code positions starting at the least significant 6 bits of the body.
-    - Tag 5: a **bitset** consisting of 60 1-bit flags.
-    - Tag 6: a **status** value consisting of a 28-bit type code followed by a 32-bit status code.
-    - Tag 7: reserved for future use.
-
-#### Host object type(s)
-
-There are many different **host object types**, and we refer to the disjoint union of all possible host object types as **the host object type**. This may be implemented in terms of a variant type, an object hierarchy, or any other similar mechanism in the host.
-
-Every host object is held in host memory and **cannot be accessed directly from guest code**. Host objects can be _referred to_ by host values in either host or guest code: specifically those values with tag 3 (object reference) refer to a host object by type code and handle.
-
-**Host object handles** are assigned sequentially from 1, as host objects are allocated during the lifecycle of a host execution context. Host object handle 0 is reserved as a sentinel value that always denotes an invalid object, on which no host functions are defined. All host object types share a single numerical range of handles. In other words: the type codes held in object references _reflect_ type differences between host objects, to allow guests to switch on host object types without calling host functions to query them, but the object type codes do not subdivide the numeric range of object handles.
-
-There are 2^28 (268,435,456) possible **host object type codes**, of which only the first 16 are defined in this CAP:
-
-  - Object type 0: a **box** which contains a single host value.
-  - Object type 1: a **vector** which contains a sequence of host values.
-  - Object type 2: a **map** which is an unordered association from host values to host values.
-  - Object type 3: an XDR **unsigned 64-bit integer**.
-  - Object type 4: an XDR **signed 64-bit integer**.
-  - Object type 5: an XDR **string**.
-  - Object type 6: an XDR opaque **binary** array.
-  - Object type 7: an arbitrary precision **big integer** number.
-  - Object type 8: an arbitrary precision **bit rational** number.
-  - Object type 9: an XDR **ledger key**.
-  - Object type 10: an XDR **operation**.
-  - Object type 11: an XDR **operation result**.
-  - Object type 12: an XDR **transaction**.
-  - Object type 13: an XDR **asset**.
-  - Object type 14: an XDR **price**.
-  - Object type 15: an XDR **account ID**.
-
-The semantics of 5 of these types -- box, vector, map, big integer and rational -- will be given in a later CAP, in terms of the host functions that act on them. In the scope of this CAP, only the remaining 11 XDR object types have defined semantics or representations, which are given by the existing corresponding Stellar network XDR protocol definitions.
-
 
 ### XDR changes
 
@@ -188,7 +192,7 @@ typedef string SCSymbol<10>;
 
 enum SCValType
 {
-    SCV_U63 = 0,
+    SCV_POS_I64 = 0,
     SCV_U32 = 1,
     SCV_I32 = 2,
     SCV_STATIC = 3,
@@ -221,8 +225,8 @@ case SST_UNKNOWN_ERROR:
 
 union SCVal switch (SCValType type)
 {
-case SCV_U63:
-    uint64 u63;
+case SCV_POS_I64:
+    int64 pos_i64;
 case SCV_U32:
     uint32 u32;
 case SCV_I32:
@@ -246,17 +250,7 @@ enum SCObjectType
     SCO_MAP = 2,
     SCO_U64 = 3,
     SCO_I64 = 4,
-    SCO_STRING = 5,
-    SCO_BINARY = 6,
-    SCO_BIGINT = 7,
-    SCO_BIGRAT = 8,
-    SCO_LEDGERKEY = 9,
-    SCO_OPERATION = 10,
-    SCO_OPERATION_RESULT = 11,
-    SCO_TRANSACTION = 12,
-    SCO_ASSET = 13,
-    SCO_PRICE = 14,
-    SCO_ACCOUNTID = 15
+    SCO_BINARY = 5,
 };
 
 struct SCMapEntry
@@ -267,19 +261,6 @@ struct SCMapEntry
 
 typedef SCVal SCVec<>;
 typedef SCMapEntry SCMap<>;
-
-struct SCBigInt
-{
-    bool positive;
-    opaque magnitude<>;
-};
-
-struct SCBigRat
-{
-    bool positive;
-    opaque numerator<>;
-    opaque denominator<>;
-};
 
 union SCObject switch (SCObjectType type)
 {
@@ -293,36 +274,127 @@ case SCO_U64:
     uint64 u64;
 case SCO_I64:
     int64 i64;
-case SCO_STRING:
-    string str<>;
 case SCO_BINARY:
     opaque bin<>;
-case SCO_BIGINT:
-    SCBigInt bi;
-case SCO_BIGRAT:
-    SCBigRat br;
-case SCO_LEDGERKEY:
-    LedgerKey* lkey;
-case SCO_OPERATION:
-    Operation* op;
-case SCO_OPERATION_RESULT:
-    OperationResult* ores;
-case SCO_TRANSACTION:
-    Transaction* tx;
-case SCO_ASSET:
-    Asset asset;
-case SCO_PRICE:
-    Price price;
-case SCO_ACCOUNTID:
-    AccountID accountID;
 };
 ~~~
+#### Host value type
 
+The **host value type** is a 64-bit integer carrying a bit-packed disjoint union of several cases:
+
+  - The least-significant bit differentiates between two _primary_ cases:
+    - If it is 0, the remaining 63 bits encode a **positive signed 64-bit integer**.
+    - If it is 1, the remaining 63 bits encode a low 3-bit **tag** and a high 60-bit **body**.
+  - The 8 tag values define an interpretation of the body, from least-significant to most-significant bits:
+    - Tag 0: a **32-bit unsigned integer** followed by 30 zero bits.
+    - Tag 1: a **32-bit signed integer** followed by 30 zero bits.
+    - Tag 2: a **static** set of 60-bit values, of which the first 3 are **void** (0), **true** (1) and **false** (2).
+    - Tag 3: an **object reference** given by a 28-bit type code followed by a 32-bit handle.
+    - Tag 4: a **symbol** having 10 or less 6-bit character codes drawn from the character repertoire `[_0-9A-Za-z]`,  with `_` assigned code 1 and trailing positions in the symbol filled with a zero code, and code positions starting at the least significant 6 bits of the body.
+    - Tag 5: a **bitset** consisting of 60 1-bit flags.
+    - Tag 6: a **status** value consisting of a 28-bit type code followed by a 32-bit status code.
+    - Tag 7: reserved for future use.
+
+Note that the tag numbers in the host value representation are _not_ identical to the `SCValType` enumeration values used in the `SCVal` union. For example `SCV_OBJECT` is `4` whereas the host object tag value is `3`. The difference arises from the fact that the host value type has a 2-level tagging scheme -- a 1-bit level followed by a 3-bit level -- whereas `SCValType` is has a single 32-bit level of tagging.
+
+#### Host object type(s)
+
+There are many different **host object types**, and we refer to the disjoint union of all possible host object types as **the host object type**. This may be implemented in terms of a variant type, an object hierarchy, or any other similar mechanism in the host.
+
+Every host object is held in host memory and **cannot be accessed directly from guest code**. Host objects can be _referred to_ by host values in either host or guest code: specifically those values with tag 3 (object reference) refer to a host object by type code and handle.
+
+**Host object handles** are assigned sequentially from 1, as host objects are allocated during the lifecycle of a host execution context. Host object handle 0 is reserved as a sentinel value that always denotes an invalid object, on which no host functions are defined. All host object types share a single numerical range of handles. In other words: the type codes held in object references _reflect_ type differences between host objects, to allow guests to switch on host object types without calling host functions to query them, but the object type codes do not subdivide the numeric range of object handles.
+
+There are 2^28 (268,435,456) possible **host object type codes**, of which only the first 6 are defined in this CAP:
+
+  - Object type 0: a **box** which contains a single host value.
+  - Object type 1: a **vector** which contains a sequence of host values.
+  - Object type 2: a **map** which is an ordered association from host values to host values.
+  - Object type 3: an **unsigned 64-bit integer**.
+  - Object type 4: an **signed 64-bit integer**.
+  - Object type 5: a **binary** object containing unspecified bytes.
+
+Note that unlike value tags, the host object type codes _are_ the same numbers as the `SCObjectType` codes in the XDR form. That is, `SCO_VEC` has value `1` which is the same as the host object type code for vector. Maintaining common numbering limits `SCObjectType` to 2^28 possible values as well.
+
+This CAP defines a basic comparison operation for these types, as well as validity and conversion operations for the XDR, but no other operations. An expanded repertoire of host object types and functions that operate on them will be presented in a later CAP.
+
+#### Comparison
+
+Values and objects in the data model have a total order. When comparing two values A and B:
+
+  - If A is a positive int64 and B is not, A is less than B.
+  - If A and B are both positive int64 values, they are ordered by the normal int64 order.
+  - If A and B are both tagged and if A has a lesser tag than B, A is less than B.
+  - If A and B are both equally tagged, then:
+    - If they have tag 0, they are ordered by the normal uint32 order on their low 32 bits.
+    - If they have tag 1, they are ordered by the normal int32 order on their low 32 bits.
+    - If they have tag 2, 5 or 6 or 7 they are ordered by the normal uint64 order on the zero-extension of their low 60 bits.
+    - If they have tag 4 they are ordered by the lexicographical order of their Unicode string value.
+    - If they have tag 3 they are ordered by calling `obj_cmp(A, B)` which performs deep object comparison.
+
+Deep object comparison can be accessed by either guest or host: it is provided to guests as a host function via the host environment interface. It performs a recursive structural comparison of objects and values embedded in objects using the following rules:
+
+  - If A and B have different object types, they are ordered by object type code.
+  - If A and B are boxes, their values are ordered by the value rules above.
+  - If A and B are vectors, they are ordered by lexicographic extension of the value order
+  - If A and B are maps, they are ordered lexicographically as ordered vectors of (key, value) pairs
+  - If A and B are int64 or uint64, they are ordered using the normal order for those types
+  - If A and B are binary, they are ordered using the lexicograhical order of their respective bytes
+#### Validity
+
+The following additional validity constraints are imposed on the XDR types. Values not conforming to these constraints are rejected during conversion to host form:
+
+  - `SCVal.pos_i64` must be >= 0.
+  - `SCVal.sym` must consist only of the characters `[_0-9A-Za-z]`
+  - `SCVal.obj` must not be empty (it is optional in the XDR only to enable type-recursion)
+  - `SCVal.bits` must have its most significant 4 bits set to 0.
+#### Conversion
+
+Conversion from an XDR `SCVal` to a host value is as follows:
+  - Type cases other than `SCV_OBJECT` are direcly encoded into their bit-packed host value form.
+  - For the `SCV_OBJECT` case, the contained `SCObject` is converted into a host object and placed in the host environment's host object array at the next available position `P`. The resulting host value is object handle `P`.
+
+Conversion from a host value to an XDR `SCVal` is as follows:
+  - For the bit-packed primary case 0, and for cases other than tag 3 (object) in primary case 1, each bit-packed representation is copied directly to its corresponding SCVal case.
+  - For tag 3 in primary case 1, the object handle value is accessed in the host environment's host object array. If the object handle has a value beyond the end of the host object array, the conversion fails with an error. Otherwise the result of conversion is an `SCVal` in `SCV_OBJECT` state, with the conversion of the located host object assigned to `SCVal.obj`.
+
+Conversion from an XDR SCObject to a host object is as follows:
+  - Type case `SCO_BOX` forms a host box containing the conversion of the contained SCVal.
+  - Type case `SCO_VEC` forms a host vector containing the conversion of each contained SCVal in order.
+  - Type case `SCO_MAP` forms an ordered host map and then for each pair `SCMapEntry`, adds an entry mapping the conversion of the map entry's `key` to the conversion of the map entry's `val`, returning the resulting host map once all `SCMapEntry`s are added. Note that this means that the resulting map will be in comparison order rather than the order `SCMapEntry`s were provided, and any redundant entries for the same key earlier in the array of `SCMapEntry`s will be overwritten by later entries for the same key.
+  - Type cases `SCO_U64`, `SCO_I64` and `SCO_BINARY` simply move their contained value into a host object with the same content, unaltered.
+
+  Conversion from a host object to an XDR SCObject is as follows:
+  - A host box object forms an `SCObject` of type `SCO_BOX` with the conversion of its value in `SCObject.box`.
+  - A host vector object forms an `SCObject` of type `SCO_VEC` with the conversions of its element values in `SCObject.vec`.
+  - A host map object forms an `SCObject` of type `SCO_MAP` with each mapping entry converted to an `SCMapEntry` and added to the resulting `SCObject.map` field in host value comparison order, from low to high.
+  - A signed or unsigned int64 object, or binary object, is simply moved to its respective `SCObject` case.
+
+  Note that due to the re-ordering and de-duplication that occurs when converting an `SCO_MAP` `SCObject`, it is not the case that "round trip" conversions from XDR to host forms produce identical results.
 ## Design Rationale
 
 ### Rationale for WASM
 
 WebAssembly was chosen as a basis for this CAP after extensive evaluation of alternative virtual machines. See ["choosing wasm"](https://www.stellar.org/blog/project-jump-cannon-choosing-wasm) for details, or the underlying [stack selection criteria](https://docs.google.com/document/d/1ggXNHVas-PpazfOY87nAz2TiAjH4MkUqHnASR02C6xg/edit#heading=h.p25wrykk29al) document.
+
+Relative to requirements listed in this CAP, WASM addresses many of them:
+
+  - Secure:
+    - Resource limits: WASM has good (though not ideal) mechanisms for enforcing resource limits.
+    - VM escape and side channels: WASM is designed as a secure sandbox and has a good security track record so far.
+  - Well-defined:
+    - WASM has a rigorous formal semantics and conformance testsuite, it is well specified.
+    - WASM's nondeterminism is narrowly circumscribed and this CAP excludes all cases.
+  - Performance:
+    - Code size: WASM code is compact but low level, risks being large. The host-centric data model in this CAP minimizes code size.
+    - Optimization: stock compilers emit efficient WASM code.
+  - Interoperable:
+    - Multi-language: many PLs have at least preliminary WASM target support, though only a few are mature enough to use.
+    - Tool maturity: languages targeting WASM -- especially Rust -- have high quality, mature tools.
+  - Simple:
+    - Non-novelty: WASM is a complete, mature, well-supported spec with many off-the-shelf implementations to choose from.
+    - Compatibility: many WASM interpreters are written in C++ and/or Rust, can be embedded easily in stellar-core.
+    - Learnability: WASM is not as familiar as EVM but is relatively widely known and appears easy to learn.
 
 ### Rationale for value / object split
 
@@ -377,9 +449,11 @@ These are chosen based on two criteria:
   - Reasonably-foreseeable use in a large number of smart contracts.
   - Widely-available implementations with efficient immutable forms.
 
-In addition, _values_ are constrained by the ability to be packed into a 64-bit tagged disjoint union.
+In addition, _values_ are constrained by the ability to be packed into a 64-bit tagged disjoint union. Special cases for common small values such as symbols, booleans, 32-bit integers, status codes and small bitsets are provided on the basis of presumed utility in a variety of contexts. 
 
-Implementations of the map and vec object types are based on design techniques from the functional language community, specifically [Relaxed-Radix-Balanced vectors (RRBs)](https://dl.acm.org/doi/10.1145/2784731.2784739) and [Hash Array Mapped Tries (HAMTs)](https://en.wikipedia.org/wiki/Hash_array_mapped_trie). Both of these data types support efficient "modifying copies" that produce new data structures from updates applied to old ones, while sharing most of the memory and substructure of the old object with the new one.
+The value tagging scheme is arranged into two levels -- an primary single-bit tag followed by a secondary 3-bit tag in one of the two primary cases -- in order to facilitate storing positive 64-bit integers in one of the primary cases, without overflowing to an object. We observe that the majority of 64-bit values in the current ledger are positive, representing (for example) asset amounts, time points and sequence numbers.
+
+Implementations of the map and vector object types are based on design techniques from the functional language community, specifically [Relaxed-Radix-Balanced vectors (RRBs)](https://dl.acm.org/doi/10.1145/2784731.2784739) and [Hash Array Mapped Tries (HAMTs)](https://en.wikipedia.org/wiki/Hash_array_mapped_trie). Both of these data types support efficient "modifying copies" that produce new data structures from updates applied to old ones, while sharing most of the memory and substructure of the old object with the new one.
 
 ### Rationale for separate XDR and host forms
 
@@ -387,11 +461,9 @@ It would be possible to store all data in memory in the host in its XDR format, 
 
   - In the host form, values are bit-packed in order to fit in exactly 64 bits. This bit-packing is implemented in stellar-core but is somewhat delicate and would be undesirable to reimplement in every client SDK and data browser. In the XDR form, the various cases that make up the value union are represented in a standard XDR union, which is automatically supported by many languages' XDR bindings.
 
-  - In the host form, objects and values are separated for reasons explained above, and their separation is mediated through object _references_ and the host _context_ which maps references to objects. In the XDR form, objects and values are _not_ separated, because they should not be: there is no implicit context in which to resolve references, and even if there were it would introduce a new category of potential reference-mismatch error in the serialized form to support it. Instead, in the XDR form values _directly contain_ objects.
+  - In the host form, objects and values are separated for reasons explained above, and their separation is mediated through object _references_ and the _host environment_ that maps references to objects. In the XDR form, objects and values are _not_ separated, because they should not be: there is no implicit context in which to resolve references, and even if there were it would introduce a new category of potential reference-mismatch error in the serialized form to support it. Instead, in the XDR form values _directly contain_ objects.
 
   - In the host form, maps and vectors are implemented using memory-efficient substructure-sharing datatypes as described above. Additionally, maps support CPU-efficient hashed lookup by key. In the XDR form, maps are simple linear arrays of key-value pairs, and neither vectors nor maps support any sort of partial substructure-sharing updates.
-
-  - In the host form, big integers and rationals are stored in CPU-dependent forms that support fast CPU-native arithmetic. In the XDR form, they are serialized into platform-agnostic big-endian byte arrays.
 
 ### Rationale for immutable objects
 
@@ -422,20 +494,17 @@ This CAP does not introduce any backward incompatibilities.
 TBD. Performance evaluation is ongoing on in-progress implementation.
 
 ## Security Concerns
-
-There are a variety of security concerns implied by this CAP, including at least the following:
-
-  - The risk of a guest-environment escape due to VM or host function bugs.
-  - The risk of a validator crash due to VM or host function bugs.
-  - The risk of guest code bugs leading to erroneous transactions. 
-  - The risk of mis-metering of guest-controlled resources and denial of service.
-  - The risk of increased load on validators and degraded service due to more expensive smart-contract transactions. 
-  - The risk of information leakage through side channels to guest code.
+TBD. Many concerns are raised in the requirements section; this section will be expanded before finalization.
 
 ## Test Cases
-
 TBD. See in-progress implementation.
 
 ## Implementation
 
-An implementation is provided in [PR 3413](https://github.com/stellar/stellar-core/pull/3413) on the stellar-core repository.
+An implementation is provided in two parts:
+
+  1. The [rs-stellar-contract-env repository](https://github.com/stellar/rs-stellar-contract-env) which contains three Rust crates defining:
+    - `stellar-contract-env-host`: a Rust implementation of the host environment
+    - `stellar-contract-env-guest`: a Rust interface for Rust guest code to interact with the host environment
+    - `stellar-contract-env-common`: a set of definitions common to both
+  2. The [PR 3428](https://github.com/stellar/stellar-core/pull/3428) on the stellar-core repository, which provides the XDR definitions above and provides a connection between stellar-core and the `rs-stellar-contract-host` crate.


### PR DESCRIPTION
A bunch of separate updates here:
  - Added a big requirements section
  - Removed most of the debated host objects -- can pick up in @jayz22's later work
  - Switched {host, guest} environment and context as terms to match code, eliminated "guest environment" as a concept
  - Renamed u63 to pos-u64 to match code, be less weird looking
  - Updated implementation URLs to match current implementatione effort
  - Mentioned rust implementation for host environment
  - Added section on validity
  - Added section on conversions
  - Added section on comparison operation
  - Expanded section on determinism, discussed WASM guarantees
  - Expanded WASM rationale with reference to requirements
  - Moved XDR forward ahead of host forms
  - Added notes about relationship between tag numbers and XDR numbers
 
I _think_ this mostly addresses all the comments from the first round. On to the next!