### PR TITLE
CAP-0047 updates

### DIFF
--- a/core/cap-0047.md
+++ b/core/cap-0047.md
@@ -47,50 +47,19 @@ contract functionality if some unexpected behavior is found in the protocol.
 
 ```diff mddiffcheck.base=ce981331000128a1c145ec364fbd83d3dd4be5ed
 diff --git a/src/xdr/Stellar-ledger-entries.x b/src/xdr/Stellar-ledger-entries.x
-index 3eb578f16..390a700fa 100644
+index 3eb578f16..b1a74cfaa 100644
 --- a/src/xdr/Stellar-ledger-entries.x
 +++ b/src/xdr/Stellar-ledger-entries.x
-@@ -491,6 +491,95 @@ struct LiquidityPoolEntry
+@@ -491,6 +491,61 @@ struct LiquidityPoolEntry
      body;
  };
  
-+typedef opaque WASMCode<>;
++//TODO:256000 is a placeholder. Still need to figure out if this is the maximum
++// or the upper bound for a maximum set by the validators
++typedef opaque WASMCode<256000>;
 +
 +enum ContractCodeType {
 +    CONTRACT_CODE_WASM = 0
-+};
-+
-+enum ContractMetadataType
-+{
-+    METADATA_TYPE_V0 = 0
-+};
-+
-+union SCType switch (SCValType type)
-+{
-+case SCV_U63:
-+case SCV_U32:
-+case SCV_I32:
-+case SCV_STATIC:
-+    void;
-+case SCV_OBJECT:
-+    SCObjectType objType;
-+case SCV_SYMBOL:
-+case SCV_BITSET:
-+case SCV_STATUS:
-+    void;
-+};
-+
-+struct FunctionSignature
-+{
-+    SCSymbol function;
-+    SCType returnType;
-+    SCType argTypes<10>;
-+}
-+
-+union ContractMetadata switch (ContractMetadataType type)
-+{
-+case METADATA_TYPE_V0:
-+    FunctionSignature interface<10>;
 +};
 +
 +union ContractBody switch (ContractCodeType type)
@@ -107,10 +76,7 @@ index 3eb578f16..390a700fa 100644
 +    }
 +    ext;
 +
-+    AccountID owner;
-+    int64 contractID;
-+    
-+    ContractMetadata metadata;
++    Hash contractID;
 +    ContractBody body;
 +};
 +
@@ -146,7 +112,7 @@ index 3eb578f16..390a700fa 100644
  struct LedgerEntryExtensionV1
  {
      SponsorshipDescriptor sponsoringID;
-@@ -521,6 +610,10 @@ struct LedgerEntry
+@@ -521,6 +576,10 @@ struct LedgerEntry
          ClaimableBalanceEntry claimableBalance;
      case LIQUIDITY_POOL:
          LiquidityPoolEntry liquidityPool;
@@ -157,14 +123,14 @@ index 3eb578f16..390a700fa 100644
      }
      data;
  
-@@ -575,6 +668,16 @@ case LIQUIDITY_POOL:
+@@ -575,6 +634,16 @@ case LIQUIDITY_POOL:
      {
          PoolID liquidityPoolID;
      } liquidityPool;
 +case CONTRACT_CODE:
 +    struct
 +    {
-+        int64 contractID;
++        Hash contractID;
 +    } contractCode;
 +case CONFIG:
 +    struct
@@ -174,6 +140,17 @@ index 3eb578f16..390a700fa 100644
  };
  
  // list of all envelope types used in the application
+@@ -589,6 +658,9 @@ enum EnvelopeType
+     ENVELOPE_TYPE_SCPVALUE = 4,
+     ENVELOPE_TYPE_TX_FEE_BUMP = 5,
+     ENVELOPE_TYPE_OP_ID = 6,
+-    ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7
++    ENVELOPE_TYPE_POOL_REVOKE_OP_ID = 7,
++    ENVELOPE_TYPE_TX_CREATE_CONTRACT_TX = 8,
++    ENVELOPE_TYPE_CONTRACT_ID = 9,
++    ENVELOPE_TYPE_CHILD_CONTRACT_ID = 10
+ };
+ }
 diff --git a/src/xdr/Stellar-ledger.x b/src/xdr/Stellar-ledger.x
 index 84b84cbf7..1ccff93b9 100644
 --- a/src/xdr/Stellar-ledger.x
@@ -221,34 +198,134 @@ index 84b84cbf7..1ccff93b9 100644
  };
  
  /* Entries used to define the bucket list */
-
+diff --git a/src/xdr/Stellar-transaction.x b/src/xdr/Stellar-transaction.x
+index 23918226d..371c39df4 100644
+--- a/src/xdr/Stellar-transaction.x
++++ b/src/xdr/Stellar-transaction.x
+@@ -545,6 +545,18 @@ case ENVELOPE_TYPE_POOL_REVOKE_OP_ID:
+         PoolID liquidityPoolID;
+         Asset asset;
+     } revokeID;
++case ENVELOPE_TYPE_CONTRACT_ID:
++    struct
++    {
++        AccountID sourceAccount;
++        SequenceNumber seqNum;
++    } contractID;
++case ENVELOPE_TYPE_CHILD_CONTRACT_ID:
++    struct
++    {
++        Hash contractID; //contractID of parent contract
++        SequenceNumber seqNum; //seqNum stored by contract
++    } childContractID;
+ };
+ 
+ enum MemoType
+@@ -733,6 +745,37 @@ struct FeeBumpTransactionEnvelope
+     DecoratedSignature signatures<20>;
+ };
+ 
++struct CreateContractTransaction
++{
++    // sourceAccount pays the fee and provides the sequence number
++    AccountID sourceAccount;
++
++    // seqNum to be consumed on sourceAccount
++    SequenceNumber seqNum;
++
++    // fee to be paid by sourceAccount
++    int64 fee;
++    
++    // contract code to be written into a ContractCodeEntry
++    ContractBody body;
++
++    union switch (int v)
++    {
++    case 0:
++        void;
++    }
++    ext;
++};
++
++struct CreateContractTransactionEnvelope
++{
++    CreateContractTransaction tx;
++
++    /* Each decorated signature is a signature over the SHA256 hash of
++    * a TransactionSignaturePayload */
++    DecoratedSignature signatures<20>;
++};
++
+ /* A TransactionEnvelope wraps a transaction with signatures. */
+ union TransactionEnvelope switch (EnvelopeType type)
+ {
+@@ -742,6 +785,8 @@ case ENVELOPE_TYPE_TX:
+     TransactionV1Envelope v1;
+ case ENVELOPE_TYPE_TX_FEE_BUMP:
+     FeeBumpTransactionEnvelope feeBump;
++case ENVELOPE_TYPE_TX_CREATE_CONTRACT_TX:
++    CreateContractTransactionEnvelope create;
+ };
+ 
+ struct TransactionSignaturePayload
+@@ -754,6 +799,8 @@ struct TransactionSignaturePayload
+         Transaction tx;
+     case ENVELOPE_TYPE_TX_FEE_BUMP:
+         FeeBumpTransaction feeBump;
++    case ENVELOPE_TYPE_TX_CREATE_CONTRACT_TX:
++        CreateContractTransaction create;
+     }
+     taggedTransaction;
+ };
 ```
 
 ## Semantics
 
-### Operations
+### CreateContractTransaction
+`CreateContractTransaction` will create a new `ContractCodeEntry`, and assign it
+a unique contractID. The contractID will be the SHA-256 hash of a
+`HashIDPreimage`, with type `ENVELOPE_TYPE_CONTRACT_ID`, which contains the
+source account that created the contract, and the sequence number for that
+source account consumed in that transaction. Note that this assumes only one
+contract can be created per transaction.
 
-#### CreateContractOp
-`CreateContractOp` will create a new `ContractCodeEntry`, and assign it a unique
-contractID.
+TODO: Reserve requirement for `ContractCodeEntry`?
 
-The new `ContractCodeEntry` will be sponsored by the source account or the
-sponsoring account if the source account is in a sponsorship sandwich, but it
-will not be a subentry. This is similar to the relationship accounts have with
-claimable balances.
+### Host function to remove contracts
+We will provide a host function to allow for the removal of contracts.
+`remove_contract` will remove the `ContractCodeEntry` that corresponds to the
+contractID of the current executing contract. The call to `remove_contract` will
+result in a positive termination condition. (TODO: Is this possible?)
+```rust
+fn remove_contract() -> bool;
+```
 
-#### UpdateContractOp
-`UpdateContractOp` will modify an existing contract. All parameters except the
-contractID are optional.
+TODO: What about contract data? The `SEQUENCE` ledger entry mentioned below?
+What's the incentive for users to remove contracts (this depends on the fee
+model)? This might not be worth it for the initial version if the incentives
+don't make sense.
 
-#### RemoveContractOp
-`RemoveContractOp` will remove an empty contract if possible.
-TODO: What if the
-contract can own a LedgerEntry like a Trustline? What happens to data owned by
-the contract? How would you delete the contract?
+### Host function to create contracts
+Factory contracts are quite popular already on other networks, so this CAP adds
+functionality to support them. The contractID for these contracts will be
+generated a little differently than a contract created by an account. First, the
+contract must make sure that a `SEQUENCE` ledger entry exists for this
+contractID by calling `create_seq`. After that, any `add_contract` call will
+create the new contractID by taking the SHA-256 hash of a `HashIDPreimage`, with
+type `ENVELOPE_TYPE_CHILD_CONTRACT_ID`, which contains the parent contractID,
+and the sequence number from the `SEQUENCE` ledger entry. The sequence number in
+the `SEQUENCE` ledger entry is then incremented.
 
-All three operations will fail if the source account is not the owner specified
-on the contract.
+```rust
+// creates a SEQUENCE ledger entry, with seqNum set to 0
+fn create_seq() -> bool;
+
+// creates a new contract. Parent contract must have a SEQUENCE ledger entry. Will fail otherwise
+fn add_contract(contract: Vec<u8>) -> bool;
+```
+
+TODO: Add the `SEQUENCE` ledger entry to the XDR.
+TODO: How does this work with the new fee model?
 
 ### Configuration settings using Ledger Upgrades
 This CAP also adds a mechanism for validators to store and update configuration
@@ -274,71 +351,54 @@ it.
 
 ### There are no built in controls for contracts
 Controls like pausing invocation or mutability for all or a subset of a contract
-should be put into a contract itself. The pausing functionally can be part of
-`UpdateContractOp`, but it would disable invocation for the entire contract,
-which may not be the desired outcome. Leaving it to the contract owner is a much
+should be put into a contract itself. Leaving it to the contract writer is a much
 more general solution than baking it into the protocol. The downside is this is
 more error prone and will take more space since the same logic will be
-implemented multiple times. If we think this is a feature most contract writers
-want, then we should consider generalizing it. Mutability can also be added on
-to the manifest, but we have left it out for now since we don't think it will be
-used much. We can base this off of what we've seen with few assets using
-`AUTH_IMMUTABLE`.
+implemented multiple times.
 
-### Contracts are mutable
-Allowing mutable contracts will make upgrades simpler for contract creators. We
-have seen how users of other smart contract platforms have deployed alternative
-solutions like proxy contracts to imitate upgradeability, but these solutions
-are more expensive and complex. Allowing mutable contracts will give users an
-additional choice in how they would like to manage upgrades.  
-Create/update/delete operations are used to manage a contract instead of a
-single operation Keeping these operations separate makes the operation
-parameters easier to understand for the user. `UpdateContractOp` is analogous to
-`SetOptionsOp`, where the only fields that are updated are the ones that are not
-null. This behavior would be confusing if we combined the create, update, and
-delete operations. 
+### ContractCodeEntry has no account associated with it
+The account that creates the `ContractCodeEntry` is not associated with it in any
+way. This means that any changes to the contract metadata must be done in the
+contract through host functions. This isn't ideal, since some of these features
+may not be available when the contracts are initally written. For example, we
+are considering leaving the metadata out of the initial version, or even
+introducing a fast routing scheme to the metadata mentioned at the bottom of
+this CAP in the future. An alternative to this is to add an "admin" account to the
+`ContractCodeEntry`, which can be used along with another transaction to update
+the metadata.
 
-### Contract size
-16384 was chosen because it should be big enough for most contracts, while not
-taking too much space in the ledger and transaction sets. This is still very
-much up for discussion. If we're worried about the transaction set size, we
-could allow contract owners to upload their contracts in smaller chunks, and
-then use an activation operation to enable them.
+### Contracts are immutable on launch
+Contract writers can use proxy contracts to upgrade contract logic, so mutable
+contract code is not neccessary. Keeping contracts immutable will keep the
+protocol implementation simpler so we can get a working product out faster. We
+can always add this functionality later. Note that contracts written before
+contract mutability is introduced will always be immutable.
 
 ### Malicious contracts
 The validators do not have a mechanism to ban specific contracts. Any kind of
 targeted banning mechanism can be worked around quite easily by creating new
 accounts and contracts.
 
-### Contract Metadata
-This CAP defines a ContractMetadata union to accompany the WASM contract. It
-specifies the functions available in the contract, along with the return and
-arguments types for each function. The host function to call into the WASM
-contract should first validate the contract call against the metadata. If the
-contract call does not match one of the functions specified in the metadata,
-then an error will be thrown.
+### WASM contract code size is configurable
+The maximum contract size will be set during the protocol upgrade, and can be
+updated by the validators. This makes it easier to increase the maximum contract
+size without updating the XDR. Note that we will still have a hardcoded upper
+bound set in the XDR. This mechanism can also be used to reduce the contract
+size if tha validators ever see a need to (TODO: size reduction is still up for
+debate).
 
-Users can also load the ContractMetadata to see what the interface looks like.
+### ContractID is calculated differently when created in another contract vs a classic Stellar transaction.
+Pulling contractIDs from `LedgerHeader.idPool` would be easier but it would make
+parallelizing contract creation more difficult in the future. It's also more
+difficult to determine what the contractID will be since the id pool would be
+used by offers and other contracts. This CAP uses a `Hash` instead as the
+contractID. `CreateContractTransaction` uses the source account and source
+account sequence number, but this doesn't make sense when a contract creates
+another contract because multiple contracts can be created in a single
+invocation. In that case, we use the parent contractID and a new
+`SEQUENCE` ledger entry created just for this scenario.
 
-This metadata can be extended to include
-versioning or the router logic mentioned at the end of this CAP.
-
-### Argument limits
-The xdr currently puts an abitrary limit (10) on the number of function
-signatures and arguments in the metadata. This needs to be revisited.
-
-### Contracts are updated at the end of UpdateContractOp
-We considered waiting until after all transactions are applied before updating
-the contract code, but no other operation on Stellar works this way. For
-example, an offer can be updated in the middle of a transaction, and a
-subsequent operation can be affected by that change. The user should be aware
-that they are interacting with a mutable contract, in which case they should be
-aware the contract can change at any time. If we think these updates can be
-harmful for contract users, we could fail invocations if `lastModifiedLedgerSeq`
-== `ledgerSeq`, but this CAP does not apply that restriction.
-
-### Versioning
-TODO:
+Note that this means a deleted contractID cannot be reused.
 
 ## Security Concerns
 The security concerns from CAP-0046
@@ -349,9 +409,69 @@ they have is blocking all contract creations and invocations, which should only
 be used in drastic situations. This CAP does not define a way for validators to
 block specific contracts.
 
-## Possible optimizations
+## Extensions
 
-### Contracts include a router along with the raw WASM
+### Mutable contracts
+We can add host functions that allow contracts to rewrite their own
+`ContractCodeEntry`, which will allow for more flexiblity like upgradable
+contracts without proxies. If mutable contracts are introduced, the host
+function to write the updated `ContractCodeEntry` should be the last thing to
+happen in the contract. This would ideally be enforced with a positive
+termination condition in WASM.
+
+### Contract metadata
+A ContractMetadata union can accompany the WASM contract, which would specify
+the functions available in the contract, along with the return and argument
+types for each function. The host function to call into the WASM contract should
+first validate the contract call against the metadata. If the contract call does
+not match one of the functions specified in the metadata, then an error will be
+thrown.
+
+Users can also load the ContractMetadata to see what the interface looks like.
+
+This metadata can be extended to include
+versioning or the router logic mentioned at the end of this CAP.
+
+TODO: The xdr currently puts an arbitrary limit (10) on the number of function
+signatures and arguments in the metadata. This needs to be revisited.
+
+```c++
+enum ContractMetadataType
+{
+    METADATA_TYPE_V0 = 0
+};
+
+union SCType switch (SCValType type)
+{
+case SCV_U63:
+case SCV_U32:
+case SCV_I32:
+case SCV_STATIC:
+    void;
+case SCV_OBJECT:
+    SCObjectType objType;
+case SCV_SYMBOL:
+case SCV_BITSET:
+case SCV_STATUS:
+    void;
+};
+
+struct FunctionSignature
+{
+    SCSymbol function;
+    SCType returnType;
+    SCType argTypes<10>;
+}
+
+union ContractMetadata switch (ContractMetadataType type)
+{
+case METADATA_TYPE_V0:
+    FunctionSignature interface<10>;
+};
+
+//CreateContractTransaction and ContractCodeEntry should be extended to add on ContractMetadata 
+```
+### Contract metadata can include a router along with the raw WASM
 - This has a couple advantages - 
   - A contract function that just calls into another contract can specify that
     route in the router, allowing the initial contract to avoid spinning up a


### PR DESCRIPTION
This update has a few changes - 
1. Move mutability and ContractMetadata from the initial version to the Extensions section. 
2. Use a new `CreateContractTransaction` instead of the previously specified operations.
3. Use a Hash instead of int64 for the contractID.
4. Add host functions for creating and removing a contract.