### PR TITLE
SEP-31: add callback URL registration endpoint

### DIFF
--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -190,7 +190,7 @@ This requires the Receiving Anchor to implement the [SEP-38 Anchor RFQ API](sep-
 1. The Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction information. The response will include a `id` that will be used to check the transaction data and status.
 1. Optionally, the Sending Anchor makes a `PUT /transactions/:id/callback` request to register a URL that the Receiving Anchor will make requests to when the transaction's status changes.
 1. The Sending Anchor makes a `GET /transactions/:id` request to ensure the status is `pending_sender`. If it is not, the Sending Anchor must wait until it receives a callback request or poll the `GET /transactions/:id` endpoint until the status becomes `pending_sender`.
-1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `POST /transactions` response.
+1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `GET /transactions/:id` response.
 1. If a callback was not registered, the Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`. Otherwise, the Sending Anchor will receive status updates from the Receiving Anchor at the registered callback URL.
 1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -175,6 +175,7 @@ This requires the Receiving Anchor to implement the [SEP-38 Anchor RFQ API](sep-
 * [`POST /transactions`](#post-transactions)
 * [`GET /transactions/:id`](#get-transaction)
 * [`PATCH /transactions/:id`](#patch-transaction)
+* [`PUT /transactions/:id/callback`](#put-transaction-callback)
 
 ### Detailed Sending Anchor Flow
 
@@ -187,9 +188,10 @@ This requires the Receiving Anchor to implement the [SEP-38 Anchor RFQ API](sep-
 1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected information for each client.
 1. If the Receiving Anchor supports the [SEP-38 Anchor RFQ API](sep-0038.md), the Sending Anchor can request a quote from the Receiving Anchor. See the [Receiving Anchor Asset Conversion](#receiving-anchor-asset-conversion) section for more information.
 1. The Sending Anchor makes a `POST /transactions` request to create a transaction record with the Receiving Anchor. This request contains the `id`s returned by the `PUT /customer` requests, the `transaction.fields` values collected from the Sending Client, as well as the transaction information. The response will include a `id` that will be used to check the transaction data and status.
-1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `pending_sender`.
-1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `GET /transactions/:id` response.
-1. The Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`.
+1. Optionally, the Sending Anchor makes a `PUT /transactions/:id/callback` request to register a URL that the Receiving Anchor will make requests to when the transaction's status changes.
+1. The Sending Anchor makes a `GET /transactions/:id` request to ensure the status is `pending_sender`. If it is not, the Sending Anchor must wait until it receives a callback request or poll the `GET /transactions/:id` endpoint until the status becomes `pending_sender`.
+1. The Sending Anchor submits the payment transaction to Stellar using the information provided in the `POST /transactions` response.
+1. If a callback was not registered, the Sending Anchor makes `GET /transactions/:id` requests until the transaction's `status` is `completed`, `error`, `pending_customer_info_update`, or `pending_transaction_info_update`. Otherwise, the Sending Anchor will receive status updates from the Receiving Anchor at the registered callback URL.
 1. If `completed`, the Sending Anchor should notify the Sending Client that funds have been delivered to the Receiving Client.
 1. If `error`, the Receiving Anchor should be contacted to resolve the situation.
 1. If `pending_transaction_info_update`, the `transaction.fields` values collected from the Sending Client were invalid and must be corrected by the Sending Client. See the [Pending Transaction Info Update](#pending-transaction-info-update) section for more information.
@@ -793,7 +795,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ### PUT Transaction Callback
 
-This endpoint can be used by the Sending Anchor to register a callback URL that the Receiving Anchor will make `application/json` POST requests to containing the transaction object defined in the response to [`GET /transaction/:id`](#get-transaction) whenever the transaction's `status` value has changed.
+This endpoint can be used by the Sending Anchor to register a callback URL that the Receiving Anchor will make `application/json` POST requests to containing the transaction object defined in the response to [`GET /transaction/:id`](#get-transaction) whenever the transaction's `status` value has changed. Note that a callback does not need to be made for the initial status of the transaction, which in most cases is `pending_sender`.
 
 This endpoint should also support replacing a previously provided callback URL for the transaction. Receiving Anchors should only make callback requests to the most recently provided URL per-transaction.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -829,7 +829,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
-* `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([]())
+* `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([#1214](https://github.com/stellar/stellar-protocol/pull/1214))
 * `v1.6.1`: Add information about how a SEP-31 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v1.6.0`: Updated the "Sending Anchor Flow" so the Sending Anchor needs to reach the `GET /transactions/:id` endpoint to get the payment information before sending the payment to the Receiving Anchor. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))
 * `v1.5.5`: Updated the description of `PATCH /transactions`. ([#1166](https://github.com/stellar/stellar-protocol/pull/1166))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-05-23
-Version 1.6.1
+Updated: 2022-05-24
+Version 1.7.0
 ```
 
 ## Simple Summary
@@ -791,8 +791,45 @@ If the information was malformed, or if the sender tried to update data that isn
 }
 ```
 
+### PUT Transaction Callback
+
+This endpoint can be used by the Sending Anchor to register a callback URL that the Receiving Anchor will make `application/json` POST requests to containing the transaction object defined in the response to [`GET /transaction/:id`](#get-transaction) whenever the transaction's `status` value has changed.
+
+This endpoint should also support replacing a previously provided callback URL for the transaction. Receiving Anchors should only make callback requests to the most recently provided URL per-transaction.
+
+If the Receiving Anchor does not support making callback requests, this endpoint should return `404 Not Found`.
+
+```
+PUT DIRECT_PAYMENT_SERVER/transactions/:id/callback
+```
+
+```json
+{
+  "url": "https://sendinganchor.com/statusCallback"
+}
+```
+
+Request:
+
+Name | Type | Description
+-----|------|------------
+`url` | string | A valid URL that can accept POST requests containing the transaction obejct defined in the response to [`GET /transaction/:id`](#get-transaction).
+
+Response:
+
+The Receiving Anchor should respond with a `204 No Content` HTTP status.
+
+#### Processing Callback Requests
+
+The sending anchor must respond with a `2XX` (ex. `204 No Content`) HTTP response code as long as the transaction specified with `id` exists and the request body adheres to the transaction object schema. 
+
+If the request is invalid, either because the transaction specified doesn't exist or the request body is not valid, return a `400 Bad Request` JSON response. Note that this is a bug on the the Receiving Anchor's side, and they should be notified in this case.
+
+It is important to note that the Receiving Anchor is not obligated, at least by default (SLAs can be defined between the parties), to retry if an unexpected status code is returned by the Sending Anchor. If Sending Anchors experience unexpected downtime, it is recommended to poll all in-progress transactions to fetch current status values.
+
 ## Changelog
 
+* `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([]())
 * `v1.6.1`: Add information about how a SEP-31 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v1.6.0`: Updated the "Sending Anchor Flow" so the Sending Anchor needs to reach the `GET /transactions/:id` endpoint to get the payment information before sending the payment to the Receiving Anchor. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))
 * `v1.5.5`: Updated the description of `PATCH /transactions`. ([#1166](https://github.com/stellar/stellar-protocol/pull/1166))


### PR DESCRIPTION
resolves #1209 

Adds a `PUT /transactions/:id/callback` endpoint for Sending Anchor to request callback requests to a specified URL. This removes the need for Sending Anchors to poll the statuses of in-progress transactions, reducing the chatter between services, especially for anchors with high transaction throughput.

I considered adding this functionality into the existing `POST /transactions` and `PATCH /transactions` requests as an optional parameter, but figured that it was likely for Receiving Anchors who did not yet implement this feature to simply ignore the `callback_url` request attribute, leading Sending Anchors to believe their callback URL was accepted but never receiving the callback requests.

Note: originally we decided not to add this functionality in #636. I disagree with my former self there and don't see why we wouldn't add this capability for the benefit of Sending Anchors that wanted it. Receiving Anchors can chose not to implement this until a Sending Anchors requests it. cc @gaclaudiu