### PR TITLE
SEP-0039: Changing NFT metadata's `url` field to use an HTTP gateway

### DIFF
--- a/ecosystem/sep-0039.md
+++ b/ecosystem/sep-0039.md
@@ -50,7 +50,7 @@ Since your NFT can be anything, another best practice is storing metadata that d
 {
   "name": "A demonstration of NFT metadata",
   "description": "This is a description of the cool NFT used for an informational SEP demo.",
-  "url": "ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
+  "url": "https://cloudflare-ipfs.com/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/RickAstleyNeverGonnaGiveYouUp7InchSingleCover.jpg",
   "issuer": "GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO",
   "code": "DEMOASSET"
 }


### PR DESCRIPTION
After some discussion within the Stellar Quest community, relating to a
newly released side quest all about NFTs, we noticed the SEP-0039 example
metadata uses the `ipfs://` protocol scheme for the metadata field of `url`.
It seems like it would be more compatible with existing ecosystem practices
to use an HTTP(S) gateway in this field, rather than the direct IPFS url.

This PR would implement exactly that suggestion in the example JSON within
this document. I've used my buttflare URL that is already used later on in
the document, under the 'Representing NFTs' section.

Signed-off-by: Elliot Voris <elliot@voris.me>