### PR TITLE
Update mddiffcheck to v1.1.0

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -15,5 +15,5 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.16
-    - run: go install github.com/stellar/mddiffcheck@v1.0.0
+    - run: go install github.com/stellar/mddiffcheck@v1.1.0
     - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md


### PR DESCRIPTION
### What
Update mddiffcheck to v1.1.0.

### Why
v1.1.0 includes automatic fetching of orphan commits, so we no longer need to manually specify a ref to fetch to get the orphaned commit. Manually specifying a ref was error prone because it assumed the commit would always be included in that ref's tree. Because refs, like PRs, on stellar-core are often force-pushed, there's a good chance commits get dropped from the ref's tree. This new version fixes that.