### PR TITLE
CAP-51: add several hostfns, add explaination of BigInt Convertion, SCStatus return.

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -6,7 +6,7 @@ Title: Smart Contract Host Functions
 Working Group:
     Owner: Jay Geng <@jay>
     Authors: TBD
-    Consulted: Graydon Hoare <@graydon>, Leigh McCulloch <@leighmcculloch>, Nicolas Barry <@MonsieurNicolas>
+    Consulted: Graydon Hoare <@graydon>, Leigh McCulloch <@leighmcculloch>, Nicolas Barry <@MonsieurNicolas>, Siddharth Suresh <@sisuresh>
 Status: Draft
 Created: 2022-05-20
 Discussion: TBD

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -146,6 +146,10 @@ func $vec_insert(param $obj_vec i64) (param $idx i64) (param $val i64) (result i
 
 /// Append the vector $obj_vec_b to the end of another vector $obj_vec_a.
 func $vec_append(param $obj_vec_a i64) (param $obj_vec_b i64) (result i64)
+
+/// Extract a slice from a vector $obj_vec at position $pos with length $len.
+/// Returns handle to the new vector.
+func $vec_slice(param $obj_vec i64) (param $pos u64) (param $len u64) (result i64)
 ```
 
 ### Invoking another function

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -97,6 +97,14 @@ func $map_del (param $obj_map i64) (param $key i64) (result i64)
 
 /// Return length of an existing map.
 func $map_len (param $obj_map i64) (result i64)
+
+/// Given a key, find the first element less than itself in the map's sorted order. 
+/// If such an element exists, return its key, otherwise return an SCStatus containing the error code (TBD).
+func $map_lower_bound (param $obj_map i64) (param $key i64) (result i64)
+
+/// Given a key, find the first element greater than itself in the map's sorted order. 
+/// If such an element exists, return its key, otherwise return an SCStatus containing the error code (TBD).
+func $map_upper_bound (param $obj_map i64) (param $key i64) (result i64)
 ```
 
 ### Vector operations
@@ -142,7 +150,7 @@ func $vec_append(param $obj_vec_a i64) (param $obj_vec_b i64) (result i64)
 
 ### Invoking another function
 ```
-/// The following list of functions $call0...4 defines the interface of a host function calling another function $func in a contract $contract, with different numbers of arguments $arg1..4.
+/// The following list of functions $call0...4 defines the interface of a host function calling another function $func in a contract $contract, with different but known numbers of arguments $arg1..4.
 /// If the call is successful, it forwards the result of the called function. Otherwise, it traps.
 func $call0(param $contract i64) (param $func i64) (result i64)
 
@@ -153,6 +161,10 @@ func $call2(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg
 func $call3(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg2 i64) (param $char i64) (result i64)
 
 func $call4(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg2 i64) (param $arg3 i64) (param $arg4 i64) (result i64)
+
+/// Calls another function $func in a contract $contract with variadic arguments stored in a vector $args_vec.
+/// If the call is successful, it forwards the result of the called function. Otherwise, it traps.
+func $call(param $contract i64) (param $func i64) (param $args_vec i64) (result i64)
 ```
 
 ### Big integer operations
@@ -254,6 +266,31 @@ func $binary_remove(param $obj_bin i64) (param $idx i64) (result i64)
 
 /// Return length of a binary array $obj_bin.
 func $binary_len(param $obj_bin i64) (result i64)
+
+/// Given a host binary object $obj_bin, copy a segment of its memory specified at $offset with length $len into guest linear memory at $pos. 
+/// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
+func $binary_copy_to_guest_mem(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
+
+/// Copy a segment of the guest's linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. 
+/// Returns handle to the new binary array.
+/// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
+func $binary_copy_from_guest_mem(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
+
+/// Convert a binary object to a hash object. 
+/// Returns handle to the new hash object. 
+func $binary_to_hash(param $obj_bin i64) (return i64)
+
+/// Convert a hash object to a binary object.
+/// Returns handle to the new binary object. 
+func $binary_from_hash(param $obj_hash i64) (return i64)
+
+/// Convert a binary object to a public key object. 
+/// Returns handle to the new public key object. 
+func $binary_to_public_key(param $obj_bin i64) (return i64)
+
+/// Convert a public key object to a binary object.
+/// Returns handle to the new binary object. 
+func $binary_from_public_key(param $obj_pubkey i64) (return i64)
 ```
 
 ### Cryptographic operations
@@ -269,43 +306,64 @@ func $verify_sig_ed25519(param $obj_bin i64) (param $obj_pk i64) (result i64)
 This CAP builds on top of CAP-0046 by expanding the repertoire of host object types. Thus the diff is made with CAP-0046 assuming it will be merged into stellar-core before this CAP finalizes. This section will be updated to observe any changes made to the CAP-0046 XDR set. 
 
 ```
-diff --git a/src/xdr/Stellar-contract.x b/src/xdr/Stellar-contract.x
-index 4085d97e..3d1631df 100644
---- a/src/xdr/Stellar-contract.x
-+++ b/src/xdr/Stellar-contract.x
-@@ -113,7 +113,10 @@ enum SCObjectType
-     SCO_MAP = 2,
-     SCO_U64 = 3,
-     SCO_I64 = 4,
--    SCO_BINARY = 5
-+    SCO_BINARY = 5,
-+    SCO_BIGINT = 6,
-+    SCO_HASH = 7,
-+    SCO_PUBLIC_KEY = 8
+diff --git a/src/protocol-next/xdr/Stellar-contract.x b/src/protocol-next/xdr/Stellar-contract.x
+index d299068e..c8d50593 100644
+--- a/src/protocol-next/xdr/Stellar-contract.x
++++ b/src/protocol-next/xdr/Stellar-contract.x
+@@ -112,7 +112,10 @@ enum SCObjectType
+     SCO_MAP = 1,
+     SCO_U64 = 2,
+     SCO_I64 = 3,
+-    SCO_BINARY = 4
++    SCO_BINARY = 4,
++    SCO_BIGINT = 5,
++    SCO_HASH = 6,
++    SCO_PUBLIC_KEY = 7,
  
      // TODO: add more
  };
-@@ -127,6 +130,12 @@ struct SCMapEntry
- typedef SCVal SCVec<>;
- typedef SCMapEntry SCMap<>;
+@@ -126,6 +129,33 @@ struct SCMapEntry
+ typedef SCVal SCVec<256000>;
+ typedef SCMapEntry SCMap<256000>;
  
-+struct SCBigInt
++enum SCNumSign
 +{
-+    bool positive;
-+    opaque magnitude<>;
++    NEGATIVE = -1,
++    ZERO = 0,
++    POSITIVE = 1,
++};
++
++union SCBigInt switch (SCNumSign sign)
++{
++case ZERO:
++    void;
++case POSITIVE:
++case NEGATIVE:
++    opaque magnitude<256000>;
++};
++
++enum SCHashType
++{
++    SCHASH_SHA256 = 0,
++};
++
++union SCHash switch (SCHashType type)
++{
++case SCHASH_SHA256:
++    Hash sha256;
 +};
 +
  union SCObject switch (SCObjectType type)
  {
- case SCO_BOX:
-@@ -141,5 +150,11 @@ case SCO_I64:
+ case SCO_VEC:
+@@ -138,5 +168,11 @@ case SCO_I64:
      int64 i64;
  case SCO_BINARY:
-     opaque bin<>;
+     opaque bin<256000>;
 +case SCO_BIGINT:
 +    SCBigInt bi;
 +case SCO_HASH:
-+    Hash hash;
++    SCHash hash;
 +case SCO_PUBLIC_KEY:
 +    PublicKey publicKey;
  };
@@ -314,23 +372,30 @@ index 4085d97e..3d1631df 100644
 
 ### New host object types
 The following new host object types are introduced on top of [CAP-0046](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046.md#host-object-types):
-- Object type 6: an arbitrary precision big integer number (BigInt).
+- Object type 6: a big integer number (BigInt) bounded by the binary object size limit of 256000 bytes, which equates to numerical range from -256^256000 + 1 to 256^256000 - 1.
 - Object type 7: an XDR hash.
 - Object type 8: an XDR public key.
+
 Of which, type 7 and 8 are XDR types, which follow the same standard semantics of XDR objects described in CAP-0046 including comparison, validity and conversion. Additional semantics are listed below.
 
 #### Comparison
-- If A and B are both public keys with different types, they are ordered by the public key type value. If A and B are of the same public key types, they are ordered by the key values. 
-- If A and B are both big integers, they are ordered by their values. 
+- Public key / hash: if A and B are both public keys / hashes with different types, they are ordered by the type value. If A and B are of the same public key / hash types, they are ordered by the key / hash values. 
+- BigInt: if A and B are both BigInts with different signs, they are ordered by the sign values. If A and B are of the same signs, they are ordered by their values -- (`sign`) `magnitude`.
 
-#### Conversion
-From XDR `SCObject` to a host object:
-- Type case `SCO_BIGINT`: construct a host object by first invoking the [from_bytes_be](https://docs.rs/num-bigint/0.4.3/num_bigint/struct.BigInt.html#method.from_bytes_be), then passing in `sign` value consistent with the `SCBigInt.positive`, and  `SCBigInt.magnitude` as the `bytes` input. The bytes are decoded in big-endian (BE) format. 
-- Type cases `SCO_HASH`, `SCO_PUBLIC_KEY`: move their contained value into a host object with the same content unaltered. 
+#### Conversion for BigInt
+The host object uses implementation-specific data structure to store the sign and magnitude of the BigInt. We intend to use leverage Rust's [num-bigint](https://docs.rs/num-bigint/latest/num_bigint/) crate, which internally stores the magnitude as a `vec<u64>`. However, the conversion rule described here should be easily generalizable to other implementations.
 
-From a host object ot and XDR `SCObject`:
-- Type case `SCO_BIGINT`: construct an XDR object by first calling the  [to_bytes_be](https://docs.rs/num-bigint/latest/num_bigint/struct.BigInt.html#method.to_bytes_be) method on the BigInt object, then assigning `SCBigInt.positive` with value consistent with the returned `sign` value and move the returned `bytes` into `SCBigInt.magnitude`. The bytes are encoded in BE. 
-- Type cases `SCO_HASH`, `SCO_PUBLIC_KEY`: move the contained value to the XDR object unaltered. 
+From XDR (`ScObject` with `type` case `SCO_BIGINT`) to a host object:
+
+Construct the host object BigInt with sign consistent with the `sign` case of the `SCBigInt`. If `sign` is `SCNumSign::ZERO`, then BigInt's magnitude is left empty. Otherwise, decode the bytes stored in the `magnitude` field in big-endian (BE) into the BigInt's magnitude. For example with [num-bigint](https://docs.rs/num-bigint/latest/num_bigint/)'s implementation, the first `u64` element in the `vec` will be constructed by taking the last 8 bytes in the opaque array, reverse the order, shift each byte by `8 * index`, then compute the sum. Refer to [from_bytes_be](https://docs.rs/num-bigint/0.4.3/num_bigint/struct.BigInt.html#method.from_bytes_be) for implementation detail. 
+
+From a host object to XDR:
+
+Construct the `SCBigInt` with the correct `sign` case, consistent with the BigInt's sign. If the BigInt is zero, then it's done. Otherwise, encode the BigInt's magnitude in BE into bytes stored in the `magnitude` field. Refer to [to_bytes_be](https://docs.rs/num-bigint/latest/num_bigint/struct.BigInt.html#method.to_bytes_be) for implementation detail.
+
+#### Conversion for other types
+For other types, i.e. `SCO_HASH`, `SCO_PUBLIC_KEY`, conversion between XDR and host object is to simply move around the contained value unaltered. 
+
 
 ## Design Rationale
 The WASM smart-contract system for the Stellar network is divided into the host context and the guest context, and the host functions define the interface between the host environment (running the host context) and the VM (running the guest code) via which guest code can interact with the compute resources and host objects. For the full definitions of the host and guest context, host environment, virtual machine, please refer to the “Components” section in [CAP-0046](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046.md#components).
@@ -358,6 +423,14 @@ There are three main reasons for biasing error handling to generate traps in the
 2. Trapping on the host in most error cases ensures errors are handled (by escalation to a transaction abort), whereas many functions that have "error code returns" can have those errors ignored, which makes contracts more likely to be buggy. 
 3. There is no easy way to communicate a structured error value to the user (such as a `result` or `option`) type. We would wind up either allocating an object to wrap every result from every function or commit one bit in the host value to denote a `None` value (analogous to Rust’s `std::option`). Both of these approaches introduce more complexity and are error prone. 
 
+### `SCStatus`-Returning Host Functions
+`SCStatus` is an `SCVal` case designed for conveying function-calling status (such as error code) between the host and the guest. The `SCStatus` cases will be expanded to include additional types as well as concrete host function error codes in future iterations of this CAP. 
+
+The only host functions that returns the `SCStatus` currently are `map_lower_bound` and `map_upper_bound`, which return an `SCStatus` containing the error code corresponding to an "element not exist" error (the exact error code and type are TBD).
+
+But what if a host function's return value **is** a `SCStatus`? E.g. calling `vec_get` on a vector object `vec<SCStatus>`. 
+
+In order to disambiguate the two cases (host function returning an `SCStatus` to communicate a call status versus a host function returning a stored `SCStatus` value), we will disallow any storage of `SCStatus` in the host context. Thus a returned `SCStatus` can only be interpreted as a function call status. 
 
 ## Protocol Upgrade Transition
 This CAP does not introduce any protocol changes.


### PR DESCRIPTION
- [ ]  Keep the Hash and public key as SCO types, as they are fairly ubiquitous and specially-purposed. But provide the following functions for interoperability:
    - [x]  Make them union types
    - [ ]  Convert between SCO_ACCOUNT_ID and SCO_PUBLIC_KEY (will be done later in whichever CAP `ACCOUNT_ID` is defined)
- [x]  Add vec functions for slicing
- [x]  ScBigInt signess:
    - [x]  add an enum {POSITIVE, ZERO, NEGATIVE} to denote its sign (instead of just a POSITIVE).
    - [x]  Update its description
    - [x]  Update the description of ScBigInt to be implementation independent
- [x]  Map: provide host functions (similar to lower-bound, upper-bound) to iterate through a map, as well as knowing when to end.
- [x]  Binary:
    - [x]  Memcpy
    - [x]  Interop: SCO_BINARY and SCO_HASH
    - [x]  Interop: SCO_BINARY and PUBLIC_KEY
- [x]  Add a small section on the status type, that they are not supposed to be stored, and explain the ambiguity issue.
- [x]  Variadic functions for contract calling.