### PR TITLE
Transfer SEPs: add the 'expired' status

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1360,6 +1360,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.12.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v3.11.1`: Add information about how a SEP-6 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v3.11.0`: Update instructions to enforce the Wallet needs to reach out to the `GET /transaction?id={id}` endpoint to get the payment `amount_in` before making the payment. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))
 * `v3.10.1`: Add firm quote withdrawal sequence diagram. ([#1147](https://github.com/stellar/stellar-protocol/pull/1147))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2022-05-23
-Version 3.11.1
+Updated: 2022-06-08
+Version 3.12.0
 ```
 
 ## Simple Summary
@@ -1078,6 +1078,7 @@ Name | Type | Description
 * `pending_customer_info_update` -- certain pieces of information need to be updated by the user. See the [pending customer info update](#pending-customer-info-update) section.
 * `pending_transaction_info_update` -- certain pieces of information need to be updated by the user. See the [pending transaction info update](#pending-transaction-info-update) section
 * `incomplete` -- there is not yet enough information for this transaction to be initiated. Perhaps the user has not yet entered necessary info in an interactive flow.
+* `expired` -- funds were never received by the anchor and the transaction is considered abandoned by the user. If a SEP-38 quote was specified when the transaction was initiated, the transaction should expire when the quote expires, otherwise anchors are responsible for determining when transactions are considered expired.
 * `no_market` -- could not complete deposit because no satisfactory asset/XLM market was available to create the account.
 * `too_small` -- deposit/withdrawal size less than `min_amount`.
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -939,10 +939,8 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * Solar wallet: https://solarwallet.io
 
 ## Changelog
+* `v2.5.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v2.4.0`: Add `refunded` transaction status. ([#1195](https://github.com/stellar/stellar-protocol/pull/1195))
-* `v2.3.0`: Change `lang` format from [ISO639-1] to [RFC4646] which is a superset of [ISO639-1]. Add `lang` field to GET `/transactions` and `/transaction`. ([#1191](https://github.com/stellar/stellar-protocol/pull/1191))
+* `v2.3.0`: Change `lang` format from [ISO639-1](https://en.wikipedia.org/wiki/ISO_639-1) to [RFC4646](https://datatracker.ietf.org/doc/html/rfc4646) which is a superset of ISO639-1. Add `lang` field to GET `/transactions` and `/transaction`. ([#1191](https://github.com/stellar/stellar-protocol/pull/1191))
 * `v2.2.1`: Make `completed_at` field optional. ([#1185](https://github.com/stellar/stellar-protocol/pull/1185))
 * `v2.2.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
-
-[RFC 4646]: https://datatracker.ietf.org/doc/html/rfc4646
-[ISO 639-1]: https://en.wikipedia.org/wiki/ISO_639-1

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-05-06
-Version 2.4.0
+Updated: 2022-06-08
+Version 2.5.0
 ```
 
 ## Simple Summary
@@ -730,6 +730,7 @@ Name | Type | Description
 * `pending_user` -- the user must take additional action before the deposit / withdrawal can complete, for example an email or 2fa confirmation of a withdraw.
 * `completed` -- deposit/withdrawal fully completed.
 * `refunded` -- the deposit/withdrawal is fully refunded.
+* `expired` -- funds were never received by the anchor and the transaction is considered abandoned by the user. Anchors are responsible for determining when transactions are considered expired.
 * `no_market` -- could not complete deposit because no satisfactory asset/XLM market was available to create the account.
 * `too_small` -- deposit/withdrawal size less than `min_amount`.
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-05-24
-Version 1.7.0
+Updated: 2022-06-08
+Version 1.8.0
 ```
 
 ## Simple Summary
@@ -543,6 +543,7 @@ Name | Type | Description
 * `pending_receiver` -- payment is being processed by the Receiving Anchor.
 * `pending_external` -- payment has been submitted to external network, but is not yet confirmed.
 * `completed` -- funds have been delivered to the Receiving Client.
+* `expired` -- funds were never received by the anchor and the transaction is considered abandoned by the user. If a SEP-38 quote was specified when the transaction was initiated, the transaction should expire when the quote expires, otherwise anchors are responsible for determining when transactions are considered expired.
 * `error` -- catch-all for any error not enumerated above.
 
 ![Status Diagram](../contents/sep-0031/state_diagram.png?raw=true)

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -543,7 +543,7 @@ Name | Type | Description
 * `pending_receiver` -- payment is being processed by the Receiving Anchor.
 * `pending_external` -- payment has been submitted to external network, but is not yet confirmed.
 * `completed` -- funds have been delivered to the Receiving Client.
-* `expired` -- funds were never received by the anchor and the transaction is considered abandoned by the user. If a SEP-38 quote was specified when the transaction was initiated, the transaction should expire when the quote expires, otherwise anchors are responsible for determining when transactions are considered expired.
+* `expired` -- funds were never received by the anchor and the transaction is considered abandoned by the Sending Client. If a SEP-38 quote was specified when the transaction was initiated, the transaction should expire when the quote expires, otherwise anchors are responsible for determining when transactions are considered expired.
 * `error` -- catch-all for any error not enumerated above.
 
 ![Status Diagram](../contents/sep-0031/state_diagram.png?raw=true)
@@ -832,6 +832,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
+* `v1.8.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([#1214](https://github.com/stellar/stellar-protocol/pull/1214))
 * `v1.6.1`: Add information about how a SEP-31 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v1.6.0`: Updated the "Sending Anchor Flow" so the Sending Anchor needs to reach the `GET /transactions/:id` endpoint to get the payment information before sending the payment to the Receiving Anchor. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))


### PR DESCRIPTION
Adds the `expired` value to the transaction `status` attribute. For SEP-31 and SEP-6, which can use SEP-38 quotes, transactions should expire when quotes expire. In all other cases, the anchor is free to determine when transactions expire.