### PR TITLE
Unify `GeneralizedTxSet` component types in CAP-42.

### DIFF
--- a/core/cap-0042.md
+++ b/core/cap-0042.md
@@ -222,6 +222,9 @@ Changes done at the transaction queue and flooding level should align as much as
 * limit the number of transactions in memory as to also take advantage of any potential additional limit on certain types of operations.
 * flood higher fee transactions first from the accumulated set.
 
+#### `LedgerCloseMeta` update
+
+The update in `LedgerCloseMeta` will happen together with the switch to the new protocol. This way we don't need to maintain backwards compatibility with legacy `TransactionSet` in `LedgerCloseMetaV1`.
 
 ## Design Rationale
 

--- a/core/cap-0042.md
+++ b/core/cap-0042.md
@@ -52,45 +52,47 @@ Note that this CAP does not modify how transactions gets applied (ie: the apply 
 
 ### XDR Changes
 
-This patch of XDR changes is based on the XDR files in commit (`eb86e88a45f91e5f8b55a37c17b21614b16eb25d`) of stellar-core.
-```diff mddiffcheck.base=eb86e88a45f91e5f8b55a37c17b21614b16eb25d
-diff --git a/src/xdr/Stellar-ledger.x b/src/xdr/Stellar-ledger.x
-index 84b84cbf7..66317b63d 100644
---- a/src/xdr/Stellar-ledger.x
-+++ b/src/xdr/Stellar-ledger.x
-@@ -176,14 +176,53 @@ case METAENTRY:
+This patch of XDR changes is based on the XDR files in commit (`b9501ae3288a5879d457841168cb4b249691cb43`) of stellar-core.
+```diff mddiffcheck.base=b9501ae3288a5879d457841168cb4b249691cb43
+---
+ src/protocol-curr/xdr/Stellar-ledger.x | 60 +++++++++++++++++++++++++-
+ 1 file changed, 59 insertions(+), 1 deletion(-)
+
+diff --git a/src/protocol-curr/xdr/Stellar-ledger.x b/src/protocol-curr/xdr/Stellar-ledger.x
+index 84b84cbf..9c2cbcee 100644
+--- a/src/protocol-curr/xdr/Stellar-ledger.x
++++ b/src/protocol-curr/xdr/Stellar-ledger.x
+@@ -176,6 +176,29 @@ case METAENTRY:
      BucketMetadata metaEntry;
  };
  
--// Transaction sets are the unit used by SCP to decide on transitions
--// between ledgers
 +enum TxSetComponentType
 +{
-+  TXSET_COMP_TXS_BID_IS_FEE = 0, // txs, with effective fee = bid
-+  TXSET_COMP_TXS_DISCOUNTED_FEE = 1 // txs, with effective fee <= bid derived from a base fee
++  // txs with effective fee <= bid derived from a base fee (if any).
++  // If base fee is not specified, no discount is applied.
++  TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE = 0
 +};
 +
-+union TxSetComponent switch (TxSetComponentType t)
++union TxSetComponent switch (TxSetComponentType type)
 +{
-+case TXSET_COMP_TXS_BID_IS_FEE:
-+    TransactionEnvelope txsBidIsFee<>;
-+case TXSET_COMP_TXS_DISCOUNTED_FEE:
++case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
 +  struct
 +  {
-+    int64 baseFee;
++    int64* baseFee;
 +    TransactionEnvelope txs<>;
-+  } txsDiscountedFee;
++  } txsMaybeDiscountedFee;
 +};
 +
-+union TransactionPhase switch(int v)
++union TransactionPhase switch (int v)
 +{
 +case 0:
 +    TxSetComponent v0Components<>;
 +};
 +
+ // Transaction sets are the unit used by SCP to decide on transitions
+ // between ledgers
  struct TransactionSet
- {
-     Hash previousLedgerHash;
+@@ -184,6 +207,19 @@ struct TransactionSet
      TransactionEnvelope txs<>;
  };
  
@@ -100,13 +102,9 @@ index 84b84cbf7..66317b63d 100644
 +    TransactionPhase phases<>;
 +};
 +
-+// Transaction sets are the unit used by SCP to decide on transitions
-+// between ledgers
-+
 +union GeneralizedTransactionSet switch (int v)
 +{
-+case 0:
-+    TransactionSet v0TxSet;
++// We consider the legacy TransactionSet to be v0.
 +case 1:
 +    TransactionSetV1 v1TxSet;
 +};
@@ -114,7 +112,7 @@ index 84b84cbf7..66317b63d 100644
  struct TransactionResultPair
  {
      Hash transactionHash;
-@@ -203,11 +242,13 @@ struct TransactionHistoryEntry
+@@ -203,11 +239,13 @@ struct TransactionHistoryEntry
      uint32 ledgerSeq;
      TransactionSet txSet;
  
@@ -125,18 +123,18 @@ index 84b84cbf7..66317b63d 100644
      case 0:
          void;
 +    case 1:
-+        GeneralizedTransactionSet txGeneralizedSet;
++        GeneralizedTransactionSet generalizedTxSet;
      }
      ext;
  };
-@@ -358,9 +399,30 @@ struct LedgerCloseMetaV0
+@@ -358,9 +396,29 @@ struct LedgerCloseMetaV0
      SCPHistoryEntry scpInfo<>;
  };
  
 +struct LedgerCloseMetaV1
 +{
 +    LedgerHeaderHistoryEntry ledgerHeader;
-+    // NB: txSet is sorted in "Hash order"
++
 +    GeneralizedTransactionSet txSet;
 +
 +    // NB: transactions are sorted in apply order here
@@ -158,9 +156,7 @@ index 84b84cbf7..66317b63d 100644
 +case 1:
 +    LedgerCloseMetaV1 v1;
  };
--}
-+
-+} // namespace stellar
+ }
 ```
 
 ### Semantics
@@ -184,8 +180,9 @@ A `v1TxSet` is validated using the following rules:
 * `v0Components`
   * transactions from different components do not overlap
   * the union of all transactions together forms a valid transaction set that can be applied to a legder (transactions are valid, accounts can pay for fees, transactions sequence numbers form valid source account chains).
-  * fee bids for any transaction satisfy the "minimum fee requirement", ie, its fee bid is greater or equal to the minimum fee derived from `ledgerHeader.baseFee`
-  * `TXSET_COMP_TXS_DISCOUNTED_FEE`
+  * fee bids for any transaction satisfy the "minimum fee requirement", i.e. its fee bid is greater or equal to the minimum fee derived from `ledgerHeader.baseFee`
+  * all the `baseFee` values in different `TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE` components are unique
+  * `TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE` with non-empty `baseFee`:
     * `baseFee >= ledgerHeader.baseFee` (a corollary from the global minimum fee bid requirement).
     * each transaction in this component has a fee bid greater than or equal to the minimum fee bid derived from `baseFee` (for a regular transaction that would translate to `baseFee * numberOfTransactionOperations <= bidFee`)
 
@@ -193,8 +190,8 @@ A `v1TxSet` is validated using the following rules:
 
 The effective fee for a given transaction is computed in the following way:
 
-  * If the transaction is in a `TXSET_COMP_TXS_BID_IS_FEE` component, its effective fee is its fee bid.
-  * If the transaction is in a `TXSET_COMP_TXS_DISCOUNTED_FEE` component, its effective fee is derived from a base fee equal to that component's `baseFee`.
+  * If the transaction is in a `TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE` component and `baseFee` is empty, its effective fee is its fee bid.
+  * If the transaction is in a `TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE` component and `baseFee` is set, its effective fee is derived from a base fee equal to that component's `baseFee`.
 
 #### Candidate value generation
 
@@ -262,7 +259,7 @@ As transaction sets are transmitted over the network, the overlay network will h
 
 #### Surge pricing behavior change
 
-While this CAP doesn't define the candidate transaction set generation strategy, the initial approach would be to just continue using surge pricing approach described in [CAP-0005](cap-0005.md). However, using it requires slightly changing the algorithm: instead of rounding up during the [base fee computation](cap-0005.md#computation-of-the-associated-effective-base-fee) we need to round it down. The reason for doing that is to satisfy the `baseFee` validation requirement of `TXSET_COMP_TXS_DISCOUNTED_FEE` component. With rounding up it's possible to have a valid transaction that doesn't satisfy that requirement. The impact of this change should be minimal.
+While this CAP doesn't define the candidate transaction set generation strategy, the initial approach would be to just continue using surge pricing approach described in [CAP-0005](cap-0005.md). However, using it requires slightly changing the algorithm: instead of rounding up during the [base fee computation](cap-0005.md#computation-of-the-associated-effective-base-fee) we need to round it down. The reason for doing that is to satisfy the `baseFee` validation requirement of `TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE` component. With rounding up it's possible to have a valid transaction that doesn't satisfy that requirement. The impact of this change should be minimal.
 
 ### Resource Utilization
 


### PR DESCRIPTION
Use a single component type with optional base fee instead of two components with non-optional fees.