### PR TITLE
CAP-51 clean up

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -154,18 +154,6 @@ func $vec_slice(param $obj_vec i64) (param $pos u64) (param $len u64) (result i6
 
 ### Invoking another function
 ```
-/// The following list of functions $call0...4 defines the interface of a host function calling another function $func in a contract $contract, with different but known numbers of arguments $arg1..4.
-/// If the call is successful, it forwards the result of the called function. Otherwise, it traps.
-func $call0(param $contract i64) (param $func i64) (result i64)
-
-func $call1(param $contract i64) (param $func i64) (param $arg1 i64) (result i64)
-
-func $call2(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg2 i64) (result i64)
-
-func $call3(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg2 i64) (param $char i64) (result i64)
-
-func $call4(param $contract i64) (param $func i64) (param $arg1 i64) (param $arg2 i64) (param $arg3 i64) (param $arg4 i64) (result i64)
-
 /// Calls another function $func in a contract $contract with variadic arguments stored in a vector $args_vec.
 /// If the call is successful, it forwards the result of the called function. Otherwise, it traps.
 func $call(param $contract i64) (param $func i64) (param $args_vec i64) (result i64)
@@ -302,8 +290,8 @@ func $binary_from_public_key(param $obj_pubkey i64) (return i64)
 /// Compute the sha256 hash of a binary array and return handle to the hash object. 
 func $compute_hash_sha256(param $obj_bin i64) (result i64)
 
-/// Verify signature of content encoded in binary array $obj_bin with a public key object $obj_pk.
-func $verify_sig_ed25519(param $obj_bin i64) (param $obj_pk i64) (result i64)
+/// Verify signature of content encoded in binary array $obj_bin with a public key object $obj_pk against a signature $obj_sig using ed25519. Returns SCStatic::TRUE/FALSE.
+func $verify_sig_ed25519(param $obj_bin i64) (param $obj_pk i64) (param $obj_sig i64) (result i64)
 ```
 
 ### XDR changes


### PR DESCRIPTION
- Remove `call0..4` functions.
- Clean up `verify_sig_ed25519` fn signature and description. 