### PR TITLE
CAP-42 - updated `txSet` validation rules.

### DIFF
--- a/core/cap-0042.md
+++ b/core/cap-0042.md
@@ -178,6 +178,7 @@ A `v1TxSet` is validated using the following rules:
 * `previousLedgerHash` is equal to the hash of the previous ledger.
 * `phases` contains exactly one element (this is an extension point).
 * `v0Components`
+  * contains at least one transaction (hence empty `v1TxSet` can *only* be represented by a single phase with no components)
   * transactions from different components do not overlap
   * the union of all transactions together forms a valid transaction set that can be applied to a legder (transactions are valid, accounts can pay for fees, transactions sequence numbers form valid source account chains).
   * fee bids for any transaction satisfy the "minimum fee requirement", i.e. its fee bid is greater or equal to the minimum fee derived from `ledgerHeader.baseFee`


### PR DESCRIPTION
The `txSet` components have to be non-empty or otherwise it's possible to build tx sets that contain the same transactions