### PR TITLE
CAP-0051:: fix max object count

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -36,7 +36,7 @@ There are a few properties and conventions that apply generally to all host func
 #### Exception safety
 Execution of the host function should never cause an exception in the host environment. If the execution fails for any reason, the host will emit a trap to the VM to stop execution immediately and abort the underlying transaction. Here are a few general conditions resulting in a trap:
 1. The guest runs out of gas. Resource accounting and gas fee calculation will be discussed later.
-2. Trying to create new host objects when there’s no slots left. Total number of host objects cannot exceed `UINT32_MAX`.
+2. Trying to create new host objects when there’s no slots left. Total number of host objects cannot exceed `UINT32_MAX+1`.
 3. A host object handle does not correspond to the intended host object type. 
 4. Invalid reference to a host object is provided.
 


### PR DESCRIPTION
The max object handle is `UINT32_MAX`, which means the max number of host objects is `UINT32_MAX+1`