### PR TITLE
SEP-12: Add callback signature

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -476,7 +476,7 @@ Anchor has no information on the customer | `404 Not Found`
 Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
 Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. 
-The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get) with an additional field `timestamp` set to the current timestamp at the time the Anchor issue the POST request. This is used to assure the freshness of the request and to prevent this request to be replay in the future. Additionally the Anchor will provide a base64 signature of the POST request payload in the HTTP Header `X-Stellar-Signature`.
+The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get) with an additional field `timestamp` set to the current timestamp at the time the Anchor issue the POST request. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. Additionally the Anchor will provide a base64 signature of the POST request payload in the HTTP Header `X-Stellar-Signature`.
 The signature is computed using the Stellar private key of the anchor used in the [SEP-10](sep-0010.md) authentication.
 
 * It's the wallet's responsibility to verify the signature using the corresponding Stellar public key provided in the Anchor [`stellar.toml`](sep-0001.md).

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -477,9 +477,9 @@ Allow the wallet to provide a callback URL to the anchor. The provided callback 
 
 Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. 
 The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get) with an additional field `timestamp` set to the current timestamp at the time the Anchor issue the POST request. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. Additionally the Anchor will provide a base64 signature of the POST request payload in the HTTP Header `X-Stellar-Signature`.
-The signature is computed using the Stellar private key of the anchor used in the [SEP-10](sep-0010.md) authentication.
+The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
 
-* It's the wallet's responsibility to verify the signature using the corresponding Stellar public key provided in the Anchor [`stellar.toml`](sep-0001.md).
+* It's the wallet's responsibility to verify the signature using the corresponding Stellar `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
 * It's the wallet's responsibility to verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds.
 * It's the wallet's responsibility to send a working callback URL to the anchor.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -475,7 +475,8 @@ Anchor has no information on the customer | `404 Not Found`
 
 Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
-Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. 
+Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get).
+Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
 
 ### PUT Request
 
@@ -505,24 +506,18 @@ Name | Type | Description
 POST [url from PUT request]
 ```
 
-Name | Type | Description
----- | ---- | -----------
-`id` | `string` | The ID of the registered customer.
-`account` | `G...` or `M...` string | Account of the regiestered customer
-`memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer.
-`memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
-`type` | `string` | (optional) the type of action the customer is being KYCd for. See the [Type Specification](#type-specification) below.
-`status` | `string` | One of the values described in [Provided Field Statuses](#provided-field-statuses)
+See [`GET /customer reponse`](#response) for the POST request fields.
+
 
 In order to validate the integrity and provenance of the request, the Anchor MUST include a signature in an additional HTTP Header `X-Stellar-Signature`.
-This Header MUST follow the specification: `X-Stellar-Signature: t=<timestamtp>, h=<host>, s=<base64 signature>` where:
+This Header MUST follow the specification: `X-Stellar-Signature: t=<timestamp>, s=<base64 signature>` where:
 * __timestamp__ is the current timestamp at the time the callback is sent. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. 
-* __host__ is the host the callback is being sent to. The host will be part of the signature. This is used to prevent malicious wallet to relay the request to another wallet
-* __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
+* __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md). Note that the timestamp and the HTTP Header Host will be part of the signature to prevent replay and relay attacks.
 
 It is the wallet's responsability to:
 * Verify the signature using the corresponding Stellar `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
-* Verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds.
+* Verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds (1 or 2 minute(s) maximum).
+* Verify that the callback is not being relayed by validating that the HTTP Header __Host__ is equal to the Wallet Host.
 * Send a working callback URL to the anchor.
 
 ### VERIFY signature
@@ -530,40 +525,32 @@ It is the wallet's responsability to:
 * Check that callback request has `X-Stellar-Signature` header
 * Parse the header and extract:
   * Key `t`: __timestamp__
-  * Key `h`: __host__
   * Key `s`: __base64 signature__
-* Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (2-5)
+* Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (1-2 minute(s) max)
+* Extract the HTTP Header __Host__, validate that it is equal to the Wallet Host
 * Extract the __body__ of the request
 * Base64 decode the __base64 signature__ to get the __signature__
 * Prepare the payload to verify the signature:
   * The __timestamp__ (as a string)
   * The character `.`
-  * The __host__
+  * The __Host__
   * The character `.`
-  * The body
+  * The __body__
 * Verify the signature using the correct `SIGNING_KEY`
 
 ### COMPUTE signature
 
-* Prepare the callback request body
-  * `id`
-  * `account`
-  * `memo` (optional)
-  * `memo_type` (optional)
-  * `type` (optional)
-  * `status`
+* Prepare the callback [request body](#response)
 * Prepare the payload to sign:
   * Current timestamp (as a string)
   * The character `.`
-  * The wallet host to send the callback request to
+  * The wallet Host to send the callback request to
   * The character `.`
   * The callback request body
 * Compute the signature using the Anchor private seed
 * Base64 encode the signature
 * Build the `X-Stellar-Signature` header:
-  * `X-Stellar-Signature: t=<current timestamp>, h=<wallet host>, s=<base64 encoded signature>`
-
-Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
+  * `X-Stellar-Signature: t=<current timestamp>, s=<base64 encoded signature>`
 
 ## Customer Files
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -511,7 +511,7 @@ See [`GET /customer reponse`](#response) for the POST request fields.
 
 In order to validate the integrity and provenance of the request, the Anchor MUST include a signature in an additional HTTP Header `X-Stellar-Signature`.
 This Header MUST follow the specification: `X-Stellar-Signature: t=<timestamp>, s=<base64 signature>` where:
-* __timestamp__ is the current timestamp at the time the callback is sent. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. 
+* __timestamp__ is the current Unix timestamp (number of seconds since epoch) at the time the callback is sent. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. 
 * __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md). Note that the timestamp and the HTTP Header Host will be part of the signature to prevent replay and relay attacks.
 
 It is the wallet's responsability to:

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -547,7 +547,7 @@ It is the wallet's responsability to:
   * The wallet Host to send the callback request to
   * The character `.`
   * The callback request body
-* Compute the signature using the Anchor private seed
+* Sign the payload '<timestamp>.<host>.<body>' using the Anchor private key
 * Base64 encode the signature
 * Build the `X-Stellar-Signature` header:
   * `X-Stellar-Signature: t=<current timestamp>, s=<base64 encoded signature>`

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -475,9 +475,107 @@ Anchor has no information on the customer | `404 Not Found`
 
 Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
-Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get).
+Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. 
+The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get) with an additional field `timestamp` set to the current timestamp at the time the Anchor issue the POST request. This is used to assure the freshness of the request and to prevent this request to be replay in the future. Additionally the Anchor will provide a base64 signature of the POST request payload in the HTTP Header `X-Stellar-Signature`.
+The signature is computed using the Stellar private key of the anchor used in the [SEP-10](sep-0010.md) authentication.
 
-It's the wallet's responsibility to send a working callback URL to the anchor.
+* It's the wallet's responsibility to verify the signature using the corresponding Stellar public key provided in the Anchor [`stellar.toml`](sep-0001.md).
+* It's the wallet's responsibility to verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds.
+* It's the wallet's responsibility to send a working callback URL to the anchor.
+
+Below is non production code to demonstrate signature and verification of the callback.
+```go
+import (
+	"bytes"
+	b64 "encoding/base64"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/stellar/go/keypair"
+)
+
+var signatureHttpHeader = "X-Stellar-Signature"
+var timeThreshold = 10
+
+// VERIFY
+func verify(anchorPublicKey *keypair, req *http.Request) error {
+	if signatures, ok := req.Header[signatureHttpHeader]; ok {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		bodyMap := map[string]string{}
+		err = json.Unmarshal(body, &bodyMap)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if reqTimestamp, ok := bodyMap["timestamp"]; ok {
+			curTimestampInt := time.Now().Unix()
+			reqTimestampInt, err := strconv.ParseInt(reqTimestamp, 0, 64)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if curTimestampInt-reqTimestampInt > int64(timeThreshold) {
+				log.Fatal("Error request freshness validation")
+			}
+		} else {
+			log.Fatal("No timestmap in the request")
+		}
+		signatureb64 := signatures[0]
+		signature, err := b64.StdEncoding.DecodeString(signatureb64)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = publicKey.Verify(body, signature)
+		if err != nil {
+			log.Fatal("Signature verification failed")
+		} else {
+			log.Println("Signature OK")
+		}
+	} else {
+		log.Fatal("Cannot find signature in Header: ", req.Header)
+	}
+}
+
+// SIGN
+func sign(callbackUrl string, seed string) {
+	var values = map[string]string{"id": "james", "status": "ACCEPTED"}
+	values["timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
+
+	json_data, err := json.Marshal(values)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body := json_data
+	
+	key, err := keypair.Parse(seed)
+	if err != nil {
+		log.Fatal(err)
+	}
+	signature, err := key.Sign(body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	signatureb64 := b64.StdEncoding.EncodeToString(signature)
+	req, err := http.NewRequest("POST", callbackUrl, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(signatureHttpHeader, signatureb64)
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(string(bodyBytes))
+}
+```
 
 Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2021-08-17
-Version 1.8.0
+Updated: 2022-06-21
+Version 1.9.0
 ```
 
 ## Abstract
@@ -715,3 +715,7 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 * Flutter SDK: https://github.com/Soneso/stellar_flutter_sdk/blob/master/documentation/sdk_examples/sep-0012-kyc.md
 * PHP SDK: https://github.com/Soneso/stellar-php-sdk/blob/main/examples/sep-0012-kyc.md
+
+## Changelog
+
+* `v1.9.0`: Added signature requirement for the [`callback`](#customer-callback-put)

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -476,110 +476,8 @@ Anchor has no information on the customer | `404 Not Found`
 Allow the wallet to provide a callback URL to the anchor. The provided callback URL will replace (and supercede) any previously-set callback URL for this account.
 
 Whenever the user's `status` field changes, the anchor will issue a POST request to the callback URL. 
-The payload of the POST request will be the same as the response of [`GET /customer`](#customer-get) with an additional field `timestamp` set to the current timestamp at the time the Anchor issue the POST request. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. Additionally the Anchor will provide a base64 signature of the POST request payload in the HTTP Header `X-Stellar-Signature`.
-The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
 
-* It's the wallet's responsibility to verify the signature using the corresponding Stellar `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
-* It's the wallet's responsibility to verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds.
-* It's the wallet's responsibility to send a working callback URL to the anchor.
-
-Below is non production code to demonstrate signature and verification of the callback.
-```go
-import (
-	"bytes"
-	b64 "encoding/base64"
-	"encoding/json"
-	"log"
-	"net/http"
-	"strconv"
-	"time"
-
-	"github.com/stellar/go/keypair"
-)
-
-var signatureHttpHeader = "X-Stellar-Signature"
-var timeThreshold = 10
-
-// VERIFY
-func verify(anchorPublicKey *keypair, req *http.Request) error {
-	if signatures, ok := req.Header[signatureHttpHeader]; ok {
-		body, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			log.Fatal(err)
-		}
-		bodyMap := map[string]string{}
-		err = json.Unmarshal(body, &bodyMap)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if reqTimestamp, ok := bodyMap["timestamp"]; ok {
-			curTimestampInt := time.Now().Unix()
-			reqTimestampInt, err := strconv.ParseInt(reqTimestamp, 0, 64)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if curTimestampInt-reqTimestampInt > int64(timeThreshold) {
-				log.Fatal("Error request freshness validation")
-			}
-		} else {
-			log.Fatal("No timestmap in the request")
-		}
-		signatureb64 := signatures[0]
-		signature, err := b64.StdEncoding.DecodeString(signatureb64)
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = publicKey.Verify(body, signature)
-		if err != nil {
-			log.Fatal("Signature verification failed")
-		} else {
-			log.Println("Signature OK")
-		}
-	} else {
-		log.Fatal("Cannot find signature in Header: ", req.Header)
-	}
-}
-
-// SIGN
-func sign(callbackUrl string, seed string) {
-	var values = map[string]string{"id": "james", "status": "ACCEPTED"}
-	values["timestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
-
-	json_data, err := json.Marshal(values)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	body := json_data
-	
-	key, err := keypair.Parse(seed)
-	if err != nil {
-		log.Fatal(err)
-	}
-	signature, err := key.Sign(body)
-	if err != nil {
-		log.Fatal(err)
-	}
-	signatureb64 := b64.StdEncoding.EncodeToString(signature)
-	req, err := http.NewRequest("POST", callbackUrl, bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(signatureHttpHeader, signatureb64)
-
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		log.Fatal(err)
-	}
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Println(string(bodyBytes))
-}
-```
-
-Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
-
-### Request
+### PUT Request
 
 ```
 PUT [KYC_SERVER || TRANSFER_SERVER]/customer/callback
@@ -600,6 +498,72 @@ Name | Type | Description
 | Success                                   | `200 OK`           |
 | Client not authenticated properly         | `401 Unauthorized` |
 | Anchor has no information on the customer | `404 Not Found`    |
+
+### Callback POST Request
+
+```
+POST [url from PUT request]
+```
+
+Name | Type | Description
+---- | ---- | -----------
+`id` | `string` | The ID of the registered customer.
+`account` | `G...` or `M...` string | Account of the regiestered customer
+`memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer.
+`memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
+`type` | `string` | (optional) the type of action the customer is being KYCd for. See the [Type Specification](#type-specification) below.
+`status` | `string` | One of the values described in [Provided Field Statuses](#provided-field-statuses)
+
+In order to validate the integrity and provenance of the request, the Anchor MUST include a signature in an additional HTTP Header `X-Stellar-Signature`.
+This Header MUST follow the specification: `X-Stellar-Signature: t=<timestamtp>, h=<host>, s=<base64 signature>` where:
+* __timestamp__ is the current timestamp at the time the callback is sent. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. 
+* __host__ is the host the callback is being sent to. The host will be part of the signature. This is used to prevent malicious wallet to relay the request to another wallet
+* __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
+
+It is the wallet's responsability to:
+* Verify the signature using the corresponding Stellar `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
+* Verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds.
+* Send a working callback URL to the anchor.
+
+### VERIFY signature
+
+* Check that callback request has `X-Stellar-Signature` header
+* Parse the header and extract:
+  * Key `t`: __timestamp__
+  * Key `h`: __host__
+  * Key `s`: __base64 signature__
+* Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (2-5)
+* Extract the __body__ of the request
+* Base64 decode the __base64 signature__ to get the __signature__
+* Prepare the payload to verify the signature:
+  * The __timestamp__ (as a string)
+  * The character `.`
+  * The __host__
+  * The character `.`
+  * The body
+* Verify the signature using the correct `SIGNING_KEY`
+
+### COMPUTE signature
+
+* Prepare the callback request body
+  * `id`
+  * `account`
+  * `memo` (optional)
+  * `memo_type` (optional)
+  * `type` (optional)
+  * `status`
+* Prepare the payload to sign:
+  * Current timestamp (as a string)
+  * The character `.`
+  * The wallet host to send the callback request to
+  * The character `.`
+  * The callback request body
+* Compute the signature using the Anchor private seed
+* Base64 encode the signature
+* Build the `X-Stellar-Signature` header:
+  * `X-Stellar-Signature: t=<current timestamp>, h=<wallet host>, s=<base64 encoded signature>`
+
+Anchors will submit POST requests until the user's status changes to `ACCEPTED` or `REJECTED`. If a wallet needs to watch a user's KYC status after that, it will need to set a callback again.
 
 ## Customer Files
 


### PR DESCRIPTION
Proposed changes for the callback status:
* Add **timestamp** field to ensure freshness of the call
* Add `X-Stellar-Signature` HTTP header: Base64 signature of the body. The signature is computed using the Anchor Stellar private key and verified using the corresponding public key