### PR TITLE
Fix bug in CAP-0051 meta change

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -346,16 +346,15 @@ func $verify_sig_ed25519(param $obj_bin i64) (param $obj_pk i64) (param $obj_sig
 This CAP makes a change to `TransactionMeta` and `TransactionResult` that will allow
 a user to cryptographically verify anything in `TransactionMetaV3`.
 `TransactionMetaV3` will store separate SHA256 hashes for ledger entry changes and
-contract logs, and the hash of those hashes will be stored in `TransactionResults`
-new extension, `TransactionResultExtensionV1`.
+contract logs, and the hash of those hashes will be stored in `TransactionResultPairV2`.
 
 How can this be used? The `LedgerHeader` contains the hash of the
-`TransactionResultSet`, so the user will first gather all results from the desired
+`TransactionResultSetV2`, so the user will first gather all results from the desired
 ledger, hash them, and verify that the hash matches what's in the `LedgerHeader`.
-With `TransactionResultSet` verified, the user can then find the `TransactionMetaV3`
+With `TransactionResultSetV2` verified, the user can then find the `TransactionMetaV3`
 for the transaction they're interested in, hash just contract logs, combine
 that hash with the other hashes in `TransactionMetaV3` and then verify it against
-the hash stored in `TransactionResultExtensionV1`.
+the hash stored in `TransactionResultPairV2`.
 
 #### Host functions
 ```rust
@@ -371,8 +370,14 @@ func $system_log(param $val i64) (result i64)
 This CAP also removes the `TransactionResult` from the archives by using
 `TransactionHistoryResultEntryV2`. Instead, the `TransactionResult` will be
 stored in `TransactionMetaV3`, while the hash of `TransactionResult` will be
-stored in `TransactionMetaV3::hashes`. With this change, the archives will take
-less space.
+stored in `TransactionMetaV3::hashes`. With this change, the archives will take less
+space, but it does mean that the results will need to be be pulled from the
+meta. Cryptographic verification would work just like contract logs describe
+above, except you would match against the `TransactionResult` hash stored in
+`TransactionMetaV3::hashes`.
+
+`LedgerHeader::txSetResultHash` will also be updated to store the hash of
+`TransactionResultSetV2`.
 
 TODO: Does this work with InnerTransactionResultPair?
 
@@ -447,7 +452,7 @@ index d299068e..c8d50593 100644
 #### XDR for logs
 ```
 diff --git a/src/protocol-next/xdr/Stellar-ledger.x b/src/protocol-next/xdr/Stellar-ledger.x
-index 49d1c3c77..6a8ccc1e6 100644
+index 49d1c3c77..4bd09e893 100644
 --- a/src/protocol-next/xdr/Stellar-ledger.x
 +++ b/src/protocol-next/xdr/Stellar-ledger.x
 @@ -237,6 +237,32 @@ struct TransactionHistoryResultEntry
@@ -457,14 +462,14 @@ index 49d1c3c77..6a8ccc1e6 100644
 +struct TransactionResultPairV2
 +{
 +    Hash transactionHash;
-+    Hash transactionResultHash;
++    Hash hashOfMetaHashes; // hash of hashes in TransactionMetaV3
++                           // TransactionResult is in the meta
 +};
 +
 +struct TransactionResultSetV2
 +{
 +    TransactionResultPairV2 results<>;
 +};
-+
 +
 +struct TransactionHistoryResultEntryV2
 +{
@@ -529,48 +534,6 @@ index 49d1c3c77..6a8ccc1e6 100644
  };
  
  // This struct groups together changes on a per transaction basis
-diff --git a/src/protocol-next/xdr/Stellar-transaction.x b/src/protocol-next/xdr/Stellar-transaction.x
-index 7e915593e..97e94fc79 100644
---- a/src/protocol-next/xdr/Stellar-transaction.x
-+++ b/src/protocol-next/xdr/Stellar-transaction.x
-@@ -1742,6 +1742,19 @@ enum TransactionResultCode
-     txMALFORMED = -16 // precondition is invalid
- };
- 
-+struct TransactionResultExtensionV1
-+{
-+    // hash of hashes in TransactionMetaV3
-+    Hash hashofHashes;
-+
-+    union switch (int v)
-+    {
-+    case 0:
-+        void;
-+    }
-+    ext;
-+};
-+
- // InnerTransactionResult must be binary compatible with TransactionResult
- // because it is be used to represent the result of a Transaction.
- struct InnerTransactionResult
-@@ -1779,6 +1792,8 @@ struct InnerTransactionResult
-     {
-     case 0:
-         void;
-+    case 1:
-+        TransactionResultExtensionV1 v1;
-     }
-     ext;
- };
-@@ -1825,6 +1840,8 @@ struct TransactionResult
-     {
-     case 0:
-         void;
-+    case 1:
-+        TransactionResultExtensionV1 v1;
-     }
-     ext;
- };
 ```
 
 ### New host object types


### PR DESCRIPTION
The current iteration has a circular dependency of hashes (hash of `TransactionResult` is stored in the meta, but `TransactionResult` stores a hash of all the hashes in the meta). This PR removes `TransactionResultExtensionV1` and instead stores the hash of the meta hashes in a new `TransactionResultPairV2`.