### PR TITLE
SEP-12: Do not use Host HTTP header

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -7,7 +7,7 @@ Author: Interstellar
 Status: Active
 Created: 2018-09-11
 Updated: 2022-06-21
-Version 1.9.0
+Version 1.9.1
 ```
 
 ## Abstract
@@ -526,13 +526,13 @@ It is the wallet's responsability to:
   * Key `t`: __timestamp__
   * Key `s`: __base64 signature__
 * Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (1-2 minute(s) max)
-* The hostname hosting the server where the wallet receives the callback is labeled as __Host__
+* The hostname hosting the server where the wallet receives the callback is labeled as __host__
 * Extract the __body__ of the request
 * Base64 decode the __base64 signature__ to get the __signature__
 * Prepare the payload to verify the signature:
   * The __timestamp__ (as a string)
   * The character `.`
-  * The __Host__
+  * The __host__
   * The character `.`
   * The __body__
 * Verify the signature using the correct `SIGNING_KEY`
@@ -543,10 +543,10 @@ It is the wallet's responsability to:
 * Prepare the payload to sign:
   * Current timestamp (as a string)
   * The character `.`
-  * The wallet Host to send the callback request to
+  * The wallet host to send the callback request to
   * The character `.`
   * The callback request body
-* Sign the payload '<timestamp>.<Host>.<body>' using the Anchor private key
+* Sign the payload '<timestamp>.<host>.<body>' using the Anchor private key
 * Base64 encode the signature
 * Build the `X-Stellar-Signature` header:
   * `X-Stellar-Signature: t=<current timestamp>, s=<base64 encoded signature>`
@@ -669,3 +669,4 @@ All responses should return `200 OK`. If no files are found for the identifer us
 ## Changelog
 
 * `v1.9.0`: Added signature requirement for the [`callback`](#customer-callback-put)
+* `v1.9.1`: Callback signature: using expected host instead of HTTP Header to validate signature

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -512,12 +512,11 @@ See [`GET /customer reponse`](#response) for the POST request fields.
 In order to validate the integrity and provenance of the request, the Anchor MUST include a signature in an additional HTTP Header `X-Stellar-Signature`.
 This Header MUST follow the specification: `X-Stellar-Signature: t=<timestamp>, s=<base64 signature>` where:
 * __timestamp__ is the current Unix timestamp (number of seconds since epoch) at the time the callback is sent. This is used to assure the freshness of the request and to prevent this request to be replayed in the future. 
-* __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md). Note that the timestamp and the HTTP Header Host will be part of the signature to prevent replay and relay attacks.
+* __base64 signature__ is the base64 encoding of the request signature. We explain below how to compute and verify this signature. The signature is computed using the Stellar private key linked to the `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md). Note that the timestamp and the Wallet hostname will be part of the signature to prevent replay and relay attacks.
 
 It is the wallet's responsability to:
 * Verify the signature using the corresponding Stellar `SIGNING_KEY` field of the anchor's [`stellar.toml`](sep-0001.md).
 * Verify the freshness of the request by comparing the `timestamp` in the request with the current timestamp at the time of the reception and discard every request above a threshold of few seconds (1 or 2 minute(s) maximum).
-* Verify that the callback is not being relayed by validating that the HTTP Header __Host__ is equal to the Wallet Host.
 * Send a working callback URL to the anchor.
 
 ### VERIFY signature
@@ -527,7 +526,7 @@ It is the wallet's responsability to:
   * Key `t`: __timestamp__
   * Key `s`: __base64 signature__
 * Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (1-2 minute(s) max)
-* Extract the HTTP Header __Host__, validate that it is equal to the Wallet Host
+* The hostname hosting the server where the wallet receives the callback is labeled as __Host__
 * Extract the __body__ of the request
 * Base64 decode the __base64 signature__ to get the __signature__
 * Prepare the payload to verify the signature:
@@ -547,7 +546,7 @@ It is the wallet's responsability to:
   * The wallet Host to send the callback request to
   * The character `.`
   * The callback request body
-* Sign the payload '<timestamp>.<host>.<body>' using the Anchor private key
+* Sign the payload '<timestamp>.<Host>.<body>' using the Anchor private key
 * Base64 encode the signature
 * Build the `X-Stellar-Signature` header:
   * `X-Stellar-Signature: t=<current timestamp>, s=<base64 encoded signature>`

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,7 +6,7 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2022-06-21
+Updated: 2022-07-07
 Version 1.9.1
 ```
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -526,13 +526,12 @@ It is the wallet's responsability to:
   * Key `t`: __timestamp__
   * Key `s`: __base64 signature__
 * Verify the request freshness: _current timestamp_ - __timestamp__ < few seconds (1-2 minute(s) max)
-* The hostname hosting the server where the wallet receives the callback is labeled as __host__
 * Extract the __body__ of the request
 * Base64 decode the __base64 signature__ to get the __signature__
 * Prepare the payload to verify the signature:
   * The __timestamp__ (as a string)
   * The character `.`
-  * The __host__
+  * The wallet host to send the callback request to
   * The character `.`
   * The __body__
 * Verify the signature using the correct `SIGNING_KEY`


### PR DESCRIPTION
It is unnecessary to use the Host HTTP header to verify the signature.
Using the expected host the callback should be sent to is enough to validate the signature.