### PR TITLE
CAP-51: Add goal to provide ways around trapping host fns

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -465,6 +465,8 @@ There are three main reasons for biasing error handling to generate traps in the
 2. Trapping on the host in most error cases ensures errors are handled (by escalation to a transaction abort), whereas many functions that have "error code returns" can have those errors ignored, which makes contracts more likely to be buggy. 
 3. There is no easy way to communicate a structured error value to the user (such as a `result` or `option`) type. We would wind up either allocating an object to wrap every result from every function or commit one bit in the host value to denote a `None` value (analogous to Rust’s `std::option`). Both of these approaches introduce more complexity and are error prone. 
 
+There is also a flexibility cost to traps. Contract developers have no opportunity to write code that is allowed to fail. For this reason, it is a goal that host functions that trap should provide a way to preemptively determine if a trap would occur if called. For example, the `vec_get` function will trap if the index argument is greater than the length of the vector, but a contract developer can use the `vec_len` function to check if this would occur before calling `vec_get`.
+
 ### `SCStatus`-Returning Host Functions
 `SCStatus` is an `SCVal` case designed for conveying function-calling status (such as error code) between the host and the guest. The `SCStatus` cases will be expanded to include additional types as well as concrete host function error codes in future iterations of this CAP. 
 


### PR DESCRIPTION
### What
Add a goal for trapping host fns to always provide a way to preemptively avoid the trap to developers.

### Why
It is important for flexibility, otherwise developers will not be able to write code that is allowed to fail. As an example why this is required, the `verify_sig_ed25519` fn traps and a developer has no way to avoid that trap if they need to check multiple signatures where not all verifications need to succeed. Related conversation: https://discord.com/channels/897514728459468821/993941320496316516.

cc @jonjove @sisuresh @graydon 