### PR TITLE
CAP-51: update binary memcpy fns

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -264,7 +264,7 @@ func $deserialize_from_binary(param $obj_bin i64, param $type u64) (result i64)
 /// Traps if either the binary object or the linear memory doesn't have enough bytes.
 func $binary_copy_to_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
 
-/// Copies a segment of the linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accommodate the new bytes. 
+/// Copies a segment of the linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary may grow in size to accommodate the new bytes. 
 /// Returns handle to the new binary array.
 /// Traps if the linear memory doesn't have enough bytes.
 func $binary_copy_from_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -272,7 +272,7 @@ func $binary_memcpy_from_guest(param $obj_bin i64) (param $offset u64) (param $p
 /// Construct an empty binary array, returns its handle
 func $binary_new() (result i64)
 
-/// Constructs a new binary array initialized with bytes copied from a guest linear memory slice specified at position $pos with length $len. 
+/// Constructs a new binary array and initializes it with bytes copied from a guest linear memory slice specified at position $pos with length $len. 
 /// Returns handle to the new binary array.
 func $binary_new_from_memcpy(param $pos u64) (param $len u64) (result i64)
 

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -260,17 +260,21 @@ func $serialize_to_binary(param $val i64) (result i64)
 /// Traps if the deserialization fails for any reason.
 func $deserialize_from_binary(param $obj_bin i64, param $type u64) (result i64)
 
-/// Given a host binary object $obj_bin, copy a segment of its memory specified at $offset with length $len into guest linear memory at $pos. 
+/// Given a host binary object $obj_bin, copies a segment of its memory specified at $offset with length $len into the guest linear memory at $pos. 
 /// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
-func $binary_copy_to_guest_mem(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
+func $binary_memcpy_to_guest(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
 
-/// Copy a segment of the guest's linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. 
+/// Copies a segment of the guest linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accomadate the new bytes. 
 /// Returns handle to the new binary array.
-/// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
-func $binary_copy_from_guest_mem(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
+/// Traps if the guest linear memory doesn't have enough bytes.
+func $binary_memcpy_from_guest(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
 
 /// Construct an empty binary array, returns its handle
 func $binary_new() (result i64)
+
+/// Constructs a new binary array initialized with bytes copied from a guest linear memory slice specified at position $pos with length $len. 
+/// Returns handle to the new binary array.
+func $binary_new_from_memcpy(param $pos u64) (param $len u64) (result i64)
 
 /// Replaces an element at index $idx of existing binary $obj_bin with value $val.
 /// Returns handle to the new binary array.

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -262,19 +262,15 @@ func $deserialize_from_binary(param $obj_bin i64, param $type u64) (result i64)
 
 /// Given a host binary object $obj_bin, copies a segment of its memory specified at $offset with length $len into the guest linear memory at $pos. 
 /// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
-func $binary_memcpy_to_guest(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
+func $binary_copy_to_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
 
 /// Copies a segment of the guest linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accomadate the new bytes. 
 /// Returns handle to the new binary array.
 /// Traps if the guest linear memory doesn't have enough bytes.
-func $binary_memcpy_from_guest(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
+func $binary_copy_from_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
 
 /// Construct an empty binary array, returns its handle
 func $binary_new() (result i64)
-
-/// Constructs a new binary array and initializes it with bytes copied from a guest linear memory slice specified at position $pos with length $len. 
-/// Returns handle to the new binary array.
-func $binary_new_from_memcpy(param $pos u64) (param $len u64) (result i64)
 
 /// Replaces an element at index $idx of existing binary $obj_bin with value $val.
 /// Returns handle to the new binary array.

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -260,14 +260,18 @@ func $serialize_to_binary(param $val i64) (result i64)
 /// Traps if the deserialization fails for any reason.
 func $deserialize_from_binary(param $obj_bin i64, param $type u64) (result i64)
 
-/// Given a host binary object $obj_bin, copies a segment of its memory specified at $offset with length $len into the guest linear memory at $pos. 
-/// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
+/// Given a host binary object $obj_bin, copies a segment of its memory specified at $offset with length $len into the linear memory at $pos. 
+/// Traps if either the binary object or the linear memory doesn't have enough bytes.
 func $binary_copy_to_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
 
-/// Copies a segment of the guest linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accommodate the new bytes. 
+/// Copies a segment of the linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accommodate the new bytes. 
 /// Returns handle to the new binary array.
-/// Traps if the guest linear memory doesn't have enough bytes.
+/// Traps if the linear memory doesn't have enough bytes.
 func $binary_copy_from_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
+
+/// Constructs a new binary array initialized with bytes copied from a linear memory slice specified at position $pos with length $len. 
+/// Returns handle to the new binary array.
+func $binary_new_from_linear_memory(param $pos u64) (param $len u64) (result i64)
 
 /// Construct an empty binary array, returns its handle
 func $binary_new() (result i64)

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -264,7 +264,7 @@ func $deserialize_from_binary(param $obj_bin i64, param $type u64) (result i64)
 /// Traps if either the binary object or the guest linear memory doesn't have enough bytes.
 func $binary_copy_to_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64)
 
-/// Copies a segment of the guest linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accomadate the new bytes. 
+/// Copies a segment of the guest linear memory specified at position $pos with length $len, into a host binary object $obj_bin at $offset. The host binary binary may grow in size to accommodate the new bytes. 
 /// Returns handle to the new binary array.
 /// Traps if the guest linear memory doesn't have enough bytes.
 func $binary_copy_from_linear_memory(param $obj_bin i64) (param $offset u64) (param $pos u64) (param $len u64) (result i64)
@@ -448,7 +448,7 @@ The guest-host split allows common smart contract operations and computational h
 - **Easy to implement**: must be reasonably straightforward to implement. This is especially relevant for the first-version of the prototype.
 
 ### Additional functions/host objects may be included
-The list of host functions presented above is by no means an exhaustive list of host functions that are officially determined. Rather It is to be interpreted as an initial set of recommendations based on the four criterias listed above, to serve as a starting point to be iterated on. Ultimately, the official list will be determined by the requirements and needs of the stellar ecosystem. For example, the cryptographic section currently only contains two functions which are the primitives (SHA256, ED25519) usd by the stellar core today. Ultimately it will be driven by the smart contract applications and the cryptographic primitives that are most vital to facilitating their development. 
+The list of host functions presented above is by no means an exhaustive list of host functions that are officially determined. Rather It is to be interpreted as an initial set of recommendations based on the four criteria listed above, to serve as a starting point to be iterated on. Ultimately, the official list will be determined by the requirements and needs of the stellar ecosystem. For example, the cryptographic section currently only contains two functions which are the primitives (SHA256, ED25519) usd by the stellar core today. Ultimately it will be driven by the smart contract applications and the cryptographic primitives that are most vital to facilitating their development. 
 
 Besides cryptographic operations, big rational numbers and string operations are two additional sections we may consider to include depending on feedback from the developer community. Additional host objects may be added accordingly as a consequence. 
 


### PR DESCRIPTION
- Update their names and descriptions.
- Add a `binary_new_from_memcpy` which constructs a binary object and initializes its data in one op via `memcpy`. 
I will add more `memcpy` "helper" functions (as @graydon suggested) in follow-ups. 