### PR TITLE
CAP-0056 - remove indexes and fix ledger close meta

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -465,6 +465,8 @@ There are three main reasons for biasing error handling to generate traps in the
 2. Trapping on the host in most error cases ensures errors are handled (by escalation to a transaction abort), whereas many functions that have "error code returns" can have those errors ignored, which makes contracts more likely to be buggy. 
 3. There is no easy way to communicate a structured error value to the user (such as a `result` or `option`) type. We would wind up either allocating an object to wrap every result from every function or commit one bit in the host value to denote a `None` value (analogous to Rust’s `std::option`). Both of these approaches introduce more complexity and are error prone. 
 
+There is also a flexibility cost to traps. Contract developers have no opportunity to write code that is allowed to fail. For this reason, it is a goal that host functions that trap should provide a way to preemptively determine if a trap would occur if called. For example, the `vec_get` function will trap if the index argument is greater than the length of the vector, but a contract developer can use the `vec_len` function to check if this would occur before calling `vec_get`.
+
 ### `SCStatus`-Returning Host Functions
 `SCStatus` is an `SCVal` case designed for conveying function-calling status (such as error code) between the host and the guest. The `SCStatus` cases will be expanded to include additional types as well as concrete host function error codes in future iterations of this CAP. 
 

--- a/core/cap-0056.md
+++ b/core/cap-0056.md
@@ -45,33 +45,19 @@ for the transaction they're interested in, hash just contract logs, combine
 that hash with the other hashes in `TransactionMetaV3` and then verify it against
 the hash stored in `TransactionResultPairV2`.
 
-#### log indexes
-The user can also specify indexes for a log message. These are represented by
-the `Index` XDR struct. This will allow downstream systems to more easily manage
-subscriptions to log messages. Up to five indexes are allowed. The `Index` label
-is an `SCSymbol`. The value is an `SCVal` with some
-limitations. All `SCVal` types are acceptable except for `SCO_VEC`,
-`SCO_MAP`, and `SCO_BINARY` where size of bin is greater than 64 bytes. The
-`SCO_BINARY` 64 byte limit is sufficient for hashes and ed25519 keys.
-
-Along with the indexes, downstream systems can filter and emit events
-used the contractID, logType, and/or the function called on the contract.
-
 #### Host functions
 ```rust
-/// Will save val and indexes to a list that will be returned to core so 
-/// the logs can be put into TransactionMetaV3.logs with type ContractLogType::CONTRACT_INFO.
-/// Indexes is an SCMap, where the keys must be SCSymbols, and values must not be SCO_VEC or
-/// SCO_MAP. If the value is SCO_BINARY, size of bin is limited to 64 bytes.  
-func $log(param $val i64) (param $indexes i64) (result i64)
+/// Will save val to a list that will be returned to core so the logs can be
+/// put into TransactionMetaV3.logs with type ContractLogType::CONTRACT_INFO.
+func $log(param $val i64) (result i64)
 
 /// Same as $log above but will use ContractLogType::LOG_ON_ERROR instead,
 /// and the logs will only show up in TransactionMetaV3.logs if the contract call fails.
-func $log_on_error(param $val i64) (param $indexes i64) (result i64)
+func $log_on_error(param $val i64) (result i64)
 
 /// Internal host function. Same as $log but will use ContractLogType::SYSTEM instead
 /// TODO: Should this only log on error?
-func $system_log(param $val i64) (param $indexes i64) (result i64)
+func $system_log(param $val i64) (result i64)
 ```
 
 #### Stop storing TransactionResults in archives
@@ -92,7 +78,7 @@ TODO: Does this work with InnerTransactionResultPair?
 ### XDR Changes
 ```diff mddiffcheck.base=104aab363c5c820bb17003c32f73d1431b58b32a
 diff --git a/src/protocol-next/xdr/Stellar-ledger.x b/src/protocol-next/xdr/Stellar-ledger.x
-index 49d1c3c77..7665f16bf 100644
+index 49d1c3c77..bf065dc10 100644
 --- a/src/protocol-next/xdr/Stellar-ledger.x
 +++ b/src/protocol-next/xdr/Stellar-ledger.x
 @@ -237,6 +237,32 @@ struct TransactionHistoryResultEntry
@@ -128,7 +114,7 @@ index 49d1c3c77..7665f16bf 100644
  struct LedgerHeaderHistoryEntry
  {
      Hash hash;
-@@ -321,6 +347,57 @@ struct TransactionMetaV2
+@@ -321,6 +347,43 @@ struct TransactionMetaV2
                                          // applied if any
  };
  
@@ -139,33 +125,19 @@ index 49d1c3c77..7665f16bf 100644
 +    LOG_ON_ERROR = 2
 +};
 +
-+struct Index
-+{
-+    SCSymbol label;
-+    SCVal value; //Cannot be SCO_VEC or SCO_MAP. If SCO_BINARY, size of bin is limited to 64 bytes
-+}
-+
-+enum ContractLogBodyType
-+{
-+    SCVAL_AND_INDEX = 0
-+};
-+
-+union ContractLogBody switch (ContractLogBodyType type)
-+{
-+case SCVAL_AND_INDEX:
-+    struct
-+    {
-+        Index indexes<5>;
-+        SCVal body;
-+    } SCValAndIndex;
-+}
-+
 +struct ContractLog
 +{
 +    Hash contractID;
-+    SCSymbol functionName;
 +    LogType type;
-+    ContractLogBody body;
++    SCVal body;
++
++    // reserved for future use
++    union switch (int v)
++    {
++    case 0:
++        void;
++    }
++    ext;
 +}
 +
 +struct TransactionMetaV3
@@ -186,7 +158,7 @@ index 49d1c3c77..7665f16bf 100644
  // this is the meta produced when applying transactions
  // it does not include pre-apply updates such as fees
  union TransactionMeta switch (int v)
-@@ -331,6 +408,8 @@ case 1:
+@@ -331,6 +394,8 @@ case 1:
      TransactionMetaV1 v1;
  case 2:
      TransactionMetaV2 v2;
@@ -195,6 +167,51 @@ index 49d1c3c77..7665f16bf 100644
  };
  
  // This struct groups together changes on a per transaction basis
+@@ -343,6 +408,13 @@ struct TransactionResultMeta
+     TransactionMeta txApplyProcessing;
+ };
+ 
++struct TransactionResultMetaV2
++{
++    TransactionResultPairV2 result;
++    LedgerEntryChanges feeProcessing;
++    TransactionMeta txApplyProcessing;
++};
++
+ // this represents a single upgrade that was performed as part of a ledger
+ // upgrade
+ struct UpgradeEntryMeta
+@@ -369,9 +441,30 @@ struct LedgerCloseMetaV0
+     SCPHistoryEntry scpInfo<>;
+ };
+ 
++// only difference between V0 and V1 is this uses TransactionResultMetaV2
++struct LedgerCloseMetaV1
++{
++    LedgerHeaderHistoryEntry ledgerHeader;
++    // NB: txSet is sorted in "Hash order"
++    TransactionSet txSet;
++
++    // NB: transactions are sorted in apply order here
++    // fees for all transactions are processed first
++    // followed by applying transactions
++    TransactionResultMetaV2 txProcessing<>;
++
++    // upgrades are applied last
++    UpgradeEntryMeta upgradesProcessing<>;
++
++    // other misc information attached to the ledger close
++    SCPHistoryEntry scpInfo<>;
++};
++
+ union LedgerCloseMeta switch (int v)
+ {
+ case 0:
+     LedgerCloseMetaV0 v0;
++case 1:
++    LedgerCloseMetaV1 v1;
+ };
+ }
 ```
 
 ## Design Rationale
@@ -203,10 +220,6 @@ index 49d1c3c77..7665f16bf 100644
 By removing the `TransactionResult` from the archives, the archives will take
 less space going forward. The results will still be available in thr meta, so
 there is no functionality lost here.
-
-### Contract Log Indexes
-In addition to the `SCVal` body of the contract, the user can add indexes to the
-message so downstream systems can allow logs to be queried against.
 
 ### TransactionMeta hashes
 This CAP allows for the cryptographic verification of `TransactionMetaV3` by

--- a/core/cap-0056.md
+++ b/core/cap-0056.md
@@ -78,7 +78,7 @@ TODO: Does this work with InnerTransactionResultPair?
 ### XDR Changes
 ```diff mddiffcheck.base=104aab363c5c820bb17003c32f73d1431b58b32a
 diff --git a/src/protocol-next/xdr/Stellar-ledger.x b/src/protocol-next/xdr/Stellar-ledger.x
-index 49d1c3c77..bf065dc10 100644
+index 49d1c3c77..2f5476633 100644
 --- a/src/protocol-next/xdr/Stellar-ledger.x
 +++ b/src/protocol-next/xdr/Stellar-ledger.x
 @@ -237,6 +237,32 @@ struct TransactionHistoryResultEntry
@@ -114,7 +114,7 @@ index 49d1c3c77..bf065dc10 100644
  struct LedgerHeaderHistoryEntry
  {
      Hash hash;
-@@ -321,6 +347,43 @@ struct TransactionMetaV2
+@@ -321,6 +347,39 @@ struct TransactionMetaV2
                                          // applied if any
  };
  
@@ -127,17 +127,13 @@ index 49d1c3c77..bf065dc10 100644
 +
 +struct ContractLog
 +{
++    // We can use this to add more fields, or because it
++    // is first, to change ContractLog into a union.
++    ExtensionPoint ext;
++
 +    Hash contractID;
 +    LogType type;
 +    SCVal body;
-+
-+    // reserved for future use
-+    union switch (int v)
-+    {
-+    case 0:
-+        void;
-+    }
-+    ext;
 +}
 +
 +struct TransactionMetaV3
@@ -158,7 +154,7 @@ index 49d1c3c77..bf065dc10 100644
  // this is the meta produced when applying transactions
  // it does not include pre-apply updates such as fees
  union TransactionMeta switch (int v)
-@@ -331,6 +394,8 @@ case 1:
+@@ -331,6 +390,8 @@ case 1:
      TransactionMetaV1 v1;
  case 2:
      TransactionMetaV2 v2;
@@ -167,7 +163,7 @@ index 49d1c3c77..bf065dc10 100644
  };
  
  // This struct groups together changes on a per transaction basis
-@@ -343,6 +408,13 @@ struct TransactionResultMeta
+@@ -343,6 +404,13 @@ struct TransactionResultMeta
      TransactionMeta txApplyProcessing;
  };
  
@@ -181,7 +177,7 @@ index 49d1c3c77..bf065dc10 100644
  // this represents a single upgrade that was performed as part of a ledger
  // upgrade
  struct UpgradeEntryMeta
-@@ -369,9 +441,30 @@ struct LedgerCloseMetaV0
+@@ -369,9 +437,30 @@ struct LedgerCloseMetaV0
      SCPHistoryEntry scpInfo<>;
  };
  


### PR DESCRIPTION
Based on feedback from @paulbellamy, the indexes will be removed for now since Horizon would like to provide less filters for event streams and let the user just subscribe by contractID. 