### PR TITLE
CAP-0056 - remove LOG_ON_ERROR and change logs to events

### DIFF
--- a/core/cap-0056.md
+++ b/core/cap-0056.md
@@ -2,7 +2,7 @@
 
 ```
 CAP: 0056
-Title: Smart Contract Logging
+Title: Smart Contract Events
 Working Group:
     Owner: Siddharth Suresh <@sisuresh>
     Authors:
@@ -14,50 +14,49 @@ Protocol version: TBD
 ```
 
 ## Simple Summary
-This CAP proposes an update to `TransactionMeta` along with new host functions to allow for contracts to log messages that can be consumed by downstream systems.
+This CAP proposes an update to `TransactionMeta` along with new host functions
+to allow for contracts to write date to the meta that can be consumed by
+downstream systems.
 
 ## Motivation
-Contract writers will need a way to emit information about what their specific contracts are doing. Downstream consumers of these new messages can also push these to subscribers, allowing users to listen to specific messages.
+Contract writers will need a way to emit information about what their specific
+contracts are doing. Downstream consumers of these new messages can also push
+these to subscribers, allowing users to listen to specific messages.
 
 ### Goals Alignment
 This CAP is aligned with the following Stellar Network Goals:
 * The Stellar Network should make it easy for developers of Stellar projects to create highly usable products
 
 ## Abstract
-This CAP provides host functions for contracts to log messages that will be put
+This CAP provides host functions for contracts to write messages that will be put
 into `TransactionMeta`. It provides a way to cryptographically verify the
 contents of `TransactionMeta`, and also moves `TransactionResult` into the meta
 so they stop taking space in the archives.
 
 ## Specification
 
-### Contract Logs
+### Contract Events
 This CAP makes a change to `TransactionMeta` and `TransactionResult` that will allow
 a user to cryptographically verify anything in `TransactionMetaV3`.
 `TransactionMetaV3` will store separate SHA256 hashes for ledger entry changes and
-contract logs, and the hash of those hashes will be stored in `TransactionResultPairV2`.
+contract events, and the hash of those hashes will be stored in `TransactionResultPairV2`.
 
 How can this be used? The `LedgerHeader` contains the hash of the
 `TransactionResultSetV2`, so the user will first gather all results from the desired
 ledger, hash them, and verify that the hash matches what's in the `LedgerHeader`.
 With `TransactionResultSetV2` verified, the user can then find the `TransactionMetaV3`
-for the transaction they're interested in, hash just contract logs, combine
+for the transaction they're interested in, hash just contract events, combine
 that hash with the other hashes in `TransactionMetaV3` and then verify it against
 the hash stored in `TransactionResultPairV2`.
 
 #### Host functions
 ```rust
-/// Will save val to a list that will be returned to core so the logs can be
-/// put into TransactionMetaV3.logs with type ContractLogType::CONTRACT_INFO.
-func $log(param $val i64) (result i64)
+/// Will save val to a list that will be returned to core so the val can be
+/// put into TransactionMetaV3.events with type ContractEventType::CONTRACT_INFO.
+func $event(param $val i64) (result i64)
 
-/// Same as $log above but will use ContractLogType::LOG_ON_ERROR instead,
-/// and the logs will only show up in TransactionMetaV3.logs if the contract call fails.
-func $log_on_error(param $val i64) (result i64)
-
-/// Internal host function. Same as $log but will use ContractLogType::SYSTEM instead
-/// TODO: Should this only log on error?
-func $system_log(param $val i64) (result i64)
+/// Internal host function. Same as $event but will use ContractEventType::SYSTEM instead
+func $system_event(param $val i64) (result i64)
 ```
 
 #### Stop storing TransactionResults in archives
@@ -66,7 +65,7 @@ This CAP also removes the `TransactionResult` from the archives by using
 stored in `TransactionMetaV3`, while the hash of `TransactionResult` will be
 stored in `TransactionMetaV3::hashes`. With this change, the archives will take less
 space, but it does mean that the results will need to be be pulled from the
-meta. Cryptographic verification would work just like contract logs describe
+meta. Cryptographic verification would work just like contract events described
 above, except you would match against the `TransactionResult` hash stored in
 `TransactionMetaV3::hashes`.
 
@@ -75,10 +74,13 @@ above, except you would match against the `TransactionResult` hash stored in
 
 TODO: Does this work with InnerTransactionResultPair?
 
+### TransactionMeta Normalization
+TODO
+
 ### XDR Changes
 ```diff mddiffcheck.base=104aab363c5c820bb17003c32f73d1431b58b32a
 diff --git a/src/protocol-next/xdr/Stellar-ledger.x b/src/protocol-next/xdr/Stellar-ledger.x
-index 49d1c3c77..2f5476633 100644
+index 49d1c3c77..4e24a4958 100644
 --- a/src/protocol-next/xdr/Stellar-ledger.x
 +++ b/src/protocol-next/xdr/Stellar-ledger.x
 @@ -237,6 +237,32 @@ struct TransactionHistoryResultEntry
@@ -114,27 +116,26 @@ index 49d1c3c77..2f5476633 100644
  struct LedgerHeaderHistoryEntry
  {
      Hash hash;
-@@ -321,6 +347,39 @@ struct TransactionMetaV2
+@@ -321,6 +347,38 @@ struct TransactionMetaV2
                                          // applied if any
  };
  
-+enum ContractLogType
++enum ContractEventType
 +{
 +    SYSTEM = 0,
-+    CONTRACT_INFO = 1,
-+    LOG_ON_ERROR = 2
++    CONTRACT_INFO = 1
 +};
 +
-+struct ContractLog
++struct ContractEvent
 +{
 +    // We can use this to add more fields, or because it
-+    // is first, to change ContractLog into a union.
++    // is first, to change ContractEvent into a union.
 +    ExtensionPoint ext;
 +
 +    Hash contractID;
-+    LogType type;
++    ContractEventType type;
 +    SCVal body;
-+}
++};
 +
 +struct TransactionMetaV3
 +{
@@ -143,18 +144,18 @@ index 49d1c3c77..2f5476633 100644
 +    OperationMeta operations<>;         // meta for each operation
 +    LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
 +                                        // applied if any
-+    ContractLog logs<>;                 // custom logs populated by the
++    ContractEvents events<>;            // custom events populated by the
 +                                        // contracts themselves
 +    TransactionResult txResult;
 +
 +    Hash hashes[3];                     // stores sha256(txChangesBefore, operations, txChangesAfter),
-+                                        // sha256(logs), and sha256(txResult)
++                                        // sha256(events), and sha256(txResult)
 +};
 +
  // this is the meta produced when applying transactions
  // it does not include pre-apply updates such as fees
  union TransactionMeta switch (int v)
-@@ -331,6 +390,8 @@ case 1:
+@@ -331,6 +389,8 @@ case 1:
      TransactionMetaV1 v1;
  case 2:
      TransactionMetaV2 v2;
@@ -163,7 +164,7 @@ index 49d1c3c77..2f5476633 100644
  };
  
  // This struct groups together changes on a per transaction basis
-@@ -343,6 +404,13 @@ struct TransactionResultMeta
+@@ -343,6 +403,13 @@ struct TransactionResultMeta
      TransactionMeta txApplyProcessing;
  };
  
@@ -177,7 +178,7 @@ index 49d1c3c77..2f5476633 100644
  // this represents a single upgrade that was performed as part of a ledger
  // upgrade
  struct UpgradeEntryMeta
-@@ -369,9 +437,30 @@ struct LedgerCloseMetaV0
+@@ -369,9 +436,30 @@ struct LedgerCloseMetaV0
      SCPHistoryEntry scpInfo<>;
  };
  
@@ -226,13 +227,13 @@ to hash the components they care about, and assume the other component hashes
 are authentic. If any of the component hashes are incorrect, the verification
 will fail. 
 
-### Different log types
-Each log host function uses a different log type. This gives downstream users
-another fields to query off of. In addition to that, logs from `log_on_error`
-are only emitted to the meta if the contract traps, which will make failures
-easy to debug. `system_log` is also special in that it can only be used by the
-host functions, allowing users to see "system" level logs as opposed to ones
-generated by contracts. 
+### Different event types
+Each event host function uses a different type. This gives downstream users
+another fields to query off of. In addition to that, events from `system_event`
+are also special in that it can only be used by the host functions, allowing
+users to see "system" level events as opposed to ones generated by contracts.
+For example, this can be used in the `create_contract_*` host functions to print
+out the hash of the created contract.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
1. Changing "logs" to "events" after a discussion with Nico.
2. Remove LOG_ON_ERROR.
3. Add a TODO section on TransactionMeta normalization.