### PR TITLE
SEP-6 & SEP-31: add `quote_id` field to the transaction object schema

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2022-07-11
-Version 3.13.0
+Updated: 2022-07-20
+Version 3.14.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1361,7 +1361,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
-* `v3.13.0`: Add `quote_id` to the transaction object schema. ([#?](https://github.com/stellar/stellar-protocol/pull/?))
+* `v3.13.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v3.12.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v3.11.1`: Add information about how a SEP-6 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v3.11.0`: Update instructions to enforce the Wallet needs to reach out to the `GET /transaction?id={id}` endpoint to get the payment `amount_in` before making the payment. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1045,7 +1045,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) Amount of fee charged by anchor. Should be equals to `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals to `quote.fee.asset` if a `quote_id` was used.
-`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present if the Anchor implementation is older than `v3.13.0`.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present in older implementations.
 `from` | string | (optional) Sent from address (perhaps BTC, IBAN, or bank account in the case of a deposit, Stellar address in the case of a withdrawal).
 `to` | string | (optional) Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).
 `external_extra` | string | (optional) Extra information for the external account involved. It could be a bank routing number, BIC, or store number for example.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1045,7 +1045,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) Amount of fee charged by anchor. Should be equals to `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals to `quote.fee.asset` if a `quote_id` was used.
-`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present if the Anchor implementation is older than `v3.13.0`.
 `from` | string | (optional) Sent from address (perhaps BTC, IBAN, or bank account in the case of a deposit, Stellar address in the case of a withdrawal).
 `to` | string | (optional) Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).
 `external_extra` | string | (optional) Extra information for the external account involved. It could be a bank routing number, BIC, or store number for example.

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1045,6 +1045,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) Amount of fee charged by anchor. Should be equals to `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using quotes. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals to `quote.fee.asset` if a `quote_id` was used.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request.
 `from` | string | (optional) Sent from address (perhaps BTC, IBAN, or bank account in the case of a deposit, Stellar address in the case of a withdrawal).
 `to` | string | (optional) Sent to address (perhaps BTC, IBAN, or bank account in the case of a withdrawal, Stellar address in the case of a deposit).
 `external_extra` | string | (optional) Extra information for the external account involved. It could be a bank routing number, BIC, or store number for example.
@@ -1360,6 +1361,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.13.0`: Add `quote_id` to the transaction object schema. ([#?](https://github.com/stellar/stellar-protocol/pull/?))
 * `v3.12.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v3.11.1`: Add information about how a SEP-6 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))
 * `v3.11.0`: Update instructions to enforce the Wallet needs to reach out to the `GET /transaction?id={id}` endpoint to get the payment `amount_in` before making the payment. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,8 +7,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-07-11
-Version 1.9.0
+Updated: 2022-07-20
+Version 1.10.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -522,7 +522,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered to the Receiving Client. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor. Should be equals `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals `quote.fee.asset` if a `quote_id` was used.
-`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present if the Anchor implementation is older than `v1.9.0`.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present in older implementations.
 `stellar_account_id` | string | The Receiving Anchor's Stellar account that the Sending Anchor will be making the payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -522,7 +522,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered to the Receiving Client. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor. Should be equals `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals `quote.fee.asset` if a `quote_id` was used.
-`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request. Clients should be aware though that the `quote_id` may not be present if the Anchor implementation is older than `v1.9.0`.
 `stellar_account_id` | string | The Receiving Anchor's Stellar account that the Sending Anchor will be making the payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -522,6 +522,7 @@ Name | Type | Description
 `amount_out_asset` | string | (optional) The asset delivered to the Receiving Client. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).
 `amount_fee` | string | (optional) The amount of fee charged by the Receiving Anchor. Should be equals `quote.fee.total` if a `quote_id` was used.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if `quote_id` or `destination_asset` was included in the `POST /transactions` request. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). Should be equals `quote.fee.asset` if a `quote_id` was used.
+`quote_id` | string | (optional) The ID of the quote used to create this transaction. Should be present if a `quote_id` was included in the `POST /transactions` request.
 `stellar_account_id` | string | The Receiving Anchor's Stellar account that the Sending Anchor will be making the payment to.
 `stellar_memo_type` | string | The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | The memo to attach to the Stellar payment.
@@ -832,6 +833,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
+* `v1.9.0`: Add `quote_id` to the transaction object schema. ([#?](https://github.com/stellar/stellar-protocol/pull/?))
 * `v1.8.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([#1214](https://github.com/stellar/stellar-protocol/pull/1214))
 * `v1.6.1`: Add information about how a SEP-31 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -833,7 +833,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
-* `v1.9.0`: Add `quote_id` to the transaction object schema. ([#?](https://github.com/stellar/stellar-protocol/pull/?))
+* `v1.9.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v1.8.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
 * `v1.7.0`: Add a `PUT /transactions/:id/callback` endpoint for Sending Anchors to request callback requests when a transaction's `status` value changes. ([#1214](https://github.com/stellar/stellar-protocol/pull/1214))
 * `v1.6.1`: Add information about how a SEP-31 transaction should populate the `amount_in`, `amount_out`, `amount_fee` and `amount_fee_asset` fields when a `quote_id` is used. ([#1204](https://github.com/stellar/stellar-protocol/pull/1204))


### PR DESCRIPTION
### What

Add `quote_id` field to SEP-6 and SEP-31 transaction object schema.

### Why

When a quote was used to create the transaction, it's important to be able to figure that out by looking at the transaction response.