### PR TITLE
SEP-12: make it explicit that the `account` and `memo` can be inferred from the JWT token

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,7 +6,7 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2022-07-07
+Updated: 2022-08-29
 Version 1.9.1
 ```
 
@@ -667,5 +667,6 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 ## Changelog
 
+* `v1.10.0`: Clarify that the `account` and `memo` fields should be inferred from the decoded SEP-10 JWT's `sub` value even when not provided in the request body.
 * `v1.9.1`: Callback signature: using expected host instead of HTTP Header to validate signature
 * `v1.9.0`: Added signature requirement for the [`callback`](#customer-callback-put)

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -667,5 +667,5 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 ## Changelog
 
-* `v1.9.0`: Added signature requirement for the [`callback`](#customer-callback-put)
 * `v1.9.1`: Callback signature: using expected host instead of HTTP Header to validate signature
+* `v1.9.0`: Added signature requirement for the [`callback`](#customer-callback-put)

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -7,7 +7,7 @@ Author: Interstellar
 Status: Active
 Created: 2018-09-11
 Updated: 2022-08-29
-Version 1.9.2
+Version 1.10.0
 ```
 
 ## Abstract

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -7,7 +7,7 @@ Author: Interstellar
 Status: Active
 Created: 2018-09-11
 Updated: 2022-08-29
-Version 1.9.1
+Version 1.9.2
 ```
 
 ## Abstract
@@ -98,7 +98,7 @@ GET [KYC_SERVER]/customer?id=<customer-id>&type=<customer-type>
 Name | Type | Description
 -----|------|------------
 `id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) The server should infer the account from the `sub` value in the SEP-10 JWT to identify the customer. The `account` parameter is only used for backwards compatibility, and if explicitly provided in the request body it should match the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `type` | string | (optional) the type of action the customer is being KYCd for.  See the [Type Specification](#type-specification) below.
@@ -356,7 +356,7 @@ Content-Type: application/json
 Name | Type | Description
 -----|------|------------
 `id` | string | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) The server should infer the account from the `sub` value in the SEP-10 JWT to identify the customer. The `account` parameter is only used for backwards compatibility, and if explicitly provided in the request body it should match the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `type` | string | (optional) The type of the customer as defined in the [Type Specification](#type-specification).
@@ -487,7 +487,7 @@ PUT [KYC_SERVER || TRANSFER_SERVER]/customer/callback
 Name | Type | Description
 ---- | ---- | -----------
 `id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) The server should infer the account from the `sub` value in the SEP-10 JWT to identify the customer. The `account` parameter is only used for backwards compatibility, and if explicitly provided in the request body it should match the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `url` | `string` | A callback URL that the SEP-12 server will POST to when the state of the account changes.

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -98,7 +98,7 @@ GET [KYC_SERVER]/customer?id=<customer-id>&type=<customer-type>
 Name | Type | Description
 -----|------|------------
 `id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `type` | string | (optional) the type of action the customer is being KYCd for.  See the [Type Specification](#type-specification) below.
@@ -356,7 +356,7 @@ Content-Type: application/json
 Name | Type | Description
 -----|------|------------
 `id` | string | (optional) The `id` value returned from a previous call to this endpoint. If specified, no other parameter is required.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `type` | string | (optional) The type of the customer as defined in the [Type Specification](#type-specification).
@@ -487,7 +487,7 @@ PUT [KYC_SERVER || TRANSFER_SERVER]/customer/callback
 Name | Type | Description
 ---- | ---- | -----------
 `id` | `string` | (optional) The ID of the customer as returned in the response of a previous `PUT` request. If the customer has not been registered, they do not yet have an `id`.
-`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT.
+`account` | `G...` or `M...` string | (**deprecated**, optional) This field should match the `sub` value of the decoded SEP-10 JWT. When omitted, the server should use the `sub` value of the decoded SEP-10 JWT.
 `memo` | string | (optional) the client-generated [memo](https://developers.stellar.org/docs/glossary/transactions/#memo) that uniquely identifies the customer. If a memo is present in the decoded SEP-10 JWT's `sub` value, it must match this parameter value. If a muxed account is used as the JWT's `sub` value, memos sent in requests must match the 64-bit integer subaccount ID of the muxed account. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos should always be of type `id`, although anchors should continue to support this parameter for outdated clients. If `hash`, `memo` should be base64-encoded. If a memo is present in the decoded SEP-10 JWT's `sub` value, this parameter can be ignored. See the [Shared Accounts](#shared-omnibus-or-pooled-accounts) section for more information.
 `url` | `string` | A callback URL that the SEP-12 server will POST to when the state of the account changes.

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -106,7 +106,7 @@ Name | Type | Description
 
 #### ID vs. Account & Memo
 
-The client can always use the `account` and optional `memo` parameters to uniquely identify a customer. However, if a `PUT /customer` request has already been made for the customer, the client may use the `id` returned in the response instead.
+The client can always use the `account` and optional `memo` parameters to uniquely identify a customer, and when not explicitly passed in the request body the server can still infer this information from the decoded SEP-10 JWT's `sub` value. If a `PUT /customer` request has already been made for the customer, the client should preferrably use the `id` returned in the response instead.
 
 #### Type Specification
 


### PR DESCRIPTION
### What

Make it explicit that the `account` and `memo` can be inferred from the JWT token.

### Why

Those fields were optional but it was not clear that the server should fill them in based on the JWT token.