### PR TITLE
Fixed typo in SEP-24 doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # vscode
 .vscode/
+
+# IntelliJ IDEA
+.idea

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-08-19
-Version 2.6.0
+Updated: 2022-11-02
+Version 2.6.1
 ```
 
 ## Simple Summary
@@ -724,7 +724,7 @@ Each object in the `transactions` array should have the following fields:
 ### Shared fields for both deposits and withdrawals
 
 Name | Type | Description
------|------|------------
+-----|------|-----------|
 `id` | string | Unique, anchor-generated id for the deposit/withdrawal.
 `kind` | string | `deposit` or `withdrawal`.
 `status` | string | Processing status of deposit/withdrawal.
@@ -734,7 +734,7 @@ Name | Type | Description
 `amount_in` | string | Amount received by anchor at start of transaction as a string with up to 7 decimals. Excludes any fees charged before the anchor received the funds.
 `amount_in_asset` | string | (optional) The asset received or to be received by the Anchor. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `amount_out` | string | Amount sent by anchor to user at end of transaction as a string with up to 7 decimals. Excludes amount converted to XLM to fund account and any external fees.
-`amount_out_asset` | string | `amount_out_asset` | string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
+`amount_out_asset` |  string | (optional) The asset delivered or to be delivered to the user. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `amount_fee` | string | Amount of fee charged by anchor.
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.


### PR DESCRIPTION
Fixed small typo that left out `amount_out_asset` field description 