### PR TITLE
SEP-24 & 6: update & add `lang` parameter to on relevant endpoints

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2022-07-20
-Version 3.14.0
+Updated: 2022-11-18
+Version 3.15.0
 ```
 
 ## Simple Summary
@@ -325,7 +325,7 @@ Name | Type | Description
 `type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`. This field may be necessary for the anchor to determine which KYC fields to collect.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `amount` | string | (optional) The amount of the asset the user would like to deposit with the anchor. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
@@ -517,7 +517,7 @@ Name | Type | Description
 `memo_type` | string | (**deprecated**, optional) Type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos used to identify users of the same Stellar account should always be of type of `id`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `amount` | string | (optional) The amount of the asset the user would like to withdraw. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
@@ -593,7 +593,7 @@ Name | Type | Description
 `type` | string | (optional) Type of deposit. If the anchor supports multiple deposit methods (e.g. `SEPA` or `SWIFT`), the wallet should specify `type`. This field may be necessary for the anchor to determine which KYC fields to collect.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `claimable_balance_supported` | string | (optional) `true` if the client supports receiving deposit transactions as a claimable balance, `false` otherwise.
@@ -641,7 +641,7 @@ Name | Type | Description
 `memo_type` | string | (**deprecated**, optional) Type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos used to identify users of the same Stellar account should always be of type of `id`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `error` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 
@@ -695,7 +695,7 @@ Name | Type | Description
 -----|------|------------
 `type` | string | Always set to `customer_info_status`.
 `status` | string | Status of customer information processing. One of: `pending`, `denied`.
-`more_info_url` | string | (optional) A URL the user can visit if they want more information about their account / status.
+`more_info_url` | string | (optional) A URL the user can visit if they want more information about their account / status. If `lang` was passed in the request, a `lang` query parameter should be added to the URL with the same value.
 `eta` | int | (optional) Estimated number of seconds until the customer information status will update.
 
 If the anchor decides that more customer information is needed after receiving some information and processing it, it can respond again with a response of type `non_interactive_customer_info_needed`. In the case of a `denied` request, an anchor can use the `more_info_url` to explain to the user the issue with their request and give them a way to rectify it manually. A wallet should show the `more_info_url` to the user when explaining that the request was denied.
@@ -784,7 +784,7 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1). `description` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 
 ### Response
 
@@ -1061,6 +1061,7 @@ Name | Type | Description
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) A list containing the desired transaction kinds. The possible values are `deposit`, `deposit-exchange`, `withdrawal` and `withdrawal-exchange`.
 `paging_id` | string | (optional) The response should contain transactions starting prior to this ID (exclusive).
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 
 Example request:
 
@@ -1305,6 +1306,7 @@ Name | Type | Description
 `id` | string | (optional) The id of the transaction.
 `stellar_transaction_id` | string | (optional) The stellar transaction id of the transaction.
 `external_transaction_id` | string | (optional) The external transaction id of the transaction.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 
 One of `id`, `stellar_transaction_id` or `external_transaction_id` is required.
 
@@ -1405,6 +1407,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.15.0`: Add `lang` to `/transactions` & `/transaction` parameters, update format to [RFC 4646]. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v3.14.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v3.13.0`: Add callback signature requirement. ([#1262](https://github.com/stellar/stellar-protocol/pull/1262))
 * `v3.12.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))
@@ -1412,3 +1415,5 @@ If the information was malformed, or if the sender tried to update data that isn
 * `v3.11.0`: Update instructions to enforce the Wallet needs to reach out to the `GET /transaction?id={id}` endpoint to get the payment `amount_in` before making the payment. ([#1203](https://github.com/stellar/stellar-protocol/pull/1203))
 * `v3.10.1`: Add firm quote withdrawal sequence diagram. ([#1147](https://github.com/stellar/stellar-protocol/pull/1147))
 * `v3.10.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
+
+[RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active
 Created: 2019-09-18
 Updated: 2022-11-16
-Version 2.6.3
+Version 2.7.0
 ```
 
 ## Simple Summary
@@ -987,6 +987,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * Solar wallet: https://solarwallet.io
 
 ## Changelog
+* `v2.6.3`: Clarify `lang` defaults to `en` when specified value is not supported. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v2.6.2`: Fixed the missing links of customer information needed. ([#1316](https://github.com/stellar/stellar-protocol/pull/1316))
 * `v2.6.0`: Add callback signature and verification requirement. ([#1263](https://github.com/stellar/stellar-protocol/pull/1263))
 * `v2.5.0`: Add `expired` transaction status. ([#1233](https://github.com/stellar/stellar-protocol/pull/1233))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-11-07
-Version 2.6.2
+Updated: 2022-11-16
+Version 2.6.3
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -230,7 +230,7 @@ Name | Type | Description
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. Because a memo can be specified in the SEP-10 JWT for [Shared Accounts](#shared-omnibus-or-pooled-accounts), this field can be different than the value included in the SEP-10 JWT. For example, a client application could use the value passed for this parameter as a reference number used to match payments made to `account`.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
 `wallet_url` | string | (optional) Anchor should link to this when notifying the user that the transaction has completed.
-`lang` | string | (optional) Defaults to `en`. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
 `claimable_balance_supported` | boolean | (optional) True if the client supports receiving deposit transactions as a claimable balance, false otherwise.
 
 Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make the onboarding experience simpler.
@@ -369,7 +369,7 @@ Name | Type | Description
 `memo_type` | string | (**deprecated**, optional) Type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos used to identify users of the same Stellar account should always be of type of `id`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
-`lang` | string | (optional) Defaults to `en`. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
 
 Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 
@@ -562,7 +562,7 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`lang` | string | (optional) Defaults to `en`. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `description` fields in the response should be in this language.
+`lang` | string | (optional) Defaults to `en` if not specified or the if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `description` fields in the response should be in this language.
 
 ### Response
 
@@ -711,7 +711,7 @@ Name | Type | Description
 `limit` | int | (optional) The response should contain at most `limit` transactions.
 `kind` | string | (optional) The kind of transaction that is desired. Should be either `deposit` or `withdrawal`.
 `paging_id` | string | (optional) The response should contain transactions starting prior to this ID (exclusive).
-`lang` | string | (optional) Defaults to `en`. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`.
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
@@ -920,7 +920,7 @@ Name | Type | Description
 `id` | string | (optional) The id of the transaction.
 `stellar_transaction_id` | (optional) string | The stellar transaction id of the transaction.
 `external_transaction_id` | (optional) string | The external transaction id of the transaction.
-`lang` | string | (optional) Defaults to `en`. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`.
+`lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`.
 
 One of `id`, `stellar_transaction_id` or `external_transaction_id` is required.
 
@@ -994,3 +994,5 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * `v2.3.0`: Change `lang` format from [ISO639-1](https://en.wikipedia.org/wiki/ISO_639-1) to [RFC4646](https://datatracker.ietf.org/doc/html/rfc4646) which is a superset of ISO639-1. Add `lang` field to GET `/transactions` and `/transaction`. ([#1191](https://github.com/stellar/stellar-protocol/pull/1191))
 * `v2.2.1`: Make `completed_at` field optional. ([#1185](https://github.com/stellar/stellar-protocol/pull/1185))
 * `v2.2.0`: Deprecate refunded boolean. Add refund object to transaction records. ([#1128](https://github.com/stellar/stellar-protocol/pull/1128))
+
+[RFC 4646]: https://www.rfc-editor.org/rfc/rfc4646


### PR DESCRIPTION
This is a request from Lobstr. Currently, Polaris and other anchors return 400 when the specified language is not supported by the anchor. But because anchors don't provide a list of supported languages, the wallets have no choice but to attempt the request with the user's preferred language anyway. Therefore, anchors should be forgiving when an unsupported language is passed and default to english.