### PR TITLE
SEP-31, 24, & 6: add optional `refund_memo` to transaction initiation requests

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1411,7 +1411,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
-* `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions. ([]())
+* `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
 * `v3.15.0`: Add `lang` to `/transactions` & `/transaction` parameters, update format to [RFC 4646]. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v3.14.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v3.13.0`: Add callback signature requirement. ([#1262](https://github.com/stellar/stellar-protocol/pull/1262))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
 Updated: 2022-11-18
-Version 3.15.0
+Version 3.16.0
 ```
 
 ## Simple Summary
@@ -521,6 +521,8 @@ Name | Type | Description
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `amount` | string | (optional) The amount of the asset the user would like to withdraw. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`refund_memo` | (optional) The memo the anchor must use when sending refund payments back to the user. If not specified, the anchor should use the same memo used by the user to send the original payment. If specified, `refund_memo_type` must also be specified.
+`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information. If specified, `refund_memo` must also be specified.
 
 Example:
 
@@ -644,6 +646,8 @@ Name | Type | Description
 `lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646]. `error` fields and other human readable messages in the response should be in this language.
 `on_change_callback` | string | (optional) A URL that the anchor should `POST` a JSON message to when the `status` property of the transaction created as a result of this request changes. The JSON message should be identical to the response format for the [/transaction](#single-historical-transaction) endpoint. The callback needs to be signed by the anchor and the signature needs to be verified by the wallet according to the [callback signature specification](#callback-signature).
 `country_code` | string | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.
+`refund_memo` | (optional) The memo the anchor must use when sending refund payments back to the user. If not specified, the anchor should use the same memo used by the user to send the original payment. If specified, `refund_memo_type` must also be specified.
+`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information. If specified, `refund_memo` must also be specified.
 
 Example:
 
@@ -1407,6 +1411,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions. ([]())
 * `v3.15.0`: Add `lang` to `/transactions` & `/transaction` parameters, update format to [RFC 4646]. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v3.14.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v3.13.0`: Add callback signature requirement. ([#1262](https://github.com/stellar/stellar-protocol/pull/1262))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -990,7 +990,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
-* `v2.7.0`: Add `refund_memo` and `refund_memo_type` parameters to withdraw endpoint. ([]())
+* `v2.7.0`: Add `refund_memo` and `refund_memo_type` parameters to withdraw endpoint. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
 * `v2.6.3`: Clarify `lang` defaults to `en` when specified value is not supported. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v2.6.2`: Fixed the missing links of customer information needed. ([#1316](https://github.com/stellar/stellar-protocol/pull/1316))
 * `v2.6.0`: Add callback signature and verification requirement. ([#1263](https://github.com/stellar/stellar-protocol/pull/1263))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,7 +6,7 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-11-16
+Updated: 2022-11-18
 Version 2.7.0
 ```
 
@@ -370,6 +370,8 @@ Name | Type | Description
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
 `wallet_url` | string | (optional) Anchor can show this to the user when referencing the wallet involved in the withdrawal (ex. in the anchor's transaction history).
 `lang` | string | (optional) Defaults to `en` if not specified or if the specified language is not supported. Language code specified using [RFC 4646] which means it can also accept locale in the format `en-US`. `error` fields in the response, as well as the interactive flow UI and any other user-facing strings returned for this transaction should be in this language.
+`refund_memo` | (optional) The memo the anchor must use when sending refund payments back to the user. If not specified, the anchor should use the same memo used by the user to send the original payment. If specified, `refund_memo_type` must also be specified.
+`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information. If specified, `refund_memo` must also be specified.
 
 Additionally, any [SEP-9](sep-0009.md) parameters may be passed as well to make the onboarding experience simpler.
 
@@ -987,6 +989,8 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 * Solar wallet: https://solarwallet.io
 
 ## Changelog
+
+* `v2.7.0`: Add `refund_memo` and `refund_memo_type` parameters to withdraw endpoint. ([]())
 * `v2.6.3`: Clarify `lang` defaults to `en` when specified value is not supported. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v2.6.2`: Fixed the missing links of customer information needed. ([#1316](https://github.com/stellar/stellar-protocol/pull/1316))
 * `v2.6.0`: Add callback signature and verification requirement. ([#1263](https://github.com/stellar/stellar-protocol/pull/1263))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -437,8 +437,8 @@ Name | Type | Description
 `receiver_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Receiving Client. Required if the Receiving Anchor requires SEP-12 KYC on the Receiving Client.
 `fields` | object | An object containing the values requested by the Receiving Anchor in the `GET /info` endpoint.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human-readable error codes or field descriptions will be returned in this language.
-`refund_memo` | (optional) The memo the Receiving Anchor must use when sending refund payments back to the Sending Anchor. If not specified, the Receiving Anchor should use the same memo the Sending Anchor used to send the original payment.
-`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information.
+`refund_memo` | (optional) The memo the Receiving Anchor must use when sending refund payments back to the Sending Anchor. If not specified, the Receiving Anchor should use the same memo the Sending Anchor used to send the original payment. If specified, `refund_memo_type` must also be specified.
+`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information. If specified, `refund_memo` must also be specified.
 
 #### Responses
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -897,6 +897,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
+* `v2.2.0`: Add `refund_memo` & `refund_memo_type` to `POST /transactions` request. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
 * `v2.1.0`: Add the `refunded` status and updated the Detailed Receiving Anchor Flow. ([#1311](https://github.com/stellar/stellar-protocol/pull/1311))
 * `v2.0.0`: Make `stellar_account_id`, `stellar_memo`, & `stellar_memo_type` optional in the `POST /transactions` response. Add the `status_message` attribute to `GET /transactions/:id`. ([#1294](https://github.com/stellar/stellar-protocol/pull/1294))
 * `v1.10.0`: Add `quote_id` to the transaction object schema. ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -6,8 +6,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2022-10-05
-Version 2.1.0
+Updated: 2022-11-16
+Version 2.2.0
 ```
 
 ## Simple Summary
@@ -437,6 +437,8 @@ Name | Type | Description
 `receiver_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Receiving Client. Required if the Receiving Anchor requires SEP-12 KYC on the Receiving Client.
 `fields` | object | An object containing the values requested by the Receiving Anchor in the `GET /info` endpoint.
 `lang` | string | (optional) Defaults to `en`. Language code specified using [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1).  Any human-readable error codes or field descriptions will be returned in this language.
+`refund_memo` | (optional) The memo the Receiving Anchor must use when sending refund payments back to the Sending Anchor. If not specified, the Receiving Anchor should use the same memo the Sending Anchor used to send the original payment.
+`refund_memo_type` | (optional) The type of the `refund_memo`. Can be `id`, `text`, or `hash`. See the [memos](https://developers.stellar.org/docs/encyclopedia/memos) documentation for more information.
 
 #### Responses
 


### PR DESCRIPTION
Receiving anchors often use custodial services to hold their on-chain assets, and these custodians often use omnibus accounts, so memos are used by the custodian to map inbound payments to their customer's balances.

To support this case, the standard allows Receiving anchors to provide a memo & memo type to use for each transaction in the `POST /transactions` request.

Sending anchors may also use custodial services to hold their on-chain assets, so in the event that a refund payment is necessary, sending anchors should be allowed to provide the receiving anchor a memo to use.

Thats why I'm adding two optional parameter to the `POST /transactions` request body, allowing the sending anchor to provide the receiving anchor with a memo to use when sending refund payments back.