### PR TITLE
SEP-23: Add a contract strkey

### DIFF
--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -54,6 +54,7 @@ base-32 encoding of the key, are listed here:
 | STRKEY\_PRE\_AUTH\_TX   | 19 << 3      | T          | no    | Hash |
 | STRKEY\_HASH\_X         | 23 << 3      | X          | no    | Hash |
 | STRKEY\_SIGNED\_PAYLOAD | 15 << 3      | P          | no    | PK   |
+| STRKEY\_CONTRACT        | 2 << 3       | C          | no    | Hash |
 
 The low 3 bits of the version byte encode an algorithm specifier. Thus,
 a version byte becomes the bitwise OR of a base value above and one of
@@ -191,6 +192,19 @@ test cases, which could in turn cause security problems.
     - ed25519: `GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ`
     - payload: 0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d (hex)
 
+1. Valid contract
+
+    - Strkey `CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUWDA`
+    - type: `HASH_TYPE_SHA256`
+    - hash:
+    ~~~ {.c}
+    {
+        0x3f, 0x0c, 0x34, 0xbf, 0x93, 0xad, 0x0d, 0x99,
+        0x71, 0xd0, 0x4c, 0xcc, 0x90, 0xf7, 0x05, 0x51,
+        0x1c, 0x83, 0x8a, 0xad, 0x97, 0x34, 0xa4, 0xa2,
+        0xfb, 0x0d, 0x7a, 0x03, 0xfc, 0x7f, 0xe8, 0x9a,
+    }
+    ~~~
 ### Invalid test cases
 
 1. Invalid length (Ed25519 should be 32 bytes, not 5)

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -7,8 +7,8 @@ Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcc
 Track: Standard
 Status: Active
 Created: 2019-09-16
-Updated: 2021-07-23
-Version: 1.1.0
+Updated: 2022-12-02
+Version: 1.2.0
 Discussion: https://groups.google.com/g/stellar-dev
 ```
 


### PR DESCRIPTION
### What
Add a contract strkey to SEP-23.

### Why
To use in applications that reference contracts deployed on Soroban, on the Stellar network.

### Discussion

- https://groups.google.com/g/stellar-dev/c/XWNpOIaXWBs
- https://discord.com/channels/897514728459468821/1048384084952502272