### PR TITLE
SEP-24: add updated_at field to transaction records

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -741,7 +741,7 @@ Name | Type | Description
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching `completed` or `refunded` status. 
-`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the latest status. If the status becomes `completed` or `refunded`, this field value should be the same as `completed_at`.
+`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the current status. If the status becomes `completed` or `refunded`, this field value should be the same as `completed_at`.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-11-18
-Version 2.7.0
+Updated: 2022-12-22
+Version 2.8.0
 ```
 
 ## Simple Summary
@@ -741,6 +741,7 @@ Name | Type | Description
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching `completed` or `refunded` status. 
+`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the latest status. If the status becomes `completed` or `refunded`, this field value should be the same as `completed_at`.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
@@ -848,6 +849,7 @@ Example response:
       "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
+      "updated_at": "2017-03-20T17:09:58Z",
       "more_info_url": "https://youranchor.com/tx/242523523",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "1941491",
@@ -876,6 +878,32 @@ Example response:
       "amount_fee": "5",
       "started_at": "2017-03-20T17:00:02Z",
       "completed_at": "2017-03-20T17:09:58Z",
+      "updated_at": "2017-03-20T17:09:58Z",
+      "more_info_url": "https://youranchor.com/tx/242523526",
+      "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
+      "external_transaction_id": "1947101",
+      "refunds": {
+        "amount_refunded": "10",
+        "amount_fee": "5",
+        "payments": [
+          {
+            "id": "1937103",
+            "id_type": "external",
+            "amount": "10",
+            "fee": "5"
+          }
+        ]
+      }
+    },
+    {
+      "id": "92fhs729f63dh0v3",
+      "kind": "deposit",
+      "status": "pending_anchor",
+      "amount_in": "510",
+      "amount_out": "490",
+      "amount_fee": "5",
+      "started_at": "2017-03-20T17:00:02Z",
+      "updated_at": "2017-03-20T17:05:58Z",
       "more_info_url": "https://youranchor.com/tx/242523526",
       "stellar_transaction_id": "17a670bc424ff5ce3b386dbfaae9990b66a2a37b4fbe51547e8794962a3f9e6a",
       "external_transaction_id": "1947101",

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -1018,6 +1018,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
+* `v2.8.0`: Add `updated_at` to transaction records. ([#1329](https://github.com/stellar/stellar-protocol/pull/1329))
 * `v2.7.0`: Add `refund_memo` and `refund_memo_type` parameters to withdraw endpoint. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
 * `v2.6.3`: Clarify `lang` defaults to `en` when specified value is not supported. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v2.6.2`: Fixed the missing links of customer information needed. ([#1316](https://github.com/stellar/stellar-protocol/pull/1316))


### PR DESCRIPTION
### What

Add updated_at field to the transaction object.

### Why

In the event of the anchor sends a callback with an older timestamp than the one that a wallet has proceeded, the callback can be safely discarded by the wallet.