### PR TITLE
SEP-24: Change the type of amount of the `/fee` endpoint to `string`

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2022-12-22
-Version 2.8.0
+Updated: 2022-12-27
+Version 2.9.0
 ```
 
 ## Simple Summary
@@ -658,12 +658,12 @@ GET TRANSFER_SERVER_SEP0024/fee
 
 Request parameters:
 
-Name | Type | Description
------|------|------------
+Name | Type   | Description
+-----|--------|------------
 `operation` | string | Kind of operation (`deposit` or `withdraw`).
 `type` | string | (optional) Type of deposit or withdrawal (`SEPA`, `bank_account`, `cash`, etc...).
 `asset_code` | string | Asset code.
-`amount` | float | Amount of the asset that will be deposited/withdrawn.
+`amount` | string | Amount of the asset that will be deposited/withdrawn.
 
 Example request:
 
@@ -673,15 +673,15 @@ GET https://api.example.com/fee?operation=withdraw&asset_code=ETH&amount=0.5
 
 On success the endpoint should return `200 OK` HTTP status code and a JSON object with the following fields:
 
-Name | Type | Description
------|------|------------
-`fee` | float | The total fee (in units of the asset involved) that would be charged to deposit/withdraw the specified `amount` of `asset_code`.
+Name | Type   | Description
+-----|--------|------------
+`fee` | string | The total fee (in units of the asset involved) that would be charged to deposit/withdraw the specified `amount` of `asset_code`.
 
 Example response:
 
 ```json
 {
-  "fee": 0.013
+  "fee": "0.013"
 }
 ```
 
@@ -1018,6 +1018,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
+* `v2.9.0`: Change the type of amount of the `/fee` endpoint to `string`. ([#1331](https://github.com/stellar/stellar-protocol/pull/1331))
 * `v2.8.0`: Add `updated_at` to transaction records. ([#1329](https://github.com/stellar/stellar-protocol/pull/1329))
 * `v2.7.0`: Add `refund_memo` and `refund_memo_type` parameters to withdraw endpoint. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
 * `v2.6.3`: Clarify `lang` defaults to `en` when specified value is not supported. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))


### PR DESCRIPTION
The `amount_in`, `amount_out` and `amount_fee` are as type `string` in most end-points. We should make them consistent.