### PR TITLE
SEP-9: add generalized account field

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -127,8 +127,8 @@ The currently accepted scheme values are:
 
 Name | Description
 ------------------
-`cbu` | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
-`cvu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
+`cbu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
+`cvu` | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
 
 #### `cbu` Identifier Format
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -85,7 +85,7 @@ Name | Type          | [Format](#encodings) |Description
 `sex` | string        | | `male`, `female`, or `other`                                                                
 `proof_of_income` | binary        | | Image of user's proof of income document
 `proof_of_liveness` | binary	| | video or image file of user as a liveness proof
-`offchain_account` | string | [Off-Chain Account Identifier Format](#off-chain-account-identifier-format) | An idenfier for the user's off-chain account. Could be a bank, virtual, or other account type.
+`account_id` | string | [Account Identifier Format](#off-chain-account-identifier-format) | An idenfier for the user's off-chain account. Could be a bank, virtual, or other account type.
 
 ### Organization KYC fields
 
@@ -113,7 +113,7 @@ Name | Type | [Format](#encodings) | Description
 
 Address formatting varies widely from country to country and even within each country. See [here](https://stackoverflow.com/questions/11160192/how-to-parse-freeform-street-postal-address-out-of-text-and-into-components) for details. Rather than attempting to create a field for each possible part of an address in every country, this protocol takes a middle of the road approach. Address fields that are fairly universal can be encoded with the `country_code`, `state_or_province`, `city`, and `postal_code` fields. Full addresses, however, should be encoded as a single multi-line string in the `address` field. This allows any address in the world to be represented with a limited number of fields. If address parsing is necessary, parsing will be easier since the country, city, and postal code are already separate fields.
 
-### Off-Chain Account Identifier Format
+### Account Identifier Format
 
 Information used to identify financial accounts varies widely depending on the country and type of account. Rather than adding fields for each type of account identifier, and requiring updates from the various implementations of this specification, accounts can be identified using the following string format:
 
@@ -121,22 +121,26 @@ Information used to identify financial accounts varies widely depending on the c
 <scheme>:<identifier>
 ```
 
+For the sake of backwards compatibility, fields used to identify accounts that were added prior to defining this format, such as `clabe_number` and `bank_acccount_number`, should continue to be supported.
+
 The currently accepted scheme values are:
 
 Name | Description
 ------------------
-`cvu` |
-`cbu` |
+`cvu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
+`cbu` | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
 
 #### `cvu` Identifier Format
 
+The CBU is made up of 22 digits, separated into two blocks. The first block has a 3-digit entity number, a 4-digit branch number, and a check digit. The second block has a 13-digit number that identifies the account within the entity and the branch, plus a verification digit.
+
 #### `cbu` Identifier Format
 
-For the sake of backwards compatibility, fields used to identify accounts that were added prior to defining this format, such as `clabe_number` and `bank_acccount_number`, should continue to be supported.
+The CVU is made up of 22 digits, separated into two blocks. The first block, digit 1 to 8, identifies the Payment Service Provider to which it belongs, and the second block, from digit 9 to 22, identifies the user.
 
 ## Changelog
 
-* `v1.9.0`: Add `offchain_account` to Natural Person KYC field (()[]).
+* `v1.9.0`: Add `offchain_account` to Natural Person KYC field ([#1334](https://github.com/stellar/stellar-protocol/pull/1334)).
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).
 * `v1.6.0`: Add `clabe_number` to Natural Person KYC fields ([#1202](https://github.com/stellar/stellar-protocol/pull/1202)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -127,16 +127,36 @@ The currently accepted scheme values are:
 
 Name | Description
 ------------------
-`cvu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
 `cbu` | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
-
-#### `cvu` Identifier Format
-
-The CBU is made up of 22 digits, separated into two blocks. The first block has a 3-digit entity number, a 4-digit branch number, and a check digit. The second block has a 13-digit number that identifies the account within the entity and the branch, plus a verification digit.
+`cvu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
 
 #### `cbu` Identifier Format
 
-The CVU is made up of 22 digits, separated into two blocks. The first block, digit 1 to 8, identifies the Payment Service Provider to which it belongs, and the second block, from digit 9 to 22, identifies the user.
+The CBU is comprosed of 22 numbers representing the bank ID, branch code and account number as follows:
+
+- 3 digits = bank ID
+- 4 digits = branch code
+- 1 digit = check digit
+- 13 digits = account number
+- 1 digit = check digit
+
+```
+cvu:2850590940090418135201
+```
+
+#### `cvu` Identifier Format
+
+The CVU is made up of 22 digits and is compatible with the CBU format.
+
+- 3 digits = CVU ID
+- 4 digits = payment service provider ID
+- 1 digit = check digit
+- 13 digits = user ID
+- 1 digit = check digit
+
+```
+cvu:2850590940090418135201
+```
 
 ## Changelog
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -85,7 +85,7 @@ Name | Type          | [Format](#encodings) |Description
 `sex` | string        | | `male`, `female`, or `other`                                                                
 `proof_of_income` | binary        | | Image of user's proof of income document
 `proof_of_liveness` | binary	| | video or image file of user as a liveness proof
-`account_id` | string | [Account Identifier Format](#off-chain-account-identifier-format) | An idenfier for the user's off-chain account. Could be a bank, virtual, or other account type.
+`account_id` | string | [Account Identifier Format](#account-identifier-format) | An idenfier for the user's off-chain account. Could be a bank, virtual, or other account type.
 
 ### Organization KYC fields
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -126,7 +126,7 @@ For the sake of backwards compatibility, fields used to identify accounts that w
 The currently accepted scheme values are:
 
 Name | Description
-------------------
+-----|------------
 `cbu` | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
 `cvu` | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2022-11-30
-Version 1.8.0
+Updated: 2023-01-09
+Version 1.9.0
 ```
 
 ## Simple Summary
@@ -85,6 +85,7 @@ Name | Type          | [Format](#encodings) |Description
 `sex` | string        | | `male`, `female`, or `other`                                                                
 `proof_of_income` | binary        | | Image of user's proof of income document
 `proof_of_liveness` | binary	| | video or image file of user as a liveness proof
+`offchain_account` | string | [Off-Chain Account Identifier Format](#off-chain-account-identifier-format) | An idenfier for the user's off-chain account. Could be a bank, virtual, or other account type.
 
 ### Organization KYC fields
 
@@ -112,8 +113,30 @@ Name | Type | [Format](#encodings) | Description
 
 Address formatting varies widely from country to country and even within each country. See [here](https://stackoverflow.com/questions/11160192/how-to-parse-freeform-street-postal-address-out-of-text-and-into-components) for details. Rather than attempting to create a field for each possible part of an address in every country, this protocol takes a middle of the road approach. Address fields that are fairly universal can be encoded with the `country_code`, `state_or_province`, `city`, and `postal_code` fields. Full addresses, however, should be encoded as a single multi-line string in the `address` field. This allows any address in the world to be represented with a limited number of fields. If address parsing is necessary, parsing will be easier since the country, city, and postal code are already separate fields.
 
+### Off-Chain Account Identifier Format
+
+Information used to identify financial accounts varies widely depending on the country and type of account. Rather than adding fields for each type of account identifier, and requiring updates from the various implementations of this specification, accounts can be identified using the following string format:
+
+```
+<scheme>:<identifier>
+```
+
+The currently accepted scheme values are:
+
+Name | Description
+------------------
+`cvu` |
+`cbu` |
+
+#### `cvu` Identifier Format
+
+#### `cbu` Identifier Format
+
+For the sake of backwards compatibility, fields used to identify accounts that were added prior to defining this format, such as `clabe_number` and `bank_acccount_number`, should continue to be supported.
+
 ## Changelog
 
+* `v1.9.0`: Add `offchain_account` to Natural Person KYC field (()[]).
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).
 * `v1.6.0`: Add `clabe_number` to Natural Person KYC fields ([#1202](https://github.com/stellar/stellar-protocol/pull/1202)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -140,7 +140,7 @@ The CVU is made up of 22 digits, separated into two blocks. The first block, dig
 
 ## Changelog
 
-* `v1.9.0`: Add `offchain_account` to Natural Person KYC field ([#1334](https://github.com/stellar/stellar-protocol/pull/1334)).
+* `v1.9.0`: Add `account_id` to Natural Person KYC field ([#1334](https://github.com/stellar/stellar-protocol/pull/1334)).
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).
 * `v1.6.0`: Add `clabe_number` to Natural Person KYC fields ([#1202](https://github.com/stellar/stellar-protocol/pull/1202)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -141,7 +141,7 @@ The CBU is comprosed of 22 numbers representing the bank ID, branch code and acc
 - 1 digit = check digit
 
 ```
-cvu:2850590940090418135201
+cbu:2850590940090418135201
 ```
 
 #### `cvu` Identifier Format


### PR DESCRIPTION
resolved #1332 

Adds the `account_id` field (open to naming suggestions) and Account Identifier Format to be used for its values.