### PR TITLE
SEP-6,24,31: unify use of `updated_at` and `refunded` status

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2023-01-10
-Version 3.17.1
+Updated: 2023-01-13
+Version 3.18.0
 ```
 
 ## Simple Summary
@@ -1108,6 +1108,7 @@ Name | Type | Description
 `withdraw_memo` | string | (optional) Memo used when the user transferred to `withdraw_anchor_account`.
 `withdraw_memo_type` | string | (optional) Memo type for `withdraw_memo`.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
+`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the current status.
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
@@ -1136,6 +1137,7 @@ Name | Type | Description
 * `too_small` -- deposit/withdrawal size less than `min_amount`.
 * `too_large` -- deposit/withdrawal size exceeded `max_amount`.
 * `error` -- catch-all for any error not enumerated above.
+* `refunded` -- the deposit/withdrawal is fully refunded.
 
 ### Refunds Object Schema
 
@@ -1414,6 +1416,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.18.0`: Added `refunded` status to match other SEPs (24, 31) ([]())
 * `v3.17.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v3.17.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1416,7 +1416,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
-* `v3.18.0`: Added `refunded` status to match other SEPs (24, 31) ([]())
+* `v3.18.0`: Added `refunded` status and `updated_at` transaction fields to match other SEPs (24, 31) ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v3.17.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v3.17.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -1021,7 +1021,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
-* `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([]())
+* `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.9.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.9.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v2.8.0`: Add `updated_at` to transaction records. ([#1329](https://github.com/stellar/stellar-protocol/pull/1329))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2023-01-10
-Version 2.9.1
+Updated: 2023-01-13
+Version 2.9.2
 ```
 
 ## Simple Summary
@@ -744,7 +744,7 @@ Name | Type | Description
 `amount_fee_asset` | string | (optional) The asset in which fees are calculated in. Must be present if the deposit/withdraw was made using non-equivalent assets. The value must be in [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). See the [Asset Exchanges](#asset-exchanges) section for more information.
 `started_at` | UTC ISO 8601 string | Start date and time of transaction.
 `completed_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching `completed` or `refunded` status. 
-`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the current status. If the status becomes `completed` or `refunded`, this field value should be the same as `completed_at`.
+`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the current status.
 `stellar_transaction_id` | string | transaction_id on Stellar network of the transfer that either completed the deposit or started the withdrawal.
 `external_transaction_id` | string | (optional) ID of transaction on external network that either started the deposit or completed the withdrawal.
 `message` | string | (optional) Human readable explanation of transaction status, if needed.
@@ -1021,6 +1021,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
+* `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([]())
 * `v2.9.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.9.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v2.8.0`: Add `updated_at` to transaction records. ([#1329](https://github.com/stellar/stellar-protocol/pull/1329))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -900,7 +900,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
-* `v2.4.0`: Add `updated_at` to `GET /transctions/:id` response ([]())
+* `v2.4.0`: Add `updated_at` to `GET /transctions/:id` response ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.3.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.3.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v2.2.0`: Add `refund_memo` & `refund_memo_type` to `POST /transactions` request. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -6,8 +6,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2023-01-10
-Version 2.3.1
+Updated: 2023-01-13
+Version 2.4.0
 ```
 
 ## Simple Summary
@@ -538,6 +538,7 @@ Name | Type | Description
 `stellar_memo_type` | string | (optional) The type of memo to attach to the Stellar payment: `text`, `hash`, or `id`.
 `stellar_memo` | string | (optional) The memo to attach to the Stellar payment.
 `started_at` | UTC ISO 8601 string | (optional) Start date and time of transaction.
+`updated_at` | UTC ISO 8601 string | (optional) The date and time of transaction reaching the current `status`.
 `completed_at` | UTC ISO 8601 string | (optional) Completion date and time of transaction.
 `stellar_transaction_id` | string | (optional) The transaction_id on Stellar network of the transfer that initiated the payment.
 `external_transaction_id` | string | (optional) The ID of transaction on external network that completes the payment into the receivers account.
@@ -899,6 +900,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
+* `v2.4.0`: Add `updated_at` to `GET /transctions/:id` response ([]())
 * `v2.3.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.3.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v2.2.0`: Add `refund_memo` & `refund_memo_type` to `POST /transactions` request. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -900,7 +900,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
-* `v2.4.0`: Add `updated_at` to `GET /transctions/:id` response ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
+* `v2.4.0`: Add `updated_at` to `GET /transactions/:id` response ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.3.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.3.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v2.2.0`: Add `refund_memo` & `refund_memo_type` to `POST /transactions` request. ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))


### PR DESCRIPTION
Some SEPs were missing or had differing descriptions of the `refunded` status and `updated_at` transaction field. This PR makes their usage and definitions consistent across SEPs.