### PR TITLE
SEP-9: add `cvu_number` and `cbu_number` fields

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2022-11-30
-Version 1.8.0
+Updated: 2023-01-25
+Version 1.9.0
 ```
 
 ## Simple Summary
@@ -85,6 +85,8 @@ Name | Type          | [Format](#encodings) |Description
 `sex` | string        | | `male`, `female`, or `other`                                                                
 `proof_of_income` | binary        | | Image of user's proof of income document
 `proof_of_liveness` | binary	| | video or image file of user as a liveness proof
+`cbu_number` | string | | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
+`cvu_number` | string | | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
 
 ### Organization KYC fields
 
@@ -114,6 +116,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
+* `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#](https://github.com/stellar/stellar-protocol/pull/))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).
 * `v1.6.0`: Add `clabe_number` to Natural Person KYC fields ([#1202](https://github.com/stellar/stellar-protocol/pull/1202)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -116,7 +116,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
-* `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#](https://github.com/stellar/stellar-protocol/pull/))
+* `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#1338](https://github.com/stellar/stellar-protocol/pull/1338))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).
 * `v1.6.0`: Add `clabe_number` to Natural Person KYC fields ([#1202](https://github.com/stellar/stellar-protocol/pull/1202)).


### PR DESCRIPTION
resolves #1332 

Adds `cvu_number` and `cbu_number` to SEP-9. We explored adding a generalized financial account field in #1334 and ultimately decided it added more complexity than it removed.