### PR TITLE
SEP-9: remove `cvu_number`, add `cbu_alias`

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -116,7 +116,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
-* `v1.10.0`: Remove `cvu_number`, update `cbu_number` to also accept CVU numbers, and add `cbu_alias` to Natural Person KYC fields ([#](https://github.com/stellar/stellar-protocol/pull/))
+* `v1.10.0`: Remove `cvu_number`, update `cbu_number` to also accept CVU numbers, and add `cbu_alias` to Natural Person KYC fields ([#1339](https://github.com/stellar/stellar-protocol/pull/1339))
 * `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#1338](https://github.com/stellar/stellar-protocol/pull/1338))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2023-01-25
-Version 1.9.0
+Updated: 2023-01-26
+Version 1.10.0
 ```
 
 ## Simple Summary
@@ -85,8 +85,8 @@ Name | Type          | [Format](#encodings) |Description
 `sex` | string        | | `male`, `female`, or `other`                                                                
 `proof_of_income` | binary        | | Image of user's proof of income document
 `proof_of_liveness` | binary	| | video or image file of user as a liveness proof
-`cbu_number` | string | | Clave Bancaria Uniforme or Unique Bank Key. The unique key for every bank account in Argentina used for receiving deposits, whether the owner is a natural or juridic person.
-`cvu_number` | string | | Clave Virtual Uniforme or Unique Virtual Key. The unique key for every user of a payment service provider (PSP) within Argentina.
+`cbu_number` | string | | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU). The unique key for every bank account in Argentina used for receiving deposits.
+`cbu_alias` | string | | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).
 
 ### Organization KYC fields
 
@@ -116,6 +116,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
+* `v1.10.0`: Remove `cvu_number`, update `cbu_number` to also accept CVU numbers, and add `cbu_alias` to Natural Person KYC fields ([#](https://github.com/stellar/stellar-protocol/pull/))
 * `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#1338](https://github.com/stellar/stellar-protocol/pull/1338))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).
 * `v1.7.0`: Add `proof_of_income` to Natural Person KYC fields ([#1310](https://github.com/stellar/stellar-protocol/pull/1310)).


### PR DESCRIPTION
After discussing with our partner, we realized that it is standard practice to use a single field that accepts both CVU & CBU numbers. We also want to add support for CVU & CVU aliases.