### PR TITLE
SEP-24: make `account` deposit request parameter optional

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -1021,7 +1021,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
-* `v3.0.0`: Make the `account` parameter for `POST /transactions/deposit/interactive` request optional ([]())
+* `v3.0.0`: Make the `account` parameter for `POST /transactions/deposit/interactive` request optional ([#1343](https://github.com/stellar/stellar-protocol/pull/1343))
 * `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.9.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.9.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2023-01-13
-Version 2.9.2
+Updated: 2023-02-06
+Version 3.0.0
 ```
 
 ## Simple Summary
@@ -228,7 +228,7 @@ Name | Type | Description
 `asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
-`account` | `G...` or `M...` string | The Stellar or muxed account of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.
+`account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client wants to use as the destination of the payment sent by the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. Because a memo can be specified in the SEP-10 JWT for [Shared Accounts](#shared-omnibus-or-pooled-accounts), this field can be different than the value included in the SEP-10 JWT. For example, a client application could use the value passed for this parameter as a reference number used to match payments made to `account`.
 `wallet_name` | string | (optional) In communications / pages about the deposit, anchor should display the wallet name to the user to explain where funds are going.
@@ -367,7 +367,7 @@ Name | Type | Description
 `asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
 `asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
-`account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client will use as the source of the withdrawal payment to the anchor. Note that the account specified in this request could differ from the account authenticated via SEP-10.
+`account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client will use as the source of the withdrawal payment to the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo` | string | (**deprecated**, optional) This field was originally intended to differentiate users of the same Stellar account. However, the anchor should use the `sub` value included in the decoded SEP-10 JWT instead. Anchors should still support this parameter to maintain support for outdated clients. See the [Shared Account Authentication](#shared-omnibus-or-pooled-accounts) section for more information.
 `memo_type` | string | (**deprecated**, optional) Type of `memo`. One of `text`, `id` or `hash`. Deprecated because memos used to identify users of the same Stellar account should always be of type of `id`.
 `wallet_name` | string | (optional) In communications / pages about the withdrawal, anchor should display the wallet name to the user to explain where funds are coming from.
@@ -1021,6 +1021,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
+* `v3.0.0`: Make the `account` parameter for `POST /transactions/deposit/interactive` request optional ([]())
 * `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.9.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.9.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))


### PR DESCRIPTION
resolves #1342 

Makes the `account` parameter for the `POST /transactions/deposit/interactive` request optional to match the `POST /transactions/withdraw/interactive` request.

SEP-24 originally did not require SEP-10, and because of that, required that the client specify the destination account of the payment via the deposit request body. When we introduced SEP-10, we should have also updated the SEP to have anchors default to using the authenticated account as the destination.

This change will make the deposit request's `account` parameter definition consistent with the withdraw request's account parameter, which is also optional.

This is technically a breaking change for anchors that assume the `account` field will always be present, although in practice this is easy for wallets to work around.