### PR TITLE
SEP-9: add `bank_account_type`

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -117,7 +117,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
-* `v1.11.0`: Add `bank_account_type` for describing types of bank accounts. ([]())
+* `v1.11.0`: Add `bank_account_type` for describing types of bank accounts. ([#1344](https://github.com/stellar/stellar-protocol/pull/1344))
 * `v1.10.0`: Remove `cvu_number`, update `cbu_number` to also accept CVU numbers, and add `cbu_alias` to Natural Person KYC fields ([#1339](https://github.com/stellar/stellar-protocol/pull/1339))
 * `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#1338](https://github.com/stellar/stellar-protocol/pull/1338))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2023-01-26
-Version 1.10.0
+Updated: 2023-02-10
+Version 1.11.0
 ```
 
 ## Simple Summary
@@ -46,45 +46,46 @@ The dot notation is _not_ an indication that the fields described should be cont
 
 ### Natural Person KYC fields
   
-Name | Type          | [Format](#encodings) |Description
------|---------------|--------|----
-`family_name` or `last_name` | string        |    | Family or last name                                                                         
-`given_name` or `first_name` | string        |   | Given or first name
-`additional_name` | string        | | Middle name or other additional name                                                        
-`address_country_code` | string        | ISO 3166-1 alpha-3 country code | country code for current address                                                            
-`state_or_province` | string        | | name of state/province/region/prefecture                                                    
-`city` | string        | | name of city/town                                                                           
-`postal_code` | string        | | Postal or other code identifying user's locale                                              
-`address` | string        | | Entire address (country, state, postal code, street address, etc...) as a multi-line string 
-`mobile_number` | string        | E.164 phone number| Mobile phone number with country code, in E.164 format                                      
-`email_address` | string        | | Email address                                                                               
-`birth_date` | date          | | Date of birth, e.g. `1976-07-04`                                                            
-`birth_place` | string        | | Place of birth (city, state, country; as on passport)                                       
-`birth_country_code` | string        | ISO 3166-1 alpha-3 country code | ISO Code of country of birth                                                                
-`bank_account_number` | string        | | Number identifying bank account                                                             
-`bank_number` | string        | | Number identifying bank in national banking system (routing number in US)                   
-`bank_phone_number` | string        | | Phone number with country code for bank                                                     
-`bank_branch_number` | string        | |  Number identifying bank branch                                                              
-`clabe_number` | string        | | Bank account number for Mexico                                                              
-`tax_id` | string        | | Tax identifier of user in their country (social security number in US)                      
-`tax_id_name` | string        | | Name of the tax ID (`SSN` or `ITIN` in the US)                                              
-`occupation` | number        | | Occupation ISCO code                                                                        
-`employer_name` | string        | | Name of employer                                                                            
-`employer_address` | string        | | Address of employer                                                                         
-`language_code` | string | ISO 639-1 language code | primary language                                                                            
-`id_type` | string        | | `passport`, `drivers_license`, `id_card`, etc...                                            
-`id_country_code` | string  | ISO 3166-1 alpha-3 country code | country issuing passport or photo ID as ISO 3166-1 alpha-3 code                             
-`id_issue_date` | date          | | ID issue date                                                                               
-`id_expiration_date` | date          | | ID expiration date                                                                          
-`id_number` | string        | | Passport or ID number                                                                       
-`photo_id_front` | binary        | | Image of front of user's photo ID or passport                                               
-`photo_id_back` | binary        | | Image of back of user's photo ID or passport                                                
-`notary_approval_of_photo_id` | binary        | | Image of notary's approval of photo ID or passport                                          
-`ip_address` | string        | | IP address of customer's computer                                                           
-`photo_proof_residence` | binary        | | Image of a utility bill, bank statement or similar with the user's name and address         
-`sex` | string        | | `male`, `female`, or `other`                                                                
-`proof_of_income` | binary        | | Image of user's proof of income document
-`proof_of_liveness` | binary	| | video or image file of user as a liveness proof
+Name | Type | [Format](#encodings) | Description
+-----|------|----------------------|------------
+`family_name` or `last_name` | string | | Family or last name
+`given_name` or `first_name` | string | | Given or first name
+`additional_name` | string | | Middle name or other additional name
+`address_country_code` | string | ISO 3166-1 alpha-3 country code | country code for current address
+`state_or_province` | string | | name of state/province/region/prefecture
+`city` | string | | name of city/town
+`postal_code` | string | | Postal or other code identifying user's locale
+`address` | string | | Entire address (country, state, postal code, street address, etc...) as a multi-line string
+`mobile_number` | string | E.164 phone number| Mobile phone number with country code, in E.164 format
+`email_address` | string | | Email address
+`birth_date` | date | | Date of birth, e.g. `1976-07-04`
+`birth_place` | string | | Place of birth (city, state, country; as on passport)
+`birth_country_code` | string | ISO 3166-1 alpha-3 country code | ISO Code of country of birth
+`bank_account_number` | string | | Number identifying bank account
+`bank_account_type` | string | | `checking` or `savings`
+`bank_number` | string | | Number identifying bank in national banking system (routing number in US)
+`bank_phone_number` | string | | Phone number with country code for bank
+`bank_branch_number` | string | |  Number identifying bank branch
+`clabe_number` | string | | Bank account number for Mexico
+`tax_id` | string | | Tax identifier of user in their country (social security number in US)                      
+`tax_id_name` | string | | Name of the tax ID (`SSN` or `ITIN` in the US)
+`occupation` | number | | Occupation ISCO code
+`employer_name` | string | | Name of employer
+`employer_address` | string | | Address of employer
+`language_code` | string | ISO 639-1 language code | primary language
+`id_type` | string | | `passport`, `drivers_license`, `id_card`, etc...
+`id_country_code` | string  | ISO 3166-1 alpha-3 country code | country issuing passport or photo ID as ISO 3166-1 alpha-3 code
+`id_issue_date` | date | | ID issue date
+`id_expiration_date` | date | | ID expiration date
+`id_number` | string | | Passport or ID number
+`photo_id_front` | binary | | Image of front of user's photo ID or passport
+`photo_id_back` | binary | | Image of back of user's photo ID or passport
+`notary_approval_of_photo_id` | binary | | Image of notary's approval of photo ID or passport
+`ip_address` | string | | IP address of customer's computer
+`photo_proof_residence` | binary | | Image of a utility bill, bank statement or similar with the user's name and address
+`sex` | string | | `male`, `female`, or `other`
+`proof_of_income` | binary | | Image of user's proof of income document
+`proof_of_liveness` | binary | | video or image file of user as a liveness proof
 `cbu_number` | string | | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU). The unique key for every bank account in Argentina used for receiving deposits.
 `cbu_alias` | string | | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).
 
@@ -116,6 +117,7 @@ Address formatting varies widely from country to country and even within each co
 
 ## Changelog
 
+* `v1.11.0`: Add `bank_account_type` for describing types of bank accounts. ([]())
 * `v1.10.0`: Remove `cvu_number`, update `cbu_number` to also accept CVU numbers, and add `cbu_alias` to Natural Person KYC fields ([#1339](https://github.com/stellar/stellar-protocol/pull/1339))
 * `v1.9.0`: Add `cbu_number` and `cvu_number` to Natural Person KYC fields ([#1338](https://github.com/stellar/stellar-protocol/pull/1338))
 * `v1.8.0`: Add `proof_of_liveness` to Natural Person KYC field ([#1323](https://github.com/stellar/stellar-protocol/pull/1323)).


### PR DESCRIPTION
Adds `bank_account_type` to the list of SEP-9 fields, with initial supported values of `checking` or `savings`. Some jurisdictions have banking systems that require that the account type be specified in addition to the account number.

Note that `bank_account_type` does not indicate the format of `bank_account_number`, and should not be used to validate `bank_account_number`. 

If an anchor needs to be able to validate an account identifier, it should use other SEP-9 fields added specifically for the format they're looking to validate, such as `cbu_number` or `clabe_number`. These fields often contain pieces of information other than the user's account number with their bank. 

For example, CBU numbers contain identifiers for the bank, the bank branch, the type of account, and the account number itself. Instead of trying to decompose CBU numbers and passing each piece via the `bank_account_number`, `bank_number`, `bank_branch_number`, and other SEP-9 fields, it is much easier for businesses operating in those jurisdictions to accept account identifiers in the formats that are common in those jurisdictions.