### PR TITLE
SEP-9: added bank_name

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -63,6 +63,7 @@ Name | Type | [Format](#encodings) | Description
 `birth_country_code` | string | ISO 3166-1 alpha-3 country code | ISO Code of country of birth
 `bank_account_number` | string | | Number identifying bank account
 `bank_account_type` | string | | `checking` or `savings`
+`bank_name` | string | | Bank name
 `bank_number` | string | | Number identifying bank in national banking system (routing number in US)
 `bank_phone_number` | string | | Phone number with country code for bank
 `bank_branch_number` | string | |  Number identifying bank branch


### PR DESCRIPTION
Some Anchors require the Bank name for KYC compliance and sending bank transfers.