### PR TITLE
SEP-24, SEP-31: Deprecate asset_code and asset_issuer in favor of asset

### DIFF
--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -227,7 +227,7 @@ Name | Type | Description
 -----|------|------------
 `asset_code` | string | (**Deprecated**, use `asset` instead) The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
-`asset` | string | The [Asset Identification Format](sep-0038.md#asset-identification-format) value.
+`asset` | string | The asset the user wants to receive for their deposit with the anchor in the [Asset Identification Format](sep-0038.md#asset-identification-format). The asset must be listed in the [/info](#info) response's deposit object.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client wants to use as the destination of the payment sent by the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar transaction, one of `text`, `id` or `hash`.
@@ -365,8 +365,9 @@ Request parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
-`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset_code` | string | (**Deprecated**, use `asset` instead) Code of the asset the user wants to withdraw. The value passed must match one of the codes listed in the [/info](#info) response's withdraw object.
+`asset_issuer` | string | (**Deprecated**, use `asset instead) (optional) The issuer of the stellar asset the user wants to withdraw with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset` | string | The asset the user wants to withdraw in the [Asset Identification Format](sep-0038.md#asset-identification-format). It must match one of the assets listed in the [/info](#info) response's withdraw object.
 `amount` | number | (optional) Amount of asset requested to withdraw.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client will use as the source of the withdrawal payment to the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo` | string | (**deprecated**, optional) This field was originally intended to differentiate users of the same Stellar account. However, the anchor should use the `sub` value included in the decoded SEP-10 JWT instead. Anchors should still support this parameter to maintain support for outdated clients. See the [Shared Account Authentication](#shared-omnibus-or-pooled-accounts) section for more information.

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -227,7 +227,7 @@ Name | Type | Description
 -----|------|------------
 `asset_code` | string | (**Deprecated**, use `asset` instead) The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
 `asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
-`asset` | string | The [Asset Identification Format](#asset-identification-format) value.
+`asset` | string | The [Asset Identification Format](sep-0038.md#asset-identification-format) value.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client wants to use as the destination of the payment sent by the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar transaction, one of `text`, `id` or `hash`.
@@ -1022,6 +1022,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 
 ## Changelog
 
+* `v3.1.0`: Deprecate `asset_code` and `asset_issuer` in favor of `asset` ([#1359](https://github.com/stellar/stellar-protocol/pull/1359))
 * `v3.0.0`: Make the `account` parameter for `POST /transactions/deposit/interactive` request optional ([#1343](https://github.com/stellar/stellar-protocol/pull/1343))
 * `v2.9.2`: Remove confusing statement on `updated_at` matching `completed_at` when `status` is `refunded` ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.9.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -6,8 +6,8 @@ Title: Hosted Deposit and Withdrawal
 Author: SDF
 Status: Active
 Created: 2019-09-18
-Updated: 2023-02-06
-Version 3.0.0
+Updated: 2023-06-08
+Version 3.1.0
 ```
 
 ## Simple Summary
@@ -225,8 +225,9 @@ Request Parameters:
 
 Name | Type | Description
 -----|------|------------
-`asset_code` | string | The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
-`asset_issuer` | string | (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset_code` | string | (**Deprecated**, use `asset` instead) The code of the stellar asset the user wants to receive for their deposit with the anchor. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.
+`asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the stellar asset the user wants to receive for their deposit with the anchor.  If asset_issuer is not provided, the anchor should use the asset issued by themselves as described in their TOML file.
+`asset` | string | The [Asset Identification Format](#asset-identification-format) value.
 `amount` | number | (optional) Amount of asset requested to deposit.  If this is not provided it will be collected in the interactive flow.
 `account` | `G...` or `M...` string | (optional) The Stellar or muxed account the client wants to use as the destination of the payment sent by the anchor. Defaults to the account authenticated via SEP-10 if not specified.
 `memo_type` | string | (optional) Type of memo that anchor should attach to the Stellar transaction, one of `text`, `id` or `hash`.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -6,7 +6,7 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2023-01-13
+Updated: 2023-06-08
 Version 2.4.0
 ```
 
@@ -429,8 +429,9 @@ Content-Type: application/json
 Name | Type | Description
 -----|-----|------
 `amount` | number | Amount of the Stellar asset sent to the Receiving Anchor.
-`asset_code` | string | Code of the asset the Sending Anchor intends to send. This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
-`asset_issuer` | string | (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
+`asset_code` | string | (**Deprecated**, use `asset` instead) Code of the asset the Sending Anchor intends to send. This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
+`asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
+`asset` | string | The [Asset Identification Format](#asset-identification-format) value.
 `destination_asset` | string | (optional) The off-chain asset the Receiving Anchor will deliver to the Receiving Client. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?sell_asset=stellar:<asset_code>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). If neither this field nor `quote_id` are set, it's assumed that [Sending Anchor Asset Conversions](#sending-anchor-asset-conversion) was used.
 `quote_id` | string | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this attribute is specified, the values for the fields defined above must match the values associated with the quote. 
 `sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Required if the Receiving Anchor requires SEP-12 KYC on the Sending Client.

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -431,7 +431,7 @@ Name | Type | Description
 `amount` | number | Amount of the Stellar asset sent to the Receiving Anchor.
 `asset_code` | string | (**Deprecated**, use `asset` instead) Code of the asset the Sending Anchor intends to send. This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
 `asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
-`asset` | string | The [Asset Identification Format](#asset-identification-format) value.
+`asset` | string | The [Asset Identification Format](sep-0038.md#asset-identification-format) value.
 `destination_asset` | string | (optional) The off-chain asset the Receiving Anchor will deliver to the Receiving Client. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?sell_asset=stellar:<asset_code>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). If neither this field nor `quote_id` are set, it's assumed that [Sending Anchor Asset Conversions](#sending-anchor-asset-conversion) was used.
 `quote_id` | string | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this attribute is specified, the values for the fields defined above must match the values associated with the quote. 
 `sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Required if the Receiving Anchor requires SEP-12 KYC on the Sending Client.
@@ -901,6 +901,7 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 
 ## Changelog
 
+* `v2.5.0`: Deprecate `asset_code` and `asset_issuer` in favor of `asset` ([#1359](https://github.com/stellar/stellar-protocol/pull/1359))
 * `v2.4.0`: Add `updated_at` to `GET /transactions/:id` response ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v2.3.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v2.3.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -7,7 +7,7 @@ Author: SDF
 Status: Active
 Created: 2020-04-07
 Updated: 2023-06-08
-Version 2.4.0
+Version 2.5.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -357,8 +357,7 @@ Content-Type: application/json
 
 {
   "amount": 100,
-  "asset_code": "USDC",
-  "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
+  "asset": "stellar:USDC:GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
   "sender_id": "d2bd1412-e2f6-4047-ad70-a1a2f133b25c",
   "receiver_id": "137938d4-43a7-4252-a452-842adcee474c",
   "fields": {
@@ -383,8 +382,7 @@ Content-Type: application/json
 
 {
   "amount": 100,
-  "asset_code": "USDC",
-  "asset_issuer": "GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
+  "asset": "stellar:USDC:GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
   "destination_asset": "iso4217:BRL",
   "sender_id": "d2bd1412-e2f6-4047-ad70-a1a2f133b25c",
   "receiver_id": "137938d4-43a7-4252-a452-842adcee474c",
@@ -401,6 +399,32 @@ Content-Type: application/json
 ---
 
 The following is an example request body if the Sending Anchor requested a _firm_ quote from [`SEP-38 POST /quote`](sep-0038.md#post-quote) and found the rate acceptable. In this case, the Receiving Anchor must ensure that the information passed in the `POST /transactions` request matches the assets and amounts defined in the `POST /quote` request and response.
+
+```
+POST DIRECT_PAYMENT_SERVER/transactions
+Content-Type: application/json
+
+{
+  "amount": 100,
+  "asset": "stellar:USDC:GDRHDSTZ4PK6VI3WL224XBJFEB6CUXQESTQPXYIB3KGITRLL7XVE4NWV",
+  "destination_asset": "iso4217:BRL",
+  "quote_id": "2bc5b322-5117-413f-869f-e7ca494cb1a4",
+  "sender_id": "d2bd1412-e2f6-4047-ad70-a1a2f133b25c",
+  "receiver_id": "137938d4-43a7-4252-a452-842adcee474c",
+  "fields": {
+    "transaction": {
+      "receiver_routing_number": "442928834",
+      "receiver_account_number": "0029483242",
+      "type": "SEPA"
+    }
+  }
+}
+```
+
+---
+
+The following is same as the previous example, but the source asset is specified using the `asset_code` and `asset_issuer` parameters instead of the `asset` parameter. This way of specifying the source asset
+will be eventually deprecated in favor of the `asset` parameter.
 
 ```
 POST DIRECT_PAYMENT_SERVER/transactions
@@ -431,7 +455,7 @@ Name | Type | Description
 `amount` | number | Amount of the Stellar asset sent to the Receiving Anchor.
 `asset_code` | string | (**Deprecated**, use `asset` instead) Code of the asset the Sending Anchor intends to send. This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
 `asset_issuer` | string | (**Deprecated**, use `asset` instead) (optional) The issuer of the Stellar asset the Sending Anchor intends to send. If not specified, the asset sent must be issued by the Receiving Anchor.
-`asset` | string | The [Asset Identification Format](sep-0038.md#asset-identification-format) value.
+`asset` | string | The asset the Sending Anchor intends to send in the [Asset Identification Format](sep-0038.md#asset-identification-format). This must match one of the entries listed in the receiving anchor's `GET /info` endpoint.
 `destination_asset` | string | (optional) The off-chain asset the Receiving Anchor will deliver to the Receiving Client. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?sell_asset=stellar:<asset_code>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format). If neither this field nor `quote_id` are set, it's assumed that [Sending Anchor Asset Conversions](#sending-anchor-asset-conversion) was used.
 `quote_id` | string | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this attribute is specified, the values for the fields defined above must match the values associated with the quote. 
 `sender_id` | `string` | (optional) The ID included in the [SEP-12 PUT /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-put) response for the Sending Client. Required if the Receiving Anchor requires SEP-12 KYC on the Sending Client.


### PR DESCRIPTION
### Abstract
SEP-38 introduced an [asset identification format](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#asset-identification-format) that allow Anchors to represent the native token (XLM), fiat assets and the usual non-native tokens in its RFQ APIs. 

This differs from the way SEP-24 and SEP-31 represents assets, where `asset_code` and `asset_issuer` must be specified. In this scheme, XLM cannot be represented as it does not have an `asset_issuer`.

### Proposal

This introduces the SEP-38 asset identification formatted `asset` request parameter to SEP-6 and SEP-24 APIs. The goal is to eventually deprecate `asset_code` and `asset_issuer` and use the SEP-38 format everywhere.