### PR TITLE
Replace price() timestamp with ranges

### DIFF
--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -102,7 +102,7 @@ pub trait PriceFeedTrait {
 
 Assets have type `Bytes`, this allows representing both fiat and Stellar assets in the following formats:
 - `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
-- `<Address>` for Stellar assets, where `Address` is the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. ``d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
+- `<Address>` for Stellar assets, where `Address` is the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
 
 ### Contract Address
 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -100,7 +100,7 @@ pub trait PriceFeedTrait {
 }
 ```
 
-The `asset` parameter has type `Bytes`, this allows representing both fiat and Stellar assets in the following formats:
+Assets have type `Bytes`, this allows representing both fiat and Stellar assets in the following formats:
 - `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
 - `<Address>` for Stellar assets, where `Address` is the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. ``d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -85,19 +85,22 @@ pub trait PriceFeedTrait {
         env: soroban_sdk::Env
     ) -> u32;
 
-    /// Get price in base asset at specific timestamp
-    fn price(
-        env: soroban_sdk::Env,
-        asset: Asset,
-        timestamp: u64
-    ) -> Option<PriceData>;
-
-    /// Get last N price records
+    /// Get prices (in base asset) contained in the provided timestamp range, ordered by oldest to newest.
+    /// Both timestamps are inclusive, meaning if there's a price exactly at
+    /// `start_timestamp`, it will be included. Same for `end_timestamp`.
     fn prices(
         env: soroban_sdk::Env,
         asset: Asset,
+        start_timestamp: u64,
+        end_timestamp: u64
+    ) -> Vec<PriceData>;
+
+    /// Get last N price records, ordered by oldest to newest
+    fn lastprices(
+        env: soroban_sdk::Env,
+        asset: Asset,
         records: u32
-    ) -> Option<Vec<PriceData>>;
+    ) -> Vec<PriceData>;
 
     /// Get the most recent price for an asset
     fn lastprice(

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -59,9 +59,8 @@ pub struct PriceData {
 
 #[contracttype]
 enum Asset {
-   Contract(Address),
-   ISO4217(String),
-   Generic(String)
+   Stellar(Address),
+   Other(Symbol),
 }
 
 /// Oracle feed interface description
@@ -108,10 +107,10 @@ pub trait PriceFeedTrait {
 }
 ```
 
-Assets are represented as the struct `Asset`, this allows representing both fiat and Stellar assets in the following formats:
-- Stellar: `Asset::Address` containing the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
-- Fiat: `Asset::ISO4217` containing the ISO4217 currency code, e.g. `USD`, `EUR`
-- Other non-standard currencies: `Asset::Generic` containing the currency or token code, e.g. `BTC`, `MYMUTUALTOKEN`
+Assets are represented as the struct `Asset`, in the following formats:
+
+- Stellar assets: `Asset::Stellar` containing the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`.
+- Other assets (e.g. fiat off-chain currencies, mutual funds tokens, etc): `Asset::Other` containing the currency or token name. Since `Asset::Other` can be any `Symbol`, each Oracle can define it's own format for representing off-chain assets.
 
 ### Contract Address
 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -52,7 +52,7 @@ The price feed contract should follow the `PriceFeedTrait` interface defined her
 ```rust
 /// Price data for an asset at a specific timestamp
 pub struct PriceData {
-    price: i128,
+    price: u128,
     timestamp: u64
 }
 
@@ -61,12 +61,12 @@ pub trait PriceFeedTrait {
     /// Return the base asset the price is reported in
     fn base(
         env: soroban_sdk::Env,
-    ) -> Address;
+    ) -> Bytes;
 
     /// Return all assets quoted by the price feed
     fn assets(
         env: soroban_sdk::Env,
-    ) -> Vec<Address>;
+    ) -> Vec<Bytes>;
 
     /// Return the number of decimals for all assets quoted by the oracle
     fn decimals(
@@ -81,24 +81,28 @@ pub trait PriceFeedTrait {
     /// Get price in base asset at specific timestamp
     fn price(
         env: soroban_sdk::Env,
-        asset: Address,
+        asset: Bytes,
         timestamp: u64
     ) -> Option<PriceData>;
 
     /// Get last N price records
     fn prices(
         env: soroban_sdk::Env,
-        asset: Address,
+        asset: Bytes,
         records: u32
     ) -> Option<Vec<PriceData>>;
 
     /// Get the most recent price for an asset
     fn lastprice(
         env: soroban_sdk::Env,
-        asset: Address,
+        asset: Bytes,
     ) -> Option<PriceData>;
 }
 ```
+
+The `asset` parameter has type `Bytes`, this allows representing both fiat and Stellar assets in the following formats:
+- `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
+- `<Address>` for Stellar assets, where `Address` is the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. ``d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
 
 ### Contract Address
 
@@ -108,7 +112,7 @@ providers.
 
 ## Design Rationale
 
-`PriceData` represents a datapoint describing a price of an asset at a specific timestamp. Price is encoded as an `i128` number where last N
+`PriceData` represents a datapoint describing a price of an asset at a specific timestamp. Price is encoded as an `u128` number where last N
 digits designate the fractional part of the price stored with precision defined by `decimals()` of the given oracle feed. So the actual
 price can be calculated as `price/10^decimals`. Note that using this conversion directly in the Soroban environment will result in the loss
 of a fractional part since only integer division is supported, so only safe integer arithmetics should be used when consuming oracle prices.

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -109,8 +109,9 @@ pub trait PriceFeedTrait {
 ```
 
 Assets are represented as the struct `Asset`, this allows representing both fiat and Stellar assets in the following formats:
-- Fiat: `Asset::Generic` containing a string in the format `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
 - Stellar: `Asset::Address` containing the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
+- Fiat: `Asset::ISO4217` containing the ISO4217 currency code, e.g. `USD`, `EUR`
+- Other non-standard currencies: `Asset::Generic` containing the currency or token code, e.g. `BTC`, `MYMUTUALTOKEN`
 
 ### Contract Address
 

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -51,9 +51,16 @@ The price feed contract should follow the `PriceFeedTrait` interface defined her
 
 ```rust
 /// Price data for an asset at a specific timestamp
+#[contracttype]
 pub struct PriceData {
-    price: u128,
+    price: i128,
     timestamp: u64
+}
+
+#[contracttype]
+enum Asset {
+   Contract(Address),
+   Generic(String)
 }
 
 /// Oracle feed interface description
@@ -61,12 +68,12 @@ pub trait PriceFeedTrait {
     /// Return the base asset the price is reported in
     fn base(
         env: soroban_sdk::Env,
-    ) -> Bytes;
+    ) -> Asset;
 
     /// Return all assets quoted by the price feed
     fn assets(
         env: soroban_sdk::Env,
-    ) -> Vec<Bytes>;
+    ) -> Vec<Asset>;
 
     /// Return the number of decimals for all assets quoted by the oracle
     fn decimals(
@@ -81,28 +88,28 @@ pub trait PriceFeedTrait {
     /// Get price in base asset at specific timestamp
     fn price(
         env: soroban_sdk::Env,
-        asset: Bytes,
+        asset: Asset,
         timestamp: u64
     ) -> Option<PriceData>;
 
     /// Get last N price records
     fn prices(
         env: soroban_sdk::Env,
-        asset: Bytes,
+        asset: Asset,
         records: u32
     ) -> Option<Vec<PriceData>>;
 
     /// Get the most recent price for an asset
     fn lastprice(
         env: soroban_sdk::Env,
-        asset: Bytes,
+        asset: Asset,
     ) -> Option<PriceData>;
 }
 ```
 
-Assets have type `Bytes`, this allows representing both fiat and Stellar assets in the following formats:
-- `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
-- `<Address>` for Stellar assets, where `Address` is the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
+Assets are represented as the struct `Asset`, this allows representing both fiat and Stellar assets in the following formats:
+- Fiat: `Asset::Generic` containing a string in the format `iso:4217:<currency code>` for fiat currencies, e.g. `iso4217:USD` for US Dollar, `iso4217:EUR` for Euro, etc
+- Stellar: `Asset::Address` containing the asset unique address in Soroban network, obtained when an asset from Stellar Classic is deployed to Soroban via the [Stellar Asset Contract](https://soroban.stellar.org/docs/how-to-guides/stellar-asset-contract). E.g. `d93f5c7bb0ebc4a9c8f727c5cebc4e41194d38257e1d0d910356b43bfc528813`
 
 ### Contract Address
 
@@ -112,7 +119,7 @@ providers.
 
 ## Design Rationale
 
-`PriceData` represents a datapoint describing a price of an asset at a specific timestamp. Price is encoded as an `u128` number where last N
+`PriceData` represents a datapoint describing a price of an asset at a specific timestamp. Price is encoded as an `i128` number where last N
 digits designate the fractional part of the price stored with precision defined by `decimals()` of the given oracle feed. So the actual
 price can be calculated as `price/10^decimals`. Note that using this conversion directly in the Soroban environment will result in the loss
 of a fractional part since only integer division is supported, so only safe integer arithmetics should be used when consuming oracle prices.

--- a/ecosystem/sep-0040.md
+++ b/ecosystem/sep-0040.md
@@ -60,6 +60,7 @@ pub struct PriceData {
 #[contracttype]
 enum Asset {
    Contract(Address),
+   ISO4217(String),
    Generic(String)
 }
 


### PR DESCRIPTION
Since prices can be set at any arbitrary timestamp, I don't think it's very useful to require a `timestamp` parameter in the `price()` function, because this would force the caller to either predict which timestamps have prices, or loop through timestamps until a price is found. This is not efficient.
Instead, `price()` should take a range of timestamps and return a list of prices contained in that range, ordered by oldest to newest in the `Vec`.
`price()` should be renamed to `prices()` since it returns a `Vec`.
The current `prices()` should be renamed to `lastprices()` since it returns the last N prices, and also to not conflict with the other function being renamed.

This would be the new `price()` parameter structure:
```
/// Get prices (in base asset) contained in the provided timestamp range, ordered by oldest to newest.
/// Both timestamps are inclusive, meaning if there's a price exactly at
/// `start_timestamp`, it will be included. Same for `end_timestamp`.
fn prices(
    env: soroban_sdk::Env,
    asset: Asset,
    start_timestamp: u64,
    end_timestamp: u64
) -> Vec<PriceData>;
```

Current `prices()` renamed to `lastprices()`:
```
/// Get last N price records, ordered by oldest to newest
fn lastprices(
    env: soroban_sdk::Env,
    asset: Asset,
    records: u32
) -> Vec<PriceData>;
```

Return type of both `prices()` and `lastprices()` changed to `Vec<PriceData>`. There's no need for `Option<Vec<PriceData>>`, since an empty `Vec` already means "no prices found".