### PR TITLE
SEP-6: Deprecate /fee endpont

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2023-01-13
-Version 3.18.1
+Updated: 2023-08-15
+Version 3.19.0
 ```
 
 ## Simple Summary
@@ -114,7 +114,7 @@ sequenceDiagram
 * [`GET /deposit-exchange`](#deposit-exchange): optional
 * [`GET /withdraw-exchange`](#withdraw-exchange): optional
 * [`GET /info`](#info): required
-* [`GET /fee`](#fee): optional
+- [`GET /fee`](#fee): **deprecated** optional (only needed for complex fee structures).
 * [`GET /transactions`](#transaction-history): required
 * [`GET /transaction`](#single-historical-transaction): required
 
@@ -1004,6 +1004,8 @@ The default values for the features listed above have been selected based on the
 
 ## Fee
 
+**This endpoint is deprecated. The [SEP-38] `GET /price` endpoint should be used to fetch fees instead.**
+
 The fee endpoint allows an anchor to report the fee that would be charged when using the `/deposit` or `/withdraw` endpoints.
 
 This endpoint is important to allow an anchor to accurately report fees to a user even when the fee schedule is complex. If a fee can be fully expressed with the `fee_fixed` and `fee_percent` fields in the `/info` response, then an anchor should not implement this endpoint.
@@ -1420,6 +1422,7 @@ If the information was malformed, or if the sender tried to update data that isn
 
 ## Changelog
 
+* `v3.19.0`: Deprecate `/fee` endpoint
 * `v3.18.1`: Fix the missing types of the `withdraw` request parameters and some typo.  ([#1365](https://github.com/stellar/stellar-protocol/pull/1365))
 * `v3.18.0`: Added `refunded` status and `updated_at` transaction fields to match other SEPs (24, 31) ([#1336](https://github.com/stellar/stellar-protocol/pull/1336))
 * `v3.17.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -1387,7 +1387,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 ## Changelog
 
 - `v3.3.0`: Add support for [SEP-38] API. Add optional `quote_id` parameter to `post /transactions/deposit/interactive`
-  and `POST /transactions/deposit/interactive` requests. Add `quote_id` to the transaction object schema.
+  and `POST /transactions/deposit/interactive` requests. Add `quote_id` to the transaction object schema. Deprecate `/fee` endpoint.
   ([#1358](https://github.com/stellar/stellar-protocol/pull/1358))
 - `v3.2.0`: Deprecate the `wallet_name` and `wallet_url` parameters of `POST /transactions/deposit/interactive` and
   `POST /transactions/withdrawal/interactive` requests ([#1364](https://github.com/stellar/stellar-protocol/pull/1364))


### PR DESCRIPTION
Deprecate `/fee` endpoint for SEP-6.
Update SEP-24 changelog, as fee was already deprecated there, but not reflected in the changelog.