### PR TITLE
SEP-9: Add crypto fields to financial account fields

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -111,6 +111,8 @@ applications use fields that are the most familiar, which are often specific to 
 | `clabe_number`        | string | Bank account number for Mexico                                                 |
 | `cbu_number`          | string | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                 |
 | `cbu_alias`           | string | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU). |
+| `crypto_address`      | string | Address for a cryptocurrency account                                           |
+| `crypto_memo`         | string | A destination tag/memo used to identify a transaction                          |
 
 ## Organization Fields
 
@@ -147,6 +149,7 @@ already separate fields.
 
 ## Changelog
 
+- `v1.13.0` Add `crypto` related fields to financial account fields section.
 - `v1.12.0`: Define financial account fields section. ([#1367](https://github.com/stellar/stellar-protocol/pull/1367))
 - `v1.11.0`: Add `bank_account_type` for describing types of bank accounts.
   ([#1344](https://github.com/stellar/stellar-protocol/pull/1344))

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2023-06-30
-Version 1.12.0
+Updated: 2023-08-16
+Version 1.13.0
 ```
 
 ## Simple Summary
@@ -149,7 +149,7 @@ already separate fields.
 
 ## Changelog
 
-- `v1.13.0` Add `crypto` related fields to financial account fields section.
+- `v1.13.0`: Add `crypto` related fields to financial account fields section. ([#1382](https://github.com/stellar/stellar-protocol/pull/1382))
 - `v1.12.0`: Define financial account fields section. ([#1367](https://github.com/stellar/stellar-protocol/pull/1367))
 - `v1.11.0`: Add `bank_account_type` for describing types of bank accounts.
   ([#1344](https://github.com/stellar/stellar-protocol/pull/1344))


### PR DESCRIPTION
SEP-6 will provide structured off-chain deposit instructions which can include deposits to an organization's crypto accounts. This adds the `crypto_address` and `crypto_memo` fields to the standard.