### PR TITLE
SEP-9: move bank_account_number into account-related fields section

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -69,7 +69,6 @@ top-level key.
 | `birth_date`                  | date   | Date of birth, e.g. `1976-07-04`                                                            |
 | `birth_place`                 | string | Place of birth (city, state, country; as on passport)                                       |
 | `birth_country_code`          | string | ISO Code of country of birth                                                                |
-| `bank_account_number`         | string | Number identifying bank account                                                             |
 | `tax_id`                      | string | Tax identifier of user in their country (social security number in US)                      |
 | `tax_id_name`                 | string | Name of the tax ID (`SSN` or `ITIN` in the US)                                              |
 | `occupation`                  | number | Occupation ISCO code                                                                        |
@@ -102,15 +101,16 @@ any country, and some fields are specific to a given country, such as `cbu_numbe
 addition to other pieces of information. In order to optimize for the user's experience, it is recommended that
 applications use fields that are the most familiar, which are often specific to a given country or financial system.
 
-| Name                 | Type   | Description                                                                    |
-| -------------------- | ------ | ------------------------------------------------------------------------------ |
-| `bank_account_type`  | string | `checking` or `savings`                                                        |
-| `bank_number`        | string | Number identifying bank in national banking system (routing number in US)      |
-| `bank_phone_number`  | string | Phone number with country code for bank                                        |
-| `bank_branch_number` | string | Number identifying bank branch                                                 |
-| `clabe_number`       | string | Bank account number for Mexico                                                 |
-| `cbu_number`         | string | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                 |
-| `cbu_alias`          | string | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU). |
+| Name                  | Type   | Description                                                                    |
+| --------------------- | ------ | ------------------------------------------------------------------------------ |
+| `bank_account_type`   | string | `checking` or `savings`                                                        |
+| `bank_account_number` | string | Number identifying bank account                                                |
+| `bank_number`         | string | Number identifying bank in national banking system (routing number in US)      |
+| `bank_phone_number`   | string | Phone number with country code for bank                                        |
+| `bank_branch_number`  | string | Number identifying bank branch                                                 |
+| `clabe_number`        | string | Bank account number for Mexico                                                 |
+| `cbu_number`          | string | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                 |
+| `cbu_alias`           | string | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU). |
 
 ## Organization Fields
 


### PR DESCRIPTION
`bank_account_number` was missed when splitting personal KYC fields and financial account fields in #1367