### PR TITLE
update CAP 0046-05 smart contract data

### DIFF
--- a/contents/cap-0046/Stellar-contract-config-setting.x
+++ b/contents/cap-0046/Stellar-contract-config-setting.x
@@ -164,7 +164,6 @@ struct StateExpirationSettings {
     uint32 maxEntryExpiration;
     uint32 minTempEntryExpiration;
     uint32 minPersistentEntryExpiration;
-    uint32 autoBumpLedgers;
 
     // rent_fee = wfee_rate_average / rent_rate_denominator_for_type
     int64 persistentRentRateDenominator;

--- a/contents/cap-0046/Stellar-contract-meta.x
+++ b/contents/cap-0046/Stellar-contract-meta.x
@@ -1,0 +1,29 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// The contract meta XDR is highly experimental, incomplete, and still being
+// iterated on. Breaking changes expected.
+
+% #include "xdr/Stellar-types.h"
+namespace stellar
+{
+
+struct SCMetaV0
+{
+    string key<>;
+    string val<>;
+};
+
+enum SCMetaKind
+{
+    SC_META_V0 = 0
+};
+
+union SCMetaEntry switch (SCMetaKind kind)
+{
+case SC_META_V0:
+    SCMetaV0 v0;
+};
+
+}

--- a/contents/cap-0046/Stellar-contract-spec.x
+++ b/contents/cap-0046/Stellar-contract-spec.x
@@ -10,29 +10,35 @@
 namespace stellar
 {
 
+const SC_SPEC_DOC_LIMIT = 1024;
+
 enum SCSpecType
 {
     SC_SPEC_TYPE_VAL = 0,
 
     // Types with no parameters.
-    SC_SPEC_TYPE_U32 = 1,
-    SC_SPEC_TYPE_I32 = 2,
-    SC_SPEC_TYPE_U64 = 3,
-    SC_SPEC_TYPE_I64 = 4,
-    SC_SPEC_TYPE_BOOL = 5,
-    SC_SPEC_TYPE_SYMBOL = 6,
-    SC_SPEC_TYPE_BITSET = 7,
-    SC_SPEC_TYPE_STATUS = 8,
-    SC_SPEC_TYPE_BYTES = 9,
-    SC_SPEC_TYPE_BIG_INT = 10,
-    SC_SPEC_TYPE_INVOKER = 11,
-    SC_SPEC_TYPE_ACCOUNT_ID = 12,
+    SC_SPEC_TYPE_BOOL = 1,
+    SC_SPEC_TYPE_VOID = 2,
+    SC_SPEC_TYPE_ERROR = 3,
+    SC_SPEC_TYPE_U32 = 4,
+    SC_SPEC_TYPE_I32 = 5,
+    SC_SPEC_TYPE_U64 = 6,
+    SC_SPEC_TYPE_I64 = 7,
+    SC_SPEC_TYPE_TIMEPOINT = 8,
+    SC_SPEC_TYPE_DURATION = 9,
+    SC_SPEC_TYPE_U128 = 10,
+    SC_SPEC_TYPE_I128 = 11,
+    SC_SPEC_TYPE_U256 = 12,
+    SC_SPEC_TYPE_I256 = 13,
+    SC_SPEC_TYPE_BYTES = 14,
+    SC_SPEC_TYPE_STRING = 16,
+    SC_SPEC_TYPE_SYMBOL = 17,
+    SC_SPEC_TYPE_ADDRESS = 19,
 
     // Types with parameters.
     SC_SPEC_TYPE_OPTION = 1000,
     SC_SPEC_TYPE_RESULT = 1001,
     SC_SPEC_TYPE_VEC = 1002,
-    SC_SPEC_TYPE_SET = 1003,
     SC_SPEC_TYPE_MAP = 1004,
     SC_SPEC_TYPE_TUPLE = 1005,
     SC_SPEC_TYPE_BYTES_N = 1006,
@@ -63,11 +69,6 @@ struct SCSpecTypeMap
     SCSpecTypeDef valueType;
 };
 
-struct SCSpecTypeSet
-{
-    SCSpecTypeDef elementType;
-};
-
 struct SCSpecTypeTuple
 {
     SCSpecTypeDef valueTypes<12>;
@@ -86,18 +87,23 @@ struct SCSpecTypeUDT
 union SCSpecTypeDef switch (SCSpecType type)
 {
 case SC_SPEC_TYPE_VAL:
-case SC_SPEC_TYPE_U64:
-case SC_SPEC_TYPE_I64:
+case SC_SPEC_TYPE_BOOL:
+case SC_SPEC_TYPE_VOID:
+case SC_SPEC_TYPE_ERROR:
 case SC_SPEC_TYPE_U32:
 case SC_SPEC_TYPE_I32:
-case SC_SPEC_TYPE_BOOL:
-case SC_SPEC_TYPE_SYMBOL:
-case SC_SPEC_TYPE_BITSET:
-case SC_SPEC_TYPE_STATUS:
+case SC_SPEC_TYPE_U64:
+case SC_SPEC_TYPE_I64:
+case SC_SPEC_TYPE_TIMEPOINT:
+case SC_SPEC_TYPE_DURATION:
+case SC_SPEC_TYPE_U128:
+case SC_SPEC_TYPE_I128:
+case SC_SPEC_TYPE_U256:
+case SC_SPEC_TYPE_I256:
 case SC_SPEC_TYPE_BYTES:
-case SC_SPEC_TYPE_BIG_INT:
-case SC_SPEC_TYPE_INVOKER:
-case SC_SPEC_TYPE_ACCOUNT_ID:
+case SC_SPEC_TYPE_STRING:
+case SC_SPEC_TYPE_SYMBOL:
+case SC_SPEC_TYPE_ADDRESS:
     void;
 case SC_SPEC_TYPE_OPTION:
     SCSpecTypeOption option;
@@ -107,8 +113,6 @@ case SC_SPEC_TYPE_VEC:
     SCSpecTypeVec vec;
 case SC_SPEC_TYPE_MAP:
     SCSpecTypeMap map;
-case SC_SPEC_TYPE_SET:
-    SCSpecTypeSet set;
 case SC_SPEC_TYPE_TUPLE:
     SCSpecTypeTuple tuple;
 case SC_SPEC_TYPE_BYTES_N:
@@ -119,25 +123,49 @@ case SC_SPEC_TYPE_UDT:
 
 struct SCSpecUDTStructFieldV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<30>;
     SCSpecTypeDef type;
 };
 
 struct SCSpecUDTStructV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTStructFieldV0 fields<40>;
 };
 
-struct SCSpecUDTUnionCaseV0
+struct SCSpecUDTUnionCaseVoidV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
-    SCSpecTypeDef *type;
+};
+
+struct SCSpecUDTUnionCaseTupleV0
+{
+    string doc<SC_SPEC_DOC_LIMIT>;
+    string name<60>;
+    SCSpecTypeDef type<12>;
+};
+
+enum SCSpecUDTUnionCaseV0Kind
+{
+    SC_SPEC_UDT_UNION_CASE_VOID_V0 = 0,
+    SC_SPEC_UDT_UNION_CASE_TUPLE_V0 = 1
+};
+
+union SCSpecUDTUnionCaseV0 switch (SCSpecUDTUnionCaseV0Kind kind)
+{
+case SC_SPEC_UDT_UNION_CASE_VOID_V0:
+    SCSpecUDTUnionCaseVoidV0 voidCase;
+case SC_SPEC_UDT_UNION_CASE_TUPLE_V0:
+    SCSpecUDTUnionCaseTupleV0 tupleCase;
 };
 
 struct SCSpecUDTUnionV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTUnionCaseV0 cases<50>;
@@ -145,12 +173,14 @@ struct SCSpecUDTUnionV0
 
 struct SCSpecUDTEnumCaseV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
     uint32 value;
 };
 
 struct SCSpecUDTEnumV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTEnumCaseV0 cases<50>;
@@ -158,12 +188,14 @@ struct SCSpecUDTEnumV0
 
 struct SCSpecUDTErrorEnumCaseV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<60>;
     uint32 value;
 };
 
 struct SCSpecUDTErrorEnumV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string lib<80>;
     string name<60>;
     SCSpecUDTErrorEnumCaseV0 cases<50>;
@@ -171,12 +203,14 @@ struct SCSpecUDTErrorEnumV0
 
 struct SCSpecFunctionInputV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     string name<30>;
     SCSpecTypeDef type;
 };
 
 struct SCSpecFunctionV0
 {
+    string doc<SC_SPEC_DOC_LIMIT>;
     SCSymbol name;
     SCSpecFunctionInputV0 inputs<10>;
     SCSpecTypeDef outputs<1>;

--- a/core/cap-0046-05.md
+++ b/core/cap-0046-05.md
@@ -5,7 +5,7 @@ CAP: CAP-0046-05 (formerly 0053)
 Title: Smart Contract Data
 Working Group:
     Owner: Graydon Hoare <@graydon>
-    Authors: Graydon Hoare <@graydon> 
+    Authors: Graydon Hoare <@graydon>
     Consulted: Siddharth Suresh <@sisuresh>, Jon Jove <@jonjove>, Nicolas Barry <@MonsieurNicolas>, Leigh McCulloch <@leighmcculloch>, Tomer Weller <@tomerweller>
 Status: Draft
 Created: 2022-05-25
@@ -15,11 +15,11 @@ Protocol version: TBD
 
 ## Simple Summary
 
-This CAP defines a ledger entry type for storing data records for smart contracts, as well as host functions for interacting with it and some discussion of its interaction with contract invocation and execution.
+This CAP defines a ledger entry types for storing data records for smart contracts, as well as host functions for interacting with it and some discussion of its interaction with contract invocation and execution.
 
 ## Working Group
 
-This protocol change was authored by Graydon Hoare, with input from the consulted individuals mentioned at the top of this document. 
+This protocol change was authored by Graydon Hoare, with input from the consulted individuals mentioned at the top of this document.
 
 ## Motivation
 
@@ -37,27 +37,76 @@ Same goals alignment as CAP-46. This CAP is essentially "a continuation of the w
   - Parallel execution must maintain a strong consistency model: strict serializability.
   - The performance impact of user-initiated IO should be strictly limited, as IO can be very costly.
   - The granularity of IO should balance the desirability of amortizing fixed per-IO costs with the undesirability of IO on redundant data.
+  - The ledger space consumed by contract data should be attenuated when possible, especially transient and dormant data.
 
-Additionally, several considerations that applied to the data model of CAP-46 apply here, especially around interoperability and simplicity:
+Additionally, several considerations that applied to the data model of CAP-0046-01 apply here, especially around interoperability and simplicity:
 
   - At least some data should be readable passively without running contract code.
   - Data should be at least somewhat robust to version changes in the contract code accessing it.
 
 ## Abstract
 
-A new ledger entry type is added that stores key-value pairs, where both key and val are of type `SCVal` (defined in CAP-46).
+A new ledger entry type is added that stores key-value pairs, where both key and val are of type `SCVal` (defined in [CAP-0046-01](./cap-0046-01.md)).
 
-New host functions are added to query and modify this ledger entry type directly from within a smart contract.
+An additional small key-value map called **instance storage** is also available inside each contract instance ledger entry (defined in [CAP-0046-02](./cap-0046-02.md)).
+
+New host functions are added to query and modify these key-value pairs from within a smart contract.
 
 ## Specification
 
-Readers should be familiar with the content of CAP-46 and CAP-47 at least, this cap uses their definitions.
+Readers should be familiar with the content of CAP-0046-01 and CAP-0046-02 at least, this CAP uses their definitions.
+
+### Ledger entry and key
 
 This CAP adds an entry type code `LedgerEntryType.CONTRACT_DATA`, an entry struct `ContractDataEntry`, and a variant of the `LedgerEntry` and `LedgerKey` unions to store the ledger entry and its key material, respectively, under the `CONTRACT_DATA` type code.
 
-The _full key_ of a `CONTRACT_DATA` ledger entry is not just by its `key` field, but also a `ContractID` field (as defined in CAP-47). A contract can only read and write `CONTRACT_DATA` ledger entries that have that contract's `ContractID`.
+The `LedgerKey` of a `CONTRACT_DATA` ledger entry is composed of:
+  - A `ContractID` field (as defined in CAP-0046-02).
+  - A `ContractDataDurability` field (as defined in CAP-0046-TBD data expiry).
+  - A `key` field, an `SCVal` chosen by the contract.
 
-Host functions are provided to get, put, delete, and check for the existence of a given `CONTRACT_DATA` entry.
+Each `CONTRACT_DATA` ledger entry has a unique `LedgerKey`, but multiple ledger entries may have the same `key` field within that `LedgerKey`, so long as the other earlier fields differ. In other words, there is a separate "key-space" for key-value mappings within each `ContractID` and `ContractDataDurability` level.
+
+The `LedgerKey` implied by an access to a key-value pair held in instance storage is different from that of a key-value pair in its own ledger entry. See the section on instance storage.
+
+### Instance storage
+
+This CAP adds (or rather, describes access to) an `SCMap` called `storage` stored inside each `SCContractInstance`. This **instance storage** map contains data that is closely coupled to the lifecycle and read-access pattern of the contract instance itself. See [CAP-0046-02](./cap-0046-02.md) for details on contract instances.
+
+A contract accesses instance storage by `key`, but this key is _not_ used to form a `LedgerKey` to access a ledger entry in the storage system. Rather, the entire `SCContractInstance` (including its entire `SCMap storage`) is accessed as a single `CONTRACT_DATA` ledger entry with its `LedgerKey` keyed by a special `SCVal` reserved just for this purpose: `SCV_LEDGER_KEY_CONTRACT_INSTANCE`.
+
+In other words, all keys and values in instance storage are loaded or saved together, and the ledger entry storing them is just the instance entry itself.
+
+### Host functions
+
+Host functions are provided to get, put, delete, and check for the existence of a key-value pair.
+
+The same host functions are used to access key-value pairs in `CONTRACT_DATA` ledger entries _or_ instance storage.
+
+When accessing `CONTRACT_DATA` ledger entries:
+  - The `ContractID` in the `LedgerKey` being accessed is implicitly that of the calling contract
+  - The host function can _only_ access ledger entries with that `ContractID`
+
+When accessing instance storage:
+  - The instance storage being accessed is implicitly that of the calling contract
+  - The host function can _only_ access that instance storage
+
+Host functions for key-value access are also passed a **storage type**.
+
+### StorageType
+
+The **storage type** provided to a given key-value access host function is, at the host interface level, a plain `u64` that encodes the Rust enum `StorageType`.
+
+This type has 3 cases:
+  - `StorageType::Temporary = 0` which directs the host function to access a `ContractData` ledger entry with `ContractDataDurability::TEMPORARY`.
+  - `StorageType::Persistent = 1` which directs the host function to access a `ContractData` ledger entry with `ContractDataDurability::PERSISTENT`.
+  - `StorageType::Instance = 2` which directs the host function to access contract-instance storage.
+
+The storage type specifies two separate dimensions of storage:
+  - Whether to access a key-value mapping held in instance storage or a separate per-key ledger entry
+  - The durability of the key-value mapping to access.
+
+These two separate dimensions are selected with a single value because instance storage is always implicitly `PERSISTENT`, as it is stored in contract instances which are `PERSISTENT`.
 
 ### Restrictions
 
@@ -65,11 +114,13 @@ Host functions are provided to get, put, delete, and check for the existence of 
 Contract data IO is restricted to so-called "point access" to specific keys. In particular there is no support for "range queries", upper or lower bounds, or any sort of iteration over the keyspace.
 
 #### Static footprints
-To facilitate parallel execution, contract data IO is also restricted to operate on keys that are declared in the so-called _footprint_ of each transaction. The footprint is a set of _full keys_ each of which is marked as either read-only or read-write. The footprint _permits_ any read of a key within it, or a write of any key within it that is marked as read-write. All other reads and writes are not permitted.
+To facilitate parallel execution, contract data IO is also restricted to operate on keys that are declared in the so-called _footprint_ of each transaction. The footprint is a set of `LedgerKey`s each of which is marked as either read-only or read-write. The footprint _permits_ any read of a key within it, or a write of any key within it that is marked as read-write. All other reads and writes are not permitted.
 
-Any call to a host function to interact with a _full key_ that is not permitted by the footprint will trap.
+Note that access to _instance storage_ is described, at the level of `LedgerKey`s and therefore footprints, as an access to the `key` reserved for identifying instances: `SCV_LEDGER_KEY_CONTRACT_INSTANCE`.
 
-The footprint of a transaction is static for the duration of the transaction: it is established before transaction execution begins and does not change during execution. The exact mechanism of defining the footprint of a transaction will be provided in a later CAP that deals with transaction invocation. 
+Any call to a host function to interact with a `LedgerKey` that is not permitted by the footprint will generally trap. For instance storage, trapping such an invalid access may be deferred until contract exit, when any modified instance storage map is implicitly written back to the ledger.
+
+The footprint of a transaction is static for the duration of the transaction: it is established before transaction execution begins and does not change during execution.
 
 ### XDR changes
 
@@ -79,28 +130,30 @@ new `CONTRACT_DATA` ledger entries.
 ### Host function additions
 
 ```
-/// Stores a CONTRACT_DATA ledger entry with the currently-executing
-/// contract ID and the provided key/val pair. Traps if the current
-/// footprint does not allow writing to (contract ID, key).
-func $contract_data_put (param $key i64) (param $val i64) (result i64)
+;; Stores a value $v_val under the key $k_val with storage type $t_storagetype.
+;; Traps if the current footprint does not allow writing to the LedgerKey implied by
+;; the write. For instance storage, the footprint check may be deferred to contract
+;; completion.
+(func $put_contract_data (param $k_val i64) (param $v_val i64) (param $t_storagetype i64) (result i64))
 
-/// Retrieves the val field from a CONTRACT_DATA ledger entry with
-/// the currently-executing contract ID and the provided key pair.
-/// Traps if the current footprint does not allow reading from
-/// (contract ID, key), or if there is no such ledger entry.
-func $contract_data_get (param $key i64) (result i64)
+;; Retrieves the value associated with the key $k_val with storage type $t_storagetype.
+;; Traps if the current footprint does not allow reading from the LedgerKey implied by
+;; the read, or if there is no value associated with $k_val. For instance storage, the
+;; footprint check may be deferred to contract completion.
+(func $get_contract_data (param $k_val i64) (param $t_storagetype i64) (result i64))
 
-/// Deletes a CONTRACT_DATA ledger entry with the currently-executing
-/// contract ID and the provided key pair. Traps if the current
-/// footprint does not allow writing to (contract ID, key), or if
-/// there is no such ledger entry.
-func $contract_data_del (param $key i64) (result i64)
+;; Deletes the value associated with the key $k_val with storage type $t_storagetype.
+;; Traps if the current footprint does not allow writing to the LedgerKey implied by
+;; the delete, or if there is no value associated with $k_val. For instance storage, the
+;; footprint check may be deferred to contract completion.
+(func $del_contract_data (param $k_val i64) (param $t_storagetype i64) (result i64))
 
-/// Returns a boolean value indicating whether a CONTRACT_DATA ledger
-/// entry exists with the currently-executing contract ID and the
-/// provided key. Traps if the current footprint does not allow reading
-/// from (contract ID, key).
-func $contract_data_has (param $key i64) (result i64)
+;; Returns a boolean value indicating whether there is a value associated with $k_val
+;; with storage type $t_storagetype. Traps if the current footprint does not allow
+;; reading from the LedgerKey implied by the query, or if there is no value associated
+;; with $k_val. For instance storage, the footprint check may be deferred to contract
+;; completion.
+(func $has_contract_data (param $k_val i64) (param $t_storagetype) (result i64))
 ```
 
 ### Semantics
@@ -111,12 +164,20 @@ These semantics should be considered in the light of the strict serializability 
   - Each write is visible immediately within the issuing transaction, but not to any other transaction, until the writing transaction commits
   - All reads and writes are observable to transactions as they would be if the transactions executed sequentially in transaction-set application order
 
+The durability of each write is controlled by the expiration strategy described in CAP-0046-TBD state expiration.
+
 ## Design Rationale
 
 ### Granularity
 Granularity of data elements is a key consideration in storage. Too large and IO is wasted loading and storing redundant data; too small and the fixed space and time overheads associated with storing each data element overwhelm the system. Moreover when parallel execution is included in consideration, the storage granularity becomes the unit of contention, with two contracts constrained to execute serially (or with some mechanism to enforce serializable consistency) when they share access to a single data element and at least one of them performs a write.
 
 Keying contract data by arbitrary `SCVal` values allows users to choose the granularity of data entering and leaving IO functions: fine-grained data may be stored under very large and specific keys, or coarser-grained data may be stored under smaller prefixes or "group" keys, with inner data structures such as vectors or maps combining together groups of data values. This is an intentional decision to allow contract authors to experiment and find the right balance, rather than deciding a priori on a granularity.
+
+### Instance storage
+
+Some data (such as authentication and configuration data) is both small and has a strong implicit connection to a contract instance: it should have the same lifecycle as the instance, and will commonly be accessed (read-only) on every call to the contract. For this sort of data, storage in a separate ledger entry can introduce unwanted performance overhead and, more importantly, potential failure modes (for example when the data expires but the contract instance does not). To simplify such cases and improve performance, instance storage was added.
+
+Note that instance storage should _not_ be used for unbounded key-value data or for data that will be frequently written during execution, as this will introduce artificial contention on the instance storage and defeat concurrent execution.
 
 ### Static footprint
 The requirement that each transaction have a static footprint serves both to limit arbitrary user-initiated IO mid-transaction (i.e. to enable efficient bulk IO only at transaction endpoints) as well as to enable static scheduling of parallel execution.


### PR DESCRIPTION
Two separate things here:

  - Update the XDR in contents/cap-0046 -- I don't think we've updated it in a while
  - Actually update the text of CAP-0046-05 to reflect instance storage, expiry, and therefore "storage types"