### PR TITLE
SEP-41: Remove spendable_balance

### DIFF
--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -7,7 +7,8 @@ Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>
 Track: Standard
 Status: Draft
 Created: 2023-09-22
-Version 0.1.0
+Updated: 2023-10-18
+Version 0.2.0
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250
 ```
 
@@ -91,20 +92,6 @@ pub trait TokenInterface {
     /// - `id` - The address for which a balance is being queried. If the
     /// address has no existing balance, returns 0.
     fn balance(env: Env, id: Address) -> i128;
-
-    /// Returns the spendable balance of `id`.
-    ///
-    /// If the token implementation makes a portion of the balance unavailable
-    /// for general use, this should return the portion that is available for
-    /// withdrawal.
-    ///
-    /// Should always return a value that is less than or equal to the amount
-    /// returned by `balance`.
-    ///
-    /// # Arguments
-    ///
-    /// - `id` - The address for which a spendable balance is being queried.
-    fn spendable_balance(env: Env, id: Address) -> i128;
 
     /// Transfer `amount` from `from` to `to`.
     ///
@@ -228,6 +215,7 @@ The event has data:
 ## Changelog
 
 - `v0.1.0` - Initial draft based on [CAP-46-6].
+- `v0.2.0` - Remove `spendable_balance`.
 
 ## Implementations
 


### PR DESCRIPTION
### What
Remove the `spendable_balance` contract function from the contract interface captured in SEP-41.

### Why
The difference between balance and spendable balance is subtle. It is clear what each should return for most tokens. But it is not clear on which should be used by tokens wishing to read the balance.

In some use cases spendable balance is clearly beneficial to use if the intent is to transfer or do something with all available balance.

In other use cases on the surface it doesn't matter which one would be used, but the downstream ramifications aren't clear. For example, if my contract reads the balance for a specific use case, and someone else using my contract then decides to transfer that amount as a result, I may make the assumption balance is the best to use while the caller of my contract might has needed me to use spendable balance.

The reason that spendable balance exists is because the Stellar Asset Contract provides an interface into Stellar Assets, and the native asset has a portion of its balance, the reserve, that becomes locked up and is held in an unspendable state. Today the balance returns the total balance while the spendable balance returns the amount of the balance not held in reserve. This concept is leaking into all custom tokens because we're exposing spendable balance and balance in this way, even though 99% of tokens will not need this concept.

As a result of removing spendable balance from the token interface the Stellar Asset Contract will be updated so that it also removes the fn. It's balance fn will continue to return the total balance.

Discussion about this occurred at: https://discord.com/channels/897514728459468821/1162081553376092280