### PR TITLE
Update SEP statuses and README.md

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -14,7 +14,7 @@
 * **Awaiting Decision** — A mature and ready SEP that is ready for approval by the SEP
   Team. If enough the approval requirements are met by SEP team members, the SEP will move towards
   `FCP`. Otherwise, it'll regress to a `Draft`.
-* **FCP** — A SEP that has entered a Final Comment Period (FCP). After one week has passed, during
+* **Final Comment Period** — A SEP that has entered a Final Comment Period. After one week has passed, during
   which any new concerns should be addressed, the SEP's status will become `Active`.
 * **Active** - An actively maintained SEP that is intended for immediate adoption by the entire
   ecosystem. Additional updates may be made without changing the SEP number.
@@ -29,28 +29,36 @@
 
 ## List of Proposals
 
+### Finalized Proposals
+
+| Number | Title | Author | Track | Status |
+| --- | --- | --- | --- | --- |
+| [SEP-0002](sep-0002.md) | Federation Protocol | SDF | Standard | Final |
+| [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts | SDF | Standard | Final |
+| [SEP-0007](sep-0007.md) | URI Scheme to facilitate delegated signing | Interstellar | Standard | Final |
+| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Standard | Final |
+| [SEP-0014](sep-0014.md) | Dynamic Asset Metadata | OrbitLens, Paul Tiplady | Standard | Final |
+| [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Final |
+| [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Final |
+| [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
+| [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Final |
+| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Final |
+| [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Final |
+
+### Active Proposals
+
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
 | [SEP-0001](sep-0001.md) | Stellar Info File | SDF | Standard | Active |
-| [SEP-0002](sep-0002.md) | Federation Protocol | SDF | Standard | Final |
-| [SEP-0004](sep-0004.md) | Tx Status Endpoint | SDF | Standard | Final |
-| [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts | SDF | Standard | Final |
-| [SEP-0006](sep-0006.md) | Deposit and Withdrawal API | SDF | Standard | Active (Interactive components are deprecated in favor of SEP-24) |
-| [SEP-0007](sep-0007.md) | URI Scheme to facilitate delegated signing | Interstellar | Standard | Final |
-| [SEP-0008](sep-0008.md) | Regulated Assets | Interstellar | Standard | Final |
+| [SEP-0006](sep-0006.md) | Deposit and Withdrawal API | SDF | Standard | Active |
 | [SEP-0009](sep-0009.md) | Standard KYC Fields | SDF | Standard | Active |
 | [SEP-0010](sep-0010.md) | Stellar Authentication | Sergey Nebolsin, Tom Quisel | Standard | Active |
 | [SEP-0011](sep-0011.md) | Txrep: Human-Readable Low-Level Representation of Stellar Transactions | David Mazières | Standard | Active |
 | [SEP-0012](sep-0012.md) | KYC API | Interstellar | Standard | Active |
-| [SEP-0014](sep-0014.md) | Dynamic Asset Metadata | OrbitLens, Paul Tiplady | Standard | Draft |
-| [SEP-0018](sep-0018.md) | Data Entry Namespaces | Mister.Ticot | Standard | Active |
-| [SEP-0020](sep-0020.md) | Self-verification of validator nodes | Johan Stén | Standard | Active |
 | [SEP-0023](sep-0023.md) | Muxed Account Strkeys | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Standard | Active |
 | [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal | SDF | Standard | Active |
-| [SEP-0028](sep-0028.md) | XDR Base64 Encoding | SDF | Standard | Final |
-| [SEP-0029](sep-0029.md) | Account Memo Requirements | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières | Standard | Active |
 | [SEP-0031](sep-0031.md) | Cross-Border Payments API | SDF | Standard | Active |
-| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts | Lobstr.co, Gleb Pitsevich | Standard | Active |
+| [SEP-0038](sep-0038.md) | Anchor RFQ API | Jake Urban and Leigh McCulloch | Standard | Active |
 
 ### Draft Proposals
 
@@ -62,26 +70,29 @@
 | [SEP-0019](sep-0019.md) | Bootstrapping Multisig Transaction Submission | Paul Selden, Nikhil Saraf | Standard | Draft |
 | [SEP-0021](sep-0021.md) | On-chain signature & transaction sharing | Mister.Ticot | Informational | Draft |
 | [SEP-0022](sep-0022.md) | IPFS Support | Samuel B. Sendelbach | Informational | Draft |
+| [SEP-0027](sep-0027.md) | Asset Information | Fritz Ekwoge(@efritze), Ernest Mbenkum (@cameroon) | Informational | Draft |
 | [SEP-0030](sep-0030.md) | Recoverysigner: multi-party key management of Stellar accounts | Leigh McCulloch, Lindsay Lin | Standard | Draft |
 | [SEP-0032](sep-0032.md) | Asset Address | Leigh McCulloch | Standard | Draft |
-| [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Final Comment Period |
-| [SEP-0035](sep-0035.md) | Operation IDs | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Standard | Draft |
 | [SEP-0037](sep-0037.md) | Address Directory API | OrbitLens | Informational | Draft |
-| [SEP-0038](sep-0038.md) | Anchor RFQ API | Jake Urban and Leigh McCulloch | Standard | Draft |
 | [SEP-0039](sep-0039.md) | Interoperability Recommendations for NFTs | SDF, Litemint.io | Informational | Active |
 | [SEP-0040](sep-0040.md) | Oracle Consumer Interface | Alex Mootz, OrbitLens, Markus Paulson-Luna | Standard | Draft |
 | [SEP-0041](sep-0041.md) | Soroban Token Interface | Jonathan Jove, Siddharth Suresh | Standard | Draft |
 
-
-
-### Rejected and Deprecated Proposals
+### Deprecated Proposals
 
 | Number | Title | Author | Track | Status |
 | --- | --- | --- | --- | --- |
 | [SEP-0003](sep-0003.md) | Compliance Protocol | SDF | Standard | Deprecated |
+| [SEP-0004](sep-0004.md) | Tx Status Endpoint | SDF | Standard | Deprecated |
+| [SEP-0025](sep-0025.md) | New Account Deposit | @msfeldstein | Standard | Deprecated |
+
+### Rejected Proposals
+
+| Number | Title | Author | Track | Status |
+| --- | --- | --- | --- | --- |
 | [SEP-0013](sep-0013.md) | DEPOSIT_SERVER proposal | @no, @ant, @manran, @pacngfar | Informational | Rejected |
 | [SEP-0026](sep-0026.md) | Non-interactive Anchor/Wallet Asset Transfer | SDF, Fritz Ekwoge (@efritze), Ernest Mbenkum (@cameroon) | Standard | Rejected |
-
+| [SEP-0034](sep-0034.md) | Wallet Attribution for Anchors | Jake Urban and Leigh McCulloch | Standard | Rejected |
 
 # Contribution Process
 
@@ -163,7 +174,7 @@ From there, the following process will happen:
 * Once a SEP has been approved, it goes into FCP which is broadcast to the protocol meeting members
   along with the mailing list.
 
-### FCP -> Active
+### Final Comment Period -> Active
 * If no major concerns are brought up, the SEP is marked as `Active` and updated to version `v1.0.0` by your SEP buddy.
 * Ideally there will be a reference implementation exhibiting the behavior and value of the SEP before moving to active state.
 * Active SEPs should be brought into production by ecosystem members.
@@ -181,7 +192,7 @@ From there, the following process will happen:
 
 ### Regression
 * It is possible for a SEP to move from `Active` to `Draft` or `Deprecated` if it is never adopted, or is abandoned by the community.
-* Regression of an active SEP occurs via the same process as a proposal (`Draft` -> `Awaiting Decision` -> `FCP` -> `Deprecated`)
+* Regression of an active SEP occurs via the same process as a proposal (`Draft` -> `Awaiting Decision` -> `Final Comment Period` -> `Deprecated`)
 
 ## SEP Versioning
 

--- a/ecosystem/sep-0004.md
+++ b/ecosystem/sep-0004.md
@@ -5,7 +5,7 @@
 SEP: 0004
 Title: Tx Status Endpoint
 Author: stellar.org
-Status: Final
+Status: Deprecated
 Created: 2017-10-30
 ```
 

--- a/ecosystem/sep-0014.md
+++ b/ecosystem/sep-0014.md
@@ -5,7 +5,7 @@ SEP: 0014
 Title: Dynamic Asset Metadata
 Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>
 Track: Standard
-Status: Active
+Status: Final
 Created: 2018-09-30
 Updated: 2019-03-12
 Discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/stellar-dev/-S7FIXJAi2A

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -4,7 +4,7 @@
 SEP: 0018
 Title: Data Entry Namespaces
 Author: MisterTicot (@misterticot), Leigh McCulloch (@leighmcculloch)
-Status: Active
+Status: Final
 Created: 2018-10-26
 Updated: 2020-06-30
 Version: 0.3.0

--- a/ecosystem/sep-0020.md
+++ b/ecosystem/sep-0020.md
@@ -3,7 +3,7 @@ SEP: 0020
 Title: Self-verification of validator nodes
 Author: Johan Stén <johan@futuretense.io>
 Track: Standard
-Status: Active
+Status: Final
 Created: 2018-05-06
 Discussion: https://github.com/stellar/stellar-protocol/issues/111
 ```

--- a/ecosystem/sep-0029.md
+++ b/ecosystem/sep-0029.md
@@ -4,7 +4,7 @@
 SEP: 0029
 Title: Account Memo Requirements
 Author: OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières
-Status: Active
+Status: Final
 Created: 2019-12-27
 Updated: 2020-05-04
 Version: 0.5.0

--- a/ecosystem/sep-0033.md
+++ b/ecosystem/sep-0033.md
@@ -4,7 +4,7 @@
 SEP: 0033
 Title: Identicons for Stellar Accounts
 Author: Lobstr.co, Gleb Pitsevich (@pitsevich)
-Status: Active
+Status: Final
 Created: 2019-11-20
 Updated: 2021-04-20
 Version: 1.0.1

--- a/ecosystem/sep-0034.md
+++ b/ecosystem/sep-0034.md
@@ -5,7 +5,7 @@ SEP: 0034
 Title: Wallet Request Attribution for Anchors
 Author: Jake Urban, Leigh McCulloch
 Track: Standard
-Status: Final Comment Period (FCP)
+Status: Rejected
 Created: 2020-08-17
 Discussion: https://github.com/stellar/stellar-protocol/issues/685
 ```

--- a/ecosystem/sep-0035.md
+++ b/ecosystem/sep-0035.md
@@ -5,7 +5,7 @@ SEP: 0035
 Title: Operation IDs
 Author: Scott Fleckenstein (@nullstyle), Isaiah Turner (@Isaiah-Turner), Debnil Sur (@debnil)
 Track: Standard
-Status: Draft
+Status: Final
 Created: 2020-08-26
 Discussion: https://groups.google.com/g/stellar-dev/c/vCgQhmox32Q
 ```

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -5,7 +5,7 @@ SEP: 0038
 Title: Anchor RFQ API
 Author: Jake Urban <@jakeurban> and Leigh McCulloch <@leighmcculloch>
 Track: Standard
-Status: Draft
+Status: Active
 Created: 2021-04-09
 Updated: 2023-08-24
 Discussion: https://github.com/stellar/stellar-protocol/issues/901


### PR DESCRIPTION
This PR updates the statuses of SEPs and improves the readability of the README.

### Changelog

- Creates a table for each status
- Moves SEP-4 from `Final` to `Deprecated`
- Moves SEP-14 from `Draft` to `Final`
- Moves SEP-18 from `Active` to `Final`
- Moves SEP-20 from `Active` to `Final`
- Moves SEP-29 from `Active` to `Final`
- Moves SEP-33 from `Active` to `Final`
- Moves SEP-34 from `Final Comment Period` to `Rejected`
- Moves SEP-35 from `Draft` to `Final`
- Moves SEP-38 from `Draft` to `Active`

