### PR TITLE
SEP-6: Make `account_id` optional in withdraw response

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2023-10-20
-Version 3.23.0
+Updated: 2023-10-31
+Version 3.24.0
 ```
 
 ## Simple Summary
@@ -611,7 +611,8 @@ The response body should be a JSON object with the following fields:
 
 Name | Type | Description
 -----|------|------------
-`account_id` | `G...` string | The account the user should send its token back to.
+`account_id` | `G...` string | (optional) The account the user should send its token back to. This field can be omitted if the anchor cannot provide this information at the time of the request.
+In this case, the wallet should query the [`/transaction`](#single-historical-transaction) endpoint to get this asynchonously.
 `memo_type` | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.
 `memo` | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. The anchor should use this memo to match the Stellar transaction with the database entry associated created to represent it.
 `id` | string | (optional) The anchor's ID for this withdrawal. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.
@@ -1484,6 +1485,7 @@ If the information was malformed, or if the sender tried to update data that isn
 [SEP-38]: sep-0038.md
 
 ## Changelog
+- `v3.24.0`: Make `account_id` optional in withdraw response ([#1417](https://github.com/stellar/stellar-protocol/pull/1417))
 - `v3.23.0`: Add `customer_id` field to deposit and withdrawal requests ([#1410](https://github.com/stellar/stellar-protocol/pull/1410))
 - `v3.22.0`: Deprecate the `wallet_name` and `wallet_url` parameters of `deposit` and `withdraw` requests ([#1393](https://github.com/stellar/stellar-protocol/pull/1393))
 * `v3.21.0`: Accept financial information via SEP-12. ([#1379](https://github.com/stellar/stellar-protocol/pull/1380/))

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -351,7 +351,7 @@ The first response, the success response, is explained below. The other possible
 
 Response code: `200 OK`
 
-This is the correct response if the anchor is able to accept the deposit and needs no additional information about the user. It should also be used if the anchor requires information about the user, but the information has previously been submitted and accepted.
+This is the correct response if the deposit request is valid and the anchor is beginning to process the deposit. The anchor may need additional information about the user, before the deposit can be completed. If the anchor needs additional information, it will be communicated to the user via the [`/transaction`](#single-historical-transaction) endpoint.
 
 The response body should be a JSON object with the following fields:
 
@@ -605,7 +605,7 @@ The first response, the success response, is explained below. The other possible
 
 Response code: `200 OK`
 
-This is the correct response if the anchor is able to execute the withdrawal and needs no additional information about the user. It should also be used if the anchor requires information about the user, but the information has previously been submitted and accepted.
+This is the correct response if the withdrawal request is valid and the anchor is beginning to process the withdrawal. The anchor may need additional information about the user, before the withdrawal can be completed. If the anchor needs additional information, it will be communicated to the user via the [`/transaction`](#single-historical-transaction) endpoint.
 
 The response body should be a JSON object with the following fields:
 


### PR DESCRIPTION
This makes the `account_id` field in the `withdraw` and `withdraw-exchange` response optional. This is to support Anchors integrating with a Custodian, in which a Stellar address other than the asset's distribution account is used as the `withdraw_anchor_account`. This is to prevent users from accidentally depositing to the wrong address in case the `withdraw_anchor_account` is changed during the SEP transaction's lifecycle.