### PR TITLE
[SEP-9] Add referral_id

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2023-08-16
-Version 1.13.0
+Updated: 2023-11-02
+Version 1.14.0
 ```
 
 ## Simple Summary
@@ -150,6 +150,7 @@ already separate fields.
 
 ## Changelog
 
+- `v1.14.0`: Add `referral_id` field ([#1418](https://github.com/stellar/stellar-protocol/pull/1418)).
 - `v1.13.0`: Add `crypto` related fields to financial account fields section.
   ([#1382](https://github.com/stellar/stellar-protocol/pull/1382))
 - `v1.12.0`: Define financial account fields section. ([#1367](https://github.com/stellar/stellar-protocol/pull/1367))

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -88,6 +88,7 @@ top-level key.
 | `sex`                         | string | `male`, `female`, or `other`                                                                |
 | `proof_of_income`             | binary | Image of user's proof of income document                                                    |
 | `proof_of_liveness`           | binary | video or image file of user as a liveness proof                                             |
+| `referral_id`                 | string | User's origin (such as an id in another application) or a referral code                     |
 
 ## Financial Account Fields
 


### PR DESCRIPTION
Sometimes user is referred to the application from an external source, and Application may want to know the external source's ID, thus the suggested new field in SEP-9