### PR TITLE
SEP-6: Get required KYC fields from transaction object only

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -6,8 +6,8 @@ Title: Deposit and Withdrawal API
 Author: SDF
 Status: Active (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
-Updated: 2023-10-31
-Version 3.24.0
+Updated: 2023-11-07
+Version 3.24.1
 ```
 
 ## Simple Summary
@@ -1427,7 +1427,7 @@ Every HTTP status code other than `200 OK` will be considered an error and in th
 
 ## Pending Customer Info Update
 
-In certain cases the anchor may need updated customer information from the user. For example, the bank could tell the anchor that the account address does not match the user's name or other identifying information. Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` status until the sender makes another `PUT /customer` request to update by providing the fields from `required_customer_info_updates` in the transaction object. The wallet can also check which fields need to be updated by making a `GET /customer` request including the `id` or `account` & `memo`. The anchor should respond with a `NEEDS_INFO` status and include the fields that need to be updated.
+In certain cases the anchor may need updated customer information from the user. For example, the bank could tell the anchor that the account address does not match the user's name or other identifying information. Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` status until the sender makes another `PUT /customer` request to update by providing the list of fields from `required_customer_info_updates` in the transaction object.
 
 ## Pending Transaction Info Update
 
@@ -1485,6 +1485,7 @@ If the information was malformed, or if the sender tried to update data that isn
 [SEP-38]: sep-0038.md
 
 ## Changelog
+- `v3.24.1`: Get required KYC fields from transaction object only ([#1420](https://github.com/stellar/stellar-protocol/pull/1420))
 - `v3.24.0`: Make `account_id` optional in withdraw response ([#1417](https://github.com/stellar/stellar-protocol/pull/1417))
 - `v3.23.0`: Add `customer_id` field to deposit and withdrawal requests ([#1410](https://github.com/stellar/stellar-protocol/pull/1410))
 - `v3.22.0`: Deprecate the `wallet_name` and `wallet_url` parameters of `deposit` and `withdraw` requests ([#1393](https://github.com/stellar/stellar-protocol/pull/1393))


### PR DESCRIPTION
Since SEP-6 does not use SEP-12 types, having the `required_customer_info_updates` be included in the SEP-12 GET /customer response would block new transactions due to unrelated KYC requirements from a previous SEP-6 deposit/withdrawal.