### PR TITLE
Mark Soroban CAPs as Accepted

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -55,6 +55,7 @@
 | [CAP-0038](cap-0038.md) | 18 | Automated Market Makers | Jonathan Jove | Final |
 | [CAP-0040](cap-0040.md) | 19 | Ed25519 Signed Payload Signer for Transaction Signature Disclosure | Leigh McCulloch | Final |
 | [CAP-0042](cap-0042.md) | - | Multi-Part Transaction Sets | Nicolas Barry | Accepted |
+| [CAP-0046](cap-0046.md) | Soroban smart contract system overview | Graydon Hoare | Accepted |
 | [CAP-0046-01 (formerly 0046)](cap-0046-01.md) | WebAssembly Smart Contract Runtime Environment | Graydon Hoare | Accepted |
 | [CAP-0046-02 (formerly 0047)](cap-0046-02.md) | Smart Contract Lifecycle | Siddharth Suresh | Accepted |
 | [CAP-0046-03 (formerly 0051)](cap-0046-03.md) | Smart Contract Host Functons | Jay Geng | Accepted |

--- a/core/README.md
+++ b/core/README.md
@@ -55,6 +55,17 @@
 | [CAP-0038](cap-0038.md) | 18 | Automated Market Makers | Jonathan Jove | Final |
 | [CAP-0040](cap-0040.md) | 19 | Ed25519 Signed Payload Signer for Transaction Signature Disclosure | Leigh McCulloch | Final |
 | [CAP-0042](cap-0042.md) | - | Multi-Part Transaction Sets | Nicolas Barry | Accepted |
+| [CAP-0046-01 (formerly 0046)](cap-0046-01.md) | WebAssembly Smart Contract Runtime Environment | Graydon Hoare | Accepted |
+| [CAP-0046-02 (formerly 0047)](cap-0046-02.md) | Smart Contract Lifecycle | Siddharth Suresh | Accepted |
+| [CAP-0046-03 (formerly 0051)](cap-0046-03.md) | Smart Contract Host Functons | Jay Geng | Accepted |
+| [CAP-0046-05 (formerly 0053)](cap-0046-05.md) | Smart Contract Data | Graydon Hoare | Accepted |
+| [CAP-0046-06 (formerly 0054)](cap-0046-06.md) | Smart Contract Standardized Asset | Jonathan Jove | Accepted |
+| [CAP-0046-07 (formerly 0055)](cap-0046-07.md) | Fee model in smart contracts | Nicolas Barry | Accepted |
+| [CAP-0046-08 (formerly 0056)](cap-0046-08.md) | Smart Contract Logging | Siddharth Suresh | Accepted |
+| [CAP-0046-09](cap-0046-09.md) | Network Configuration Ledger Entries | Dmytro Kozhevin | Accepted |
+| [CAP-0046-10](cap-0046-10.md) | Smart Contract Budget Metering | Jay Geng | Accepted |
+| [CAP-0046-11](cap-0046-11.md) | Soroban Authorization Framework | Dmytro Kozhevin | Accepted |
+| [CAP-0046-12](cap-0046-12.md) | Soroban State Archival Interface | Garand Tyson | Accepted |
 
 ### Draft Proposals
 | Number | Title | Author | Status |
@@ -73,18 +84,6 @@
 | [CAP-0043](cap-0043.md) | ECDSA Signers with P-256 and secp256k1 Curves | Leigh McCulloch | Draft |
 | [CAP-0044](cap-0044.md) | SPEEDEX - Configuration | Jonathan Jove | Draft |
 | [CAP-0045](cap-0045.md) | SPEEDEX - Pricing | Jonathan Jove | Draft |
-| [CAP-0046](cap-0046.md) | Soroban smart contract system overview | Graydon Hoare | FCP: Accepted |
-| [CAP-0046-01 (formerly 0046)](cap-0046-01.md) | WebAssembly Smart Contract Runtime Environment | Graydon Hoare | FCP: Accepted |
-| [CAP-0046-02 (formerly 0047)](cap-0046-02.md) | Smart Contract Lifecycle | Siddharth Suresh | FCP: Accepted |
-| [CAP-0046-03 (formerly 0051)](cap-0046-03.md) | Smart Contract Host Functons | Jay Geng | FCP: Accepted |
-| [CAP-0046-05 (formerly 0053)](cap-0046-05.md) | Smart Contract Data | Graydon Hoare | FCP: Accepted |
-| [CAP-0046-06 (formerly 0054)](cap-0046-06.md) | Smart Contract Standardized Asset | Jonathan Jove | FCP: Accepted |
-| [CAP-0046-07 (formerly 0055)](cap-0046-07.md) | Fee model in smart contracts | Nicolas Barry | FCP: Accepted |
-| [CAP-0046-08 (formerly 0056)](cap-0046-08.md) | Smart Contract Logging | Siddharth Suresh | FCP: Accepted |
-| [CAP-0046-09](cap-0046-09.md) | Network Configuration Ledger Entries | Dmytro Kozhevin | FCP: Accepted |
-| [CAP-0046-10](cap-0046-10.md) | Smart Contract Budget Metering | Jay Geng | FCP: Accepted |
-| [CAP-0046-11](cap-0046-11.md) | Soroban Authorization Framework | Dmytro Kozhevin | FCP: Accepted |
-| [CAP-0046-12](cap-0046-12.md) | Soroban State Archival Interface | Garand Tyson | FCP: Accepted |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0046-01.md
+++ b/core/cap-0046-01.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Leigh McCulloch <@leighmcculloch>, Tomer Weller <@tomerweller>, Jon Jove <@jonjove>, Nicolas Barry <@MonsieurNicolas>, Thibault de Lacheze-Murel <@C0x41lch0x41>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-04-18
 Discussion: https://groups.google.com/g/stellar-dev/c/X0oRzJoIr10
 Protocol version: TBD

--- a/core/cap-0046-02.md
+++ b/core/cap-0046-02.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Siddharth Suresh <@sisuresh>
     Authors: Siddharth Suresh <@sisuresh>, Dmytro Kozhevin <@dmkozh>, Jay Geng <@jayz22>
     Consulted: Graydon Hoare <@graydon>, Jon Jove <@jonjove>, Leigh McCulloch <@leighmcculloch>, Nicolas Barry <@MonsieurNicolas>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-05-02
 Discussion:
 Protocol version: TBD

--- a/core/cap-0046-03.md
+++ b/core/cap-0046-03.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Jay Geng <@jayz22>, Graydon Hoare <@graydon>
     Authors: Jay Geng <@jayz22>
     Consulted: Leigh McCulloch <@leighmcculloch>, Nicolas Barry <@MonsieurNicolas>, Siddharth Suresh <@sisuresh>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-05-20
 Discussion: TBD
 Protocol version: TBD

--- a/core/cap-0046-05.md
+++ b/core/cap-0046-05.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Siddharth Suresh <@sisuresh>, Jon Jove <@jonjove>, Nicolas Barry <@MonsieurNicolas>, Leigh McCulloch <@leighmcculloch>, Tomer Weller <@tomerweller>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-05-25
 Discussion: https://groups.google.com/g/stellar-dev/c/vkzMeM_t7e8
 Protocol version: TBD

--- a/core/cap-0046-06.md
+++ b/core/cap-0046-06.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Jonathan Jove <@jonjove>
     Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>,
     Consulted: Nicolas Barry <@monsieurnicolas>, Leigh McCulloch <@leighmcculloch>, Tomer Weller <@tomerweller>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-05-31
 Discussion: TBD
 Protocol version: TBD

--- a/core/cap-0046-07.md
+++ b/core/cap-0046-07.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: MonsieurNicolas
     Authors: dmkozh
     Consulted:
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-06-03
 Discussion: TBD
 Protocol version: TBD

--- a/core/cap-0046-08.md
+++ b/core/cap-0046-08.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Siddharth Suresh <@sisuresh>
     Authors:
     Consulted:
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-06-29
 Discussion: TBD
 Protocol version: TBD

--- a/core/cap-0046-09.md
+++ b/core/cap-0046-09.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>, Siddharth Suresh <@sisuresh>
     Consulted:
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-11-01
 Discussion:
 Protocol version: TBD

--- a/core/cap-0046-10.md
+++ b/core/cap-0046-10.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Jay Geng <@jayz22>, Graydon Hoare <@graydon>
     Authors: Jay Geng <@jayz22>
     Consulted: Nicolas Barry <@MonsieurNicolas>, Dmytro Kozhevin <@dmkozh>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-12-20
 Discussion: TBD
 Protocol version: TBD

--- a/core/cap-0046-11.md
+++ b/core/cap-0046-11.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: FCP: Accepted
+Status: Accepted
 Created: 2023-07-28
 Discussion:
 Protocol version: 20

--- a/core/cap-0046-12.md
+++ b/core/cap-0046-12.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>, Siddharth Suresh <@sisuresh>
     Consulted: Nicolas Barry <@MonsieurNicolas>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2023-09-14
 Discussion:
 Protocol version: 20

--- a/core/cap-0046.md
+++ b/core/cap-0046.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>, Siddharth Suresh <@sisuresh>, Dmytro Kozhevin <@dmkozh>, Jay Geng <@jayz22>, Garand Tyson <@SirTyson>
     Consulted: Leigh McCulloch <@leighmcculloch>, Tomer Weller <@tomerweller>, Jon Jove <@jonjove>, Nicolas Barry <@MonsieurNicolas>, Thibault de Lacheze-Murel <@C0x41lch0x41>
-Status: FCP: Accepted
+Status: Accepted
 Created: 2022-10-27
 Discussion: 
 Protocol version: TBD


### PR DESCRIPTION
Final Comment Period is now complete, and there were no questions or objections raised, so this PR changes the designation of the Soroban CAPs from `FCP: Acceptance` to `Accepted`