### PR TITLE
Deprecate `PUT /verifcation` and update verification process for SEP-12

### DIFF
--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,7 +6,7 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2024-01-17
+Updated: 2024-01-25
 Version 1.12.0
 ```
 
@@ -125,7 +125,7 @@ Name | Type | Description
 `id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
 `status` | string | Status of the customers KYC process.
 `fields` | object | (optional) An object containing the fields the anchor has not yet received for the given customer of the `type` provided in the request. Required for customers in the `NEEDS_INFO` status. See [Fields](#fields) for more detailed information.
-`provided_fields` | object | (optional) An object containing the fields the anchor has received for the given customer. See [Provided Fields](#provided-fields) for more detailed information. Required for customers whose information needs verification via [`PUT /customer/verification`](#customer-put-verification).
+`provided_fields` | object | (optional) An object containing the fields the anchor has received for the given customer. See [Provided Fields](#provided-fields) for more detailed information. Required for customers whose information needs [verification](#verification).
 `message` | string | (optional) Human readable message describing the current state of customer's KYC process.
 
 ```js
@@ -275,7 +275,7 @@ Property | Type | Description
 
 #### Provided Fields
 
-The provided fields object defines the pieces of information the anchor has received for the customer. It is not required unless one or more of provided fields require verification via [`PUT /customer/verification`](#customer-put-verification).
+The provided fields object defines the pieces of information the anchor has received for the customer. It is not required unless one or more of provided fields require [verification](#verification).
 
 Property | Type | Description
 -----|------|------------
@@ -293,7 +293,7 @@ Status | Description
 ACCEPTED | The field has been validated. When all required fields are accepted, the [Customer Status](#customer-statuses) should also be accepted.
 PROCESSING | The field is being validated. The client can make [GET /customer](#customer-get) requests to check on the result of this validation in the future.
 REJECTED | The field was in the `PROCESSING` status but did not pass validation. If the client may resubmit this field, the [Customer Status](#customer-statuses) should be `NEEDS_INFO`, otherwise it should be `REJECTED`.
-VERIFICATION_REQUIRED | The field must be verified using the [PUT /customer/verification](#customer-put-verification) endpoint. For example, the `mobile_number` field could be placed in this status until a confirmation code is sent to the customer and passed back to the this endpoint.
+VERIFICATION_REQUIRED | The field must be verified using the [verification](#verification) process. For example, the `mobile_number` field could be placed in this status until a confirmation code is sent to the customer and passed back to the this endpoint.
 
 #### Errors
 
@@ -365,6 +365,22 @@ The wallet should also transmit one or more of the fields listed in [SEP-9](./se
 
 When uploading data for fields specificed in [SEP-9](./sep-0009.md), `binary` type fields (typically files) should be submitted **after all other fields**. The reason for this is that some web servers require `binary` fields at the end so that they know when they can begin processing the request as a stream.
 
+### Verification
+
+For any field that require verification (such as mobile number, or email address), it will first receive status `VERIFICATION_REQUIRED` by the application (see [fields statuses](#provided-field-statuses) for details). Afterward, all such fields should be passed to the `PUT /customer` request and suffixed with `_verification` string, with an appropriate verification as the value of the field. 
+
+Example:
+
+```json
+{
+  "id": "391fb415-c223-4608-b2f5-dd1e91e3a986",
+  "email": "test@example.com",
+  "mobile_number_verification": "123456"
+}
+```
+
+In the example above customer with id `391fb415-c223-4608-b2f5-dd1e91e3a986` will update their email and send their mobile number confirmation to the application. On success, client application will receive an `ACCEPTED` status on `mobile_number` field if the application instantly verified the mobile number, and `PROCESSING` if it needs time to process it. 
+
 ### Response
 
 If the anchor received and stored the data successfully, it should respond with a `202 Accepted` or `200 Success` HTTP status code in addition to a response body containing the customer ID.
@@ -397,10 +413,17 @@ For example:
 }
 ```
 
+```json
+{
+  "error": "The provided confirmation code was invalid."
+}
+```
+
 ## Customer PUT Verification
 
-**Deprecated**
-This endpoint has been deprecated in favor 
+### **Deprecated**
+
+This endpoint has been deprecated in favor of existing `PUT /customer` endpoint.
 
 This endpoint allows servers to accept data values, usually confirmation codes, that verify a previously provided field via `PUT /customer`, such as `mobile_number` or `email_address`. Note that while fields such as `photo_proof_residence` or `notary_approval_of_photo_id` are verifications of other fields described in [SEP-9](#sep-0009.md), the server does not require the associated fields _before_ verification can be accomplished, so this endpoint would not be useful for such fields.
 
@@ -672,6 +695,7 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 ## Changelog
 
+* `v1.12.0`: Deprecate `PUT /verifcation` and update verification process (#1431)[https://github.com/stellar/stellar-protocol/pull/1431]
 * `v1.11.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v1.11.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v1.10.0`: Clarify that the `account` and `memo` fields should be inferred from the decoded SEP-10 JWT's `sub` value even when not provided in the request body.

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2023-01-10
-Version 1.11.1
+Updated: 2024-01-17
+Version 1.12.0
 ```
 
 ## Abstract
@@ -37,7 +37,7 @@ To support this protocol an anchor acts as a server and implements the specified
 * [`GET /customer`](#customer-get): Check the status of a customers info
 * [`PUT /customer`](#customer-put): Idempotent upload of customer info
 * [`PUT /customer/callback`](#customer-callback-put): Set a callback for a wallet to receive status updates from the anchor
-* [`PUT /customer/verification`](#customer-put-verification): Idempotent upload of data for verifying customer info
+* [`PUT /customer/verification`](#customer-put-verification): (**Deprecated**) Idempotent upload of data for verifying customer info
 * [`DELETE /customer/[account]`](#customer-delete): Deletion of customer info
 * [`POST /customer/files`](#customer-files)
 * [`GET /customer/files`](#get-request)
@@ -398,6 +398,9 @@ For example:
 ```
 
 ## Customer PUT Verification
+
+**Deprecated**
+This endpoint has been deprecated in favor 
 
 This endpoint allows servers to accept data values, usually confirmation codes, that verify a previously provided field via `PUT /customer`, such as `mobile_number` or `email_address`. Note that while fields such as `photo_proof_residence` or `notary_approval_of_photo_id` are verifications of other fields described in [SEP-9](#sep-0009.md), the server does not require the associated fields _before_ verification can be accomplished, so this endpoint would not be useful for such fields.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -695,7 +695,7 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 ## Changelog
 
-* `v1.12.0`: Deprecate `PUT /verifcation` and update verification process (#1431)[https://github.com/stellar/stellar-protocol/pull/1431]
+* `v1.12.0`: Deprecate `PUT /verifcation` and update verification process ([#1431](https://github.com/stellar/stellar-protocol/pull/1431))
 * `v1.11.1`: Allow anchors to omit the deprecated `X-Stellar-Signature` header ([#1335](https://github.com/stellar/stellar-protocol/pull/1335))
 * `v1.11.0`: Deprecate `X-Stellar-Signature` in favor of `Signature` ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v1.10.0`: Clarify that the `account` and `memo` fields should be inferred from the decoded SEP-10 JWT's `sub` value even when not provided in the request body.


### PR DESCRIPTION
## Background
Currently, to verify any field it's required to call `PUT /customer/verification` by suffixing said field with `_verification`. This proposal deprecated this approach in favor of more simplified flow  

## Proposed change
Merge functionality of `PUT /customer//verification` with `PUT /customer`. Now, client should first fields via `PUT /customer`, and then verify them (if needed) in the same manner as before (suffix field with `_verification` and pass verification information as value of the field) 