### PR TITLE
CAP-51: Add client data JSON example

### DIFF
--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -161,7 +161,19 @@ webauthn authenticator data, and a SHA-256 hash of the client data JSON. The
 client data JSON contains several fields, one being the `challenge` field, that
 an application requesting a signature can set. The challenge provided by an
 application is base64 url encoded in the `challenge` field of the client data
-JSON. For Stellar transactions intended to be authenticated by a webauthn
+JSON.
+
+For example, a client data JSON:
+```json
+{
+  "type":"webauthn.get",
+  "challenge":"hJHFvaaoU7qkcH9kML46shLL_btpYGCA6ty3ie0M1Qw",
+  "origin":"http://localhost:4507",
+  "crossOrigin":false
+}
+```
+
+For Stellar transactions intended to be authenticated by a webauthn
 signature in a Soroban custom account, this challenge can be the SHA-256 hash of
 the `HashIDPreimage` `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION`.
 
@@ -183,7 +195,8 @@ client data JSON for the base64 url encoded challenge surrounded by `"`, and
 then surrounded by either `:`, `,`, ` `, `{`, or `}`. Assuming consistency with
 which clients produce the client data JSON it is also possible to check the
 prefix of the client data JSON contains an exact format including the base64 url
-encoded challenge. **(TODO: This requires more verification.)**
+encoded challenge. **(TODO: This paragraph is incorrect and needs replacing with
+nother solution.)**
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
### What
Add client data JSON example to CAP-51.

### Why
It's helpful to readers visually be able to see what a full client data JSON looks like.