### PR TITLE
Address some review comments from protocol meeting

### DIFF
--- a/core/cap-0054.md
+++ b/core/cap-0054.md
@@ -42,7 +42,7 @@ A more refined model will enable a tigher bound on costs, essentially charging s
 There are three parts to this work:
 
   1. On contract upload, the initial contract parse and validation pass will initially use the old cost model, but the host will then analyze the contract and extract refined cost-input values (i.e. it will count the number of functions, imports, exports, data segment sizes and so forth).
-  2. This new refinedcost-input information will be saved into the ledger along with the uploaded WASM bytecode, so that _subsequent_ instantiations can use a refined cost model.
+  2. This new refined cost-input information will be saved into the ledger along with the uploaded WASM bytecode, so that _subsequent_ instantiations can use a refined cost model.
   3. When instantiating a contract with saved refined cost inputs, the refined cost model will be charged. This will also allow the cost model to properly _reflect_ changes in subsequent CAPs that lower the actual amount of work done during VM instantiation.
 
 ### XDR changes
@@ -156,6 +156,11 @@ The way these are intended to be used is as follows:
   - When a contract is instantiated, the host checks the `ext` field:
     - If the contract has `ContractCodeCostInputs` then new code supporting this CAP charges the instantiation each of the new `ContractCostType`s using the corresponding `ContractCodeCostInputs` as inputs.
     - Otherwise the instantiation is charged the old `VmInstantiation` cost model using the contract byte size, as happens today.
+
+Additionally, to enable gradual upgrades to existing contracts, the semantics of uploading a contract that _already exists_ are altered:
+
+  - Before this change, uploading an existing contract has no effect.
+  - With this change, uploading an existing contract will check to see if the existing contract has `ContractCodeInputs`, and if not will add them and write the contract back to storage with the new inputs. Since the Wasm bytecode of the contract does not change (its identity is actually the hash of its bytecode) there is no risk to allowing this operation: it does not change the contract's meaning, only how it is charged during instantiation.
 
 ## Design Rationale
 

--- a/core/cap-0056.md
+++ b/core/cap-0056.md
@@ -43,12 +43,31 @@ There are no XDR changes beyond those proposed in CAP-0054, which as mentioned a
 
 ### Semantics
 
+#### Normative
+
+This section describes the change to observable behaviour.
+
+- When a Soroban transaction is constructed, before it begins executing:
+    - For each `ContractCode` ledger entry mentioned in the read footprint of the transaction:
+        - If CAP-0054 is accepted **and** the ledger entry contains the new CAP-0054 refined cost model input types:
+            - The transaction is charged the new refined `ParseWasm*` module-parsing cost models with the new refined cost model inputs
+        - Else:
+            - The transaction is charged the old `VmInstantiation` cost type, which will have been recalibrated by this change to only cover the cost of parsing the `ContractCode`'s Wasm module, not fully instantiating it.
+- When a Soroban transaction performs an _invocation_ on some contract implemented by some Wasm module:
+    - If CAP-0054 is accepted **and** the ledger entry contains the new CAP-0054 refined cost model input types:
+        - The transaction is charged the new refined `InstantiateWasm*` module-instantiating cost models with the new refined cost model inputs
+    - Else:
+        - The transaction is charged the old `VmCachedInstantiation` cost type, which will have been recalibrated by this change to only cover the cost of instantiating an already-parsed module.
+
+#### Informative
+
+This section explains the implementation. It is intended for illustration purposes, and other possible impementations that achieve the same observable normative behaviour are possible.
+
 - When a Soroban `Host` is constructed for a transaction, it contains a new module cache that will hold parsed Wasm modules.
 - The module cache is then, before any modules are executed, unconditionally populated with a parsed Wasm module for every contract mentioned in the transaction's read footprint.
-- When parsing a module for caching, it will be charged to either the cost model of the old `VmInstantiation` cost type, or the new refined cost models for the CAP-0054 `ParseWasm*` cost types.
-- As invocations require instantiation of parsed modules, then either:
-    - If CAP-0054 is accepted **and** the module has stored inputs for the refined CAP-0054 cost inputs, then instantiating it will charge the cost models for the new `InstantiateWasm*` cost types.
-    - Otherwise instantiating the model will charge the cost model for the existing `VmCachedInstantiation` cost type (which must be recalibrated and have its network setting updated along with this change).
+    - When parsing a module for caching, it will be charged to either the cost model of the old `VmInstantiation` cost type, or the new refined cost models for the CAP-0054 `ParseWasm*` cost types.
+- As invocations require instantiation of parsed modules, pre-parsed modules will be extracted from the cache and instantiated.
+    - When instantiating a cached module, it will be charged to either the cost modelof the old `VmCachedInstantiation` cost type, or the new refined cost models for the CAP-0054 `InstantiateWasm*` cost types.
 
 ## Design Rationale
 


### PR DESCRIPTION
Just a couple additions that came up in protocol meeting today around upgrading cost models and clarifying that the cache cost-charging behaviour is somewhat logically distinct from the _actual existence_ of a cache.