### PR TITLE
SEP-9 : Add `mobile_number_format` field to Natural Person Fields

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -54,42 +54,42 @@ top-level key.
 
 ## Natural Person Fields
 
-| Name                          | Type   | Description                                                                                 |
-| ----------------------------- | ------ | ------------------------------------------------------------------------------------------- |
-| `family_name` or `last_name`  | string | Family or last name                                                                         |
-| `given_name` or `first_name`  | string | Given or first name                                                                         |
-| `additional_name`             | string | Middle name or other additional name                                                        |
-| `address_country_code`        | string | country code for current address                                                            |
-| `state_or_province`           | string | name of state/province/region/prefecture                                                    |
-| `city`                        | string | name of city/town                                                                           |
-| `postal_code`                 | string | Postal or other code identifying user's locale                                              |
-| `address`                     | string | Entire address (country, state, postal code, street address, etc...) as a multi-line string |
+| Name                          | Type   | Description                                                                                                                                                                                   |
+| ----------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `family_name` or `last_name`  | string | Family or last name                                                                                                                                                                           |
+| `given_name` or `first_name`  | string | Given or first name                                                                                                                                                                           |
+| `additional_name`             | string | Middle name or other additional name                                                                                                                                                          |
+| `address_country_code`        | string | country code for current address                                                                                                                                                              |
+| `state_or_province`           | string | name of state/province/region/prefecture                                                                                                                                                      |
+| `city`                        | string | name of city/town                                                                                                                                                                             |
+| `postal_code`                 | string | Postal or other code identifying user's locale                                                                                                                                                |
+| `address`                     | string | Entire address (country, state, postal code, street address, etc...) as a multi-line string                                                                                                   |
 | `mobile_number`               | string | Mobile phone number with country code, in `E.164` format unless specified differently on `mobile_number_format` field. It could be hashed in case `mobile_number_format` is defined as `hash` |
-| `mobile_number_format`        | string | Expected format of the `mobile_number` field. E.g.: `E.164`, `hash`, etc... In case this field is not specified, receiver should assume it's in `E.164` format |
-| `email_address`               | string | Email address                                                                               |
-| `birth_date`                  | date   | Date of birth, e.g. `1976-07-04`                                                            |
-| `birth_place`                 | string | Place of birth (city, state, country; as on passport)                                       |
-| `birth_country_code`          | string | ISO Code of country of birth                                                                |
-| `tax_id`                      | string | Tax identifier of user in their country (social security number in US)                      |
-| `tax_id_name`                 | string | Name of the tax ID (`SSN` or `ITIN` in the US)                                              |
-| `occupation`                  | number | Occupation ISCO code                                                                        |
-| `employer_name`               | string | Name of employer                                                                            |
-| `employer_address`            | string | Address of employer                                                                         |
-| `language_code`               | string | primary language                                                                            |
-| `id_type`                     | string | `passport`, `drivers_license`, `id_card`, etc...                                            |
-| `id_country_code`             | string | country issuing passport or photo ID as ISO 3166-1 alpha-3 code                             |
-| `id_issue_date`               | date   | ID issue date                                                                               |
-| `id_expiration_date`          | date   | ID expiration date                                                                          |
-| `id_number`                   | string | Passport or ID number                                                                       |
-| `photo_id_front`              | binary | Image of front of user's photo ID or passport                                               |
-| `photo_id_back`               | binary | Image of back of user's photo ID or passport                                                |
-| `notary_approval_of_photo_id` | binary | Image of notary's approval of photo ID or passport                                          |
-| `ip_address`                  | string | IP address of customer's computer                                                           |
-| `photo_proof_residence`       | binary | Image of a utility bill, bank statement or similar with the user's name and address         |
-| `sex`                         | string | `male`, `female`, or `other`                                                                |
-| `proof_of_income`             | binary | Image of user's proof of income document                                                    |
-| `proof_of_liveness`           | binary | video or image file of user as a liveness proof                                             |
-| `referral_id`                 | string | User's origin (such as an id in another application) or a referral code                     |
+| `mobile_number_format`        | string | Expected format of the `mobile_number` field. E.g.: `E.164`, `hash`, etc... In case this field is not specified, receiver should assume it's in `E.164` format                                |
+| `email_address`               | string | Email address                                                                                                                                                                                 |
+| `birth_date`                  | date   | Date of birth, e.g. `1976-07-04`                                                                                                                                                              |
+| `birth_place`                 | string | Place of birth (city, state, country; as on passport)                                                                                                                                         |
+| `birth_country_code`          | string | ISO Code of country of birth                                                                                                                                                                  |
+| `tax_id`                      | string | Tax identifier of user in their country (social security number in US)                                                                                                                        |
+| `tax_id_name`                 | string | Name of the tax ID (`SSN` or `ITIN` in the US)                                                                                                                                                |
+| `occupation`                  | number | Occupation ISCO code                                                                                                                                                                          |
+| `employer_name`               | string | Name of employer                                                                                                                                                                              |
+| `employer_address`            | string | Address of employer                                                                                                                                                                           |
+| `language_code`               | string | primary language                                                                                                                                                                              |
+| `id_type`                     | string | `passport`, `drivers_license`, `id_card`, etc...                                                                                                                                              |
+| `id_country_code`             | string | country issuing passport or photo ID as ISO 3166-1 alpha-3 code                                                                                                                               |
+| `id_issue_date`               | date   | ID issue date                                                                                                                                                                                 |
+| `id_expiration_date`          | date   | ID expiration date                                                                                                                                                                            |
+| `id_number`                   | string | Passport or ID number                                                                                                                                                                         |
+| `photo_id_front`              | binary | Image of front of user's photo ID or passport                                                                                                                                                 |
+| `photo_id_back`               | binary | Image of back of user's photo ID or passport                                                                                                                                                  |
+| `notary_approval_of_photo_id` | binary | Image of notary's approval of photo ID or passport                                                                                                                                            |
+| `ip_address`                  | string | IP address of customer's computer                                                                                                                                                             |
+| `photo_proof_residence`       | binary | Image of a utility bill, bank statement or similar with the user's name and address                                                                                                           |
+| `sex`                         | string | `male`, `female`, or `other`                                                                                                                                                                  |
+| `proof_of_income`             | binary | Image of user's proof of income document                                                                                                                                                      |
+| `proof_of_liveness`           | binary | video or image file of user as a liveness proof                                                                                                                                               |
+| `referral_id`                 | string | User's origin (such as an id in another application) or a referral code                                                                                                                       |
 
 ## Financial Account Fields
 

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -64,8 +64,8 @@ top-level key.
 | `city`                        | string | name of city/town                                                                           |
 | `postal_code`                 | string | Postal or other code identifying user's locale                                              |
 | `address`                     | string | Entire address (country, state, postal code, street address, etc...) as a multi-line string |
-| `mobile_number`               | string | Mobile phone number with country code, in E.164 format                                      |
-| `mobile_number_hash`          | string | Hashed version of a mobile phone number with country code, in E.164 format                  |
+| `mobile_number`               | string | Mobile phone number with country code, in `E.164` format unless specified differently on `mobile_number_format` field. It could be hashed in case `mobile_number_format` is defined as `hash` |
+| `mobile_number_format`        | string | Expected format of the `mobile_number` field. E.g.: `E.164`, `hash`, etc... In case this field is not specified, receiver should assume it's in `E.164` format |
 | `email_address`               | string | Email address                                                                               |
 | `birth_date`                  | date   | Date of birth, e.g. `1976-07-04`                                                            |
 | `birth_place`                 | string | Place of birth (city, state, country; as on passport)                                       |
@@ -176,7 +176,7 @@ receive. Usually, application would require either `token`, or set of: `number`,
 
 ## Changelog
 
-- `v1.17.0`: Add `mobile_number_hash` field to Natural Person Fields
+- `v1.17.0`: Add `mobile_number_format` field to Natural Person Fields
   ([#1481](https://github.com/stellar/stellar-protocol/pull/1481)).
 - `v1.16.0`: Add `external_transfer_memo` field to Financial Account Fields
   ([#1452](https://github.com/stellar/stellar-protocol/pull/1452)).

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -65,6 +65,7 @@ top-level key.
 | `postal_code`                 | string | Postal or other code identifying user's locale                                              |
 | `address`                     | string | Entire address (country, state, postal code, street address, etc...) as a multi-line string |
 | `mobile_number`               | string | Mobile phone number with country code, in E.164 format                                      |
+| `mobile_number_hash`          | string | Hashed version of a mobile phone number with country code, in E.164 format                  |
 | `email_address`               | string | Email address                                                                               |
 | `birth_date`                  | date   | Date of birth, e.g. `1976-07-04`                                                            |
 | `birth_place`                 | string | Place of birth (city, state, country; as on passport)                                       |

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC Fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2024-03-16
-Version 1.16.0
+Updated: 2024-04-22
+Version 1.17.0
 ```
 
 ## Simple Summary
@@ -176,6 +176,8 @@ receive. Usually, application would require either `token`, or set of: `number`,
 
 ## Changelog
 
+- `v1.17.0`: Add `mobile_number_hash` field to Natural Person Fields
+  ([#1481](https://github.com/stellar/stellar-protocol/pull/1481)).
 - `v1.16.0`: Add `external_transfer_memo` field to Financial Account Fields
   ([#1452](https://github.com/stellar/stellar-protocol/pull/1452)).
 - `v1.15.0`: Add fields for card details ([#1430](https://github.com/stellar/stellar-protocol/pull/1430)).


### PR DESCRIPTION
Depending on the integration (e.g the [Stellar Disbursement Platform](https://github.com/stellar/stellar-disbursement-platform-backend/pull/256)) parts may want to hash the mobile number to increase security during the data sharing between wallets and Anchors.