### PR TITLE
Add the PHP Anchor SDK to the implementations of SEP-06, SEP-10, SEP-12, SEP-24, SEP-31 and SEP-38.

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -1783,6 +1783,7 @@ object containing an error message.
   https://github.com/Soneso/stellar-ios-mac-sdk/blob/master/README.md#6-anchor-client-interoperability
 - Flutter SDK: https://github.com/Soneso/stellar_flutter_sdk/blob/master/documentation/sdk_examples/sep-0006-transfer.md
 - PHP SDK: https://github.com/Soneso/stellar-php-sdk/blob/main/examples/sep-0006-transfer.md
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-06.md
 
 [SEP-12]: sep-0012.md
 [SEP-38]: sep-0038.md

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -201,7 +201,7 @@ time the token is signed with a **Client Account** () private key
 ##### Verifying request header
 
 When server receives a request with an `Authorization` header, server should validate the token before processing with
-issuing a challenge transaction.  
+issuing a challenge transaction.
 First, server must use the same steps of choosing the public key (see above), and verify **ed25519** signature of the
 token. Next, server must verify JWT claims:
 
@@ -555,6 +555,7 @@ of best current practices when using JWTs: [IETF JWT BCP].
 - iOS and macOS SDK: https://github.com/Soneso/stellar-ios-mac-sdk/blob/master/README.md#8-stellar-web-authentication
 - Flutter SDK: https://github.com/Soneso/stellar_flutter_sdk/blob/master/documentation/sdk_examples/sep-0010-webauth.md
 - PHP SDK: https://github.com/Soneso/stellar-php-sdk/blob/main/examples/sep-0010-webauth.md
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-10.md
 
 ## Changelog
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -780,6 +780,7 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 - Flutter SDK: https://github.com/Soneso/stellar_flutter_sdk/blob/master/documentation/sdk_examples/sep-0012-kyc.md
 - PHP SDK: https://github.com/Soneso/stellar-php-sdk/blob/main/examples/sep-0012-kyc.md
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-12.md
 
 ## Changelog
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -1406,6 +1406,7 @@ There is a small set of changes when upgrading from SEP-6 to SEP-24.
 - Demo wallet client for development of an anchor server: https://sep24.stellar.org
 - Anchor server implementation example and reuseable app in Python: https://github.com/stellar/django-polaris
 - Solar wallet: https://solarwallet.io
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-24.md
 
 ## Changelog
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -1032,6 +1032,10 @@ It is important to note that the Receiving Anchor is not obligated, at least by 
 parties), to retry if an unexpected status code is returned by the Sending Anchor. If Sending Anchors experience
 unexpected downtime, it is recommended to poll all in-progress transactions to fetch current status values.
 
+## Implementations
+
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-31.md
+
 ## Changelog
 
 - `v2.6.0`: Add `fee_details` field to the transaction object ([]())

--- a/ecosystem/sep-0038.md
+++ b/ecosystem/sep-0038.md
@@ -609,6 +609,10 @@ GET /quote/de762cda-a193-4961-861e-57b31fed6eb3
 
 [`SEP-10`]: #authentication
 
+## Implementations
+
+- PHP Anchor SDK: https://github.com/Argo-Navis-Dev/php-anchor-sdk/blob/main/docs/sep-38.md
+
 ## Changelog
 
 - `v2.2.0`: Switch from ISO-3166-1 alpha-3 country code to ISO-3166-2/ISO-3166-1 alpha-3 country code in the requests


### PR DESCRIPTION
The [PHP Anchor SDK](https://github.com/Argo-Navis-Dev/php-anchor-sdk) implements the SEPs 06, 10, 12, 24, 31 and 38. This PR adds the PHP Anchor SDK
to the list of implementations for this SEPs.