### PR TITLE
SEP-10: Add support for contracts (storage bound)

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2024-03-20
-Version: 3.4.0
+Version: 3.5.0
 ```
 
 ## Simple Summary
@@ -33,7 +33,7 @@ It involves the following components:
   document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or a different domain.
   - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
 - A **Client Account**: the account being authenticated.
-  - A Stellar account (`G...`) or a muxed account (`M...`).
+  - A Stellar account (`G...`) or a muxed account (`M...`) or a contract account (`C...`).
   - If a Stellar account (`G...`), may be accompanied by a memo to scope the authentication to a user or sub-account of
     the account.
 - A **Client**: the software used by the holder of the **Client Account** being authenticated by the **Server**.
@@ -59,9 +59,12 @@ The authentication flow is as follows:
    the transaction isn't malicious.
 1. The **Client** verifies that the transaction is signed by the **Server Account** obtained through discovery flow.
 1. The **Client** verifies that the transaction's first operation is a Manage Data operation that has its:
-   1. Source account set to the **Client Account**
+   1. Source account set to the **Client Account** or the G-zero address
    1. Key set to `<home domain> auth` where the home domain is the **Home Domain**.
    1. Value set to a nonce value.
+1. If the source account is set to the G-zero address, the **Client** verifies that the transaction has a Manage Data operation with:
+   1. Key set to `client_account`.
+   1. Value set to the bytes of the `G...`, `M...`, or `C...` address strkey.
 1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
    1. Source account set to the **Server Account**.
    1. Value set to the **Server**'s domain that the client requested the challenge from.
@@ -75,16 +78,18 @@ The authentication flow is as follows:
 1. The **Client** signs the transaction using the secret key(s) of the signer(s) for the **Client Account**
 1. The **Client** submits the signed challenge back to the **Server** using [`token`](#token) endpoint
 1. The **Server** checks that the **Client Account** exists
-1. If the **Client Account** exists:
-1. The **Server** gets the signers of the **Client Account**
-1. The **Server** verifies that one or more signatures are from signers of the **Client Account**.
-1. The **Server** verifies that there is only one additional signature from the **Server Account**
-1. The **Server** verifies the weight provided by the signers of the **Client Account** meets the required threshold(s),
-   if any
-1. If the **Client Account** does not exist (optional):
-1. The **Server** verifies the signature count is two
-1. The **Server** verifies that one signature is correct for the master key of the **Client Account**
-1. The **Server** verified that the other signature is from the **Server Account**
+1. If the **Client Account** is a `G...` address and exists on the ledger:
+   1. The **Server** gets the signers of the **Client Account**
+   1. The **Server** verifies that one or more signatures are from signers of the **Client Account**.
+   1. The **Server** verifies that there is only one additional signature from the **Server Account**
+   1. The **Server** verifies the weight provided by the signers of the **Client Account** meets the required threshold(s), if any
+1. If the **Client Account** is a `G...` address and does not exist on the ledger (optional):
+   1. The **Server** verifies the signature count is two
+   1. The **Server** verifies that one signature is correct for the master key of the **Client Account**
+   1. The **Server** verified that the other signature is from the **Server Account**
+1. If the **Client Account** is a `C...` address (optional):
+   1. The **Server** verifies that the signature count is two
+   1. The **Server** verifies that one signature is correct for one of the public keys stored in an `ScVec` in a Contract Data ledger entry for the contract, with key set to an `ScSymbol` containing the symbol `sep-10-signers`.
 1. If the transaction has a Manage Data operation with key `client_domain`, the **Server** verifies that the source
    account of the operation signed the transaction and includes an additional `client_domain` claim in the JWT included
    in the response
@@ -215,7 +220,7 @@ should respond with an error.
 
 | Name            | Type          | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `account`       | `G...` string | The **Client Account**, which can be a stellar account (`G...`) or muxed account (`M...`) that the **Client** wishes to authenticate with the **Server**.                                                                                                                                                                                                                                                                  |
+| `account`       | `G...` string | The **Client Account**, which can be a stellar account (`G...`), muxed account (`M...`), or contract address (`C...`) that the **Client** wishes to authenticate with the **Server**.                                                                                                                                                                                                                                                                  |
 | `memo`          | string        | (optional) The memo to attach to the challenge transaction. Only permitted if a Stellar account (`G...`) is used. The memo must be of type `id`. Other memo types are not supported. See the [Memo](#memos) section for details.                                                                                                                                                                                           |
 | `home_domain`   | string        | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.                                                                                                     |
 | `client_domain` | string        | (optional) a **Client Domain**. Supplied by **Clients** that intend to verify their domain in addition to the **Client Account**. See [Verifying the Client Domain](#verifying-the-client-domain). **Servers** should ignore this parameter if the **Server** does not support **Client Domain** verification, or the **Server** does not support verification for the specific **Client Domain** included in the request. |
@@ -248,8 +253,11 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
       - `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
         - The source account is the **Server Account**
         - The value is the **Server**'s domain. It can be at most 64 characters.
-      - (optional) `manage_data(source: client domain account, key: 'client_domain', value: client_domain)`
-        - The source account is the **Client Domain Account**
+      - (optional) `manage_data(source: client domain account or G-zero, key: 'client_account', value: client_account e.g. C...)`
+        - The source account is the **Client Domain Account** or G-zero
+        - Add this operation if the client account is a contract `C...` address
+      - (optional) `manage_data(source: client domain account or G-zero, key: 'client_domain', value: client_domain)`
+        - The source account is the **Client Domain Account** or G-zero
         - Add this operation if the server supports [Verifying the Client Domain](#verifying-the-client-domain) and the
           client provided a `client_domain` parameter in the request.
       - zero or more `manage_data(source: server account, ...)` reserved for future use
@@ -338,6 +346,10 @@ fail, then the authentication request must be rejected — that is, treated by t
 - if the first operation's source account does not exist:
   - verify that remaining signature count is one;
   - verify that remaining signature is correct for the master key of the **Client Account**
+- if the first operation's source account is G-zero, and contains a Manage Data operation with the key `client_account`:
+  - use the value of this operation for the client account instead of the source account value
+- if the client account is a contract `C...` address
+  - verify that the transaction was signed by one of the public keys stored in the `ScVec` of the Contract Data ledger entry stored in persistent storage of the contract with key `ScSymbol` containing the symbol `sep-10-signers`
 - if the transaction contains a Manage Data operation with the key `client_domain`:
   - verify that the transaction was signed by the source account of the Manage Data operation
 - verify that transaction containing additional Manage Data operations have their source account set to the **Server
@@ -475,6 +487,18 @@ with less than any threshold may allow a third-party to authenticate.
 
 A **Server** that needs to support validating accounts that do not exist can require a signature of the master key of
 the account address for accounts that do not exist.
+
+### Verifying Contract Accounts
+
+A **Server** that supports contract accounts should require that the challenge transaction is signed by a public key
+stored on ledger in the persistent contract data for that contract.
+
+The contract data should be structured such that the:
+- contract is the address of the contract authenticating
+- key is the `ScSymbol` `sep-10-signers`
+- value is an `ScVec` containing a list of `String` types containing strkeys
+
+Any one signer in the list can sign. No complex multisig is supported.
 
 ### Verifying the Client Domain
 


### PR DESCRIPTION
### What
Add support for contracts to SEP-10 using storage to store a fixed key.

### Why
So that contract accounts can authenticate with SEP-24, SEP-30, etc.

### State
This PR is a early draft and idea for how SEP-10 could be modified.

cc @JakeUrban @tomerweller @philipliu @reecexlm @mtwtfss 


Related:
- https://github.com/stellar/stellar-protocol/pull/1494