### PR TITLE
SEP-10: Add support for contracts (Soroban Auth bound)

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2024-03-20
-Version: 3.5.0
+Version: 4.0.0
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2024-03-20
-Version: 3.4.0
+Version: 3.5.0
 ```
 
 ## Simple Summary
@@ -33,7 +33,7 @@ It involves the following components:
   document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or a different domain.
   - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
 - A **Client Account**: the account being authenticated.
-  - A Stellar account (`G...`) or a muxed account (`M...`).
+  - A Stellar account (`G...`) or a muxed account (`M...`) or a contract account (`C...`).
   - If a Stellar account (`G...`), may be accompanied by a memo to scope the authentication to a user or sub-account of
     the account.
 - A **Client**: the software used by the holder of the **Client Account** being authenticated by the **Server**.
@@ -59,9 +59,15 @@ The authentication flow is as follows:
    the transaction isn't malicious.
 1. The **Client** verifies that the transaction is signed by the **Server Account** obtained through discovery flow.
 1. The **Client** verifies that the transaction's first operation is a Manage Data operation that has its:
-   1. Source account set to the **Client Account**
+   1. Source account set to the **Client Account** or the G-zero address
    1. Key set to `<home domain> auth` where the home domain is the **Home Domain**.
    1. Value set to a nonce value.
+1. If the source account is set to the G-zero address, the **Client** verifies that the transaction has an Invoke Host Function operation with:
+   1. Host Function set to `HOST_FUNCTION_TYPE_INVOKE_CONTRACT` with:
+      1. Contract address set to the **Client Account**.
+      1. Function name set to `webauth_verify`.
+      1. Args set to an empty list.
+   1. Auth containing a single Soroban Authorization Entry that was provided by the **Client** in the challenge request.
 1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
    1. Source account set to the **Server Account**.
    1. Value set to the **Server**'s domain that the client requested the challenge from.
@@ -84,6 +90,8 @@ The authentication flow is as follows:
 1. If the **Client Account** does not exist (optional):
 1. The **Server** verifies the signature count is two
 1. The **Server** verifies that one signature is correct for the master key of the **Client Account**
+1. If the **Client Account** is the G-zero address:
+1. The **Server** verifies the account by submitting the Invoke Host Function operation to a Stellar RPC for simulation with auth verification enabled and checking that auth succeeds in simulation.
 1. The **Server** verified that the other signature is from the **Server Account**
 1. If the transaction has a Manage Data operation with key `client_domain`, the **Server** verifies that the source
    account of the operation signed the transaction and includes an additional `client_domain` claim in the JWT included
@@ -216,6 +224,7 @@ should respond with an error.
 | Name            | Type          | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `account`       | `G...` string | The **Client Account**, which can be a stellar account (`G...`) or muxed account (`M...`) that the **Client** wishes to authenticate with the **Server**.                                                                                                                                                                                                                                                                  |
+| `auth`       | XDR string | (optional) The Soroban Authorization Entry encoded as XDR base64. Required when the `account` is a `C...` address.                                                                                                                                                                                                                                                                  |
 | `memo`          | string        | (optional) The memo to attach to the challenge transaction. Only permitted if a Stellar account (`G...`) is used. The memo must be of type `id`. Other memo types are not supported. See the [Memo](#memos) section for details.                                                                                                                                                                                           |
 | `home_domain`   | string        | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.                                                                                                     |
 | `client_domain` | string        | (optional) a **Client Domain**. Supplied by **Clients** that intend to verify their domain in addition to the **Client Account**. See [Verifying the Client Domain](#verifying-the-client-domain). **Servers** should ignore this parameter if the **Server** does not support **Client Domain** verification, or the **Server** does not support verification for the specific **Client Domain** included in the request. |
@@ -475,6 +484,27 @@ with less than any threshold may allow a third-party to authenticate.
 
 A **Server** that needs to support validating accounts that do not exist can require a signature of the master key of
 the account address for accounts that do not exist.
+
+### Verifying Contract Accounts
+
+A **Server** can verify a contract account if the contract has a `webauth` function that has a `require_auth` called on its own address.
+
+When requesting the challenge the **Client** must include the `auth` parameter containing a prebuilt and presigned Soroban Authorization Entry to authorize a call to the contracts `webauth` function.
+
+The Soroban Authorization Entry should contain:
+1. Credentials set to a Soroban Address Credentials with:
+   1. Address set to the **Client Account**.
+   1. Nonce set to a random value.
+   1. Signature Expiration Ledger set to a value in the near future to define the length of time of validatity of the signature.
+   1. Signature set to the values the account requires to authenticate, as defined by the contract.
+1. Root invocation with:
+   1. Host Function set to `HOST_FUNCTION_TYPE_INVOKE_CONTRACT` with:
+      1. Contract address set to the **Client Account**.
+      1. Function name set to `webauth_verify`.
+      1. Args set to an empty list.
+   1. Sub-invocations set as required.
+
+The server will consider the contract authenticated and authorized if the simulation of invoking its `webauth` function succeeds.
 
 ### Verifying the Client Domain
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -65,9 +65,9 @@ The authentication flow is as follows:
 1. If the source account is set to the G-zero address, the **Client** verifies that the transaction has an Invoke Host Function operation with:
    1. Host Function set to `HOST_FUNCTION_TYPE_INVOKE_CONTRACT` with:
       1. Contract address set to the **Client Account**.
-      1. Function name set to `webauth_verify`.
+      1. Function name set to `web_auth_verify`.
       1. Args set to an empty list.
-   1. Auth containing a single Soroban Authorization Entry that was provided by the **Client** in the challenge request.
+   1. Auth containing one or more Soroban Authorization Entries that were provided by the **Client** in the challenge request.
 1. The **Client** verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
    1. Source account set to the **Server Account**.
    1. Value set to the **Server**'s domain that the client requested the challenge from.
@@ -224,7 +224,7 @@ should respond with an error.
 | Name            | Type          | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
 | --------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `account`       | `G...` string | The **Client Account**, which can be a stellar account (`G...`) or muxed account (`M...`) that the **Client** wishes to authenticate with the **Server**.                                                                                                                                                                                                                                                                  |
-| `auth`       | XDR string | (optional) The Soroban Authorization Entry encoded as XDR base64. Required when the `account` is a `C...` address.                                                                                                                                                                                                                                                                  |
+| `auth`       | XDR string | (optional) An XDR var-array of Soroban Authorization Entries encoded as XDR base64. Required when the `account` is a `C...` address.                                                                                                                                                                                                                                                                  |
 | `memo`          | string        | (optional) The memo to attach to the challenge transaction. Only permitted if a Stellar account (`G...`) is used. The memo must be of type `id`. Other memo types are not supported. See the [Memo](#memos) section for details.                                                                                                                                                                                           |
 | `home_domain`   | string        | (optional) a **Home Domain**. Servers that generate tokens for multiple **Home Domain**s can use this parameter to identify which home domain the **Client** hopes to authenticate with. If not provided by the **Client**, the **Server** should assume a default for backwards compatibility with older **Clients**.                                                                                                     |
 | `client_domain` | string        | (optional) a **Client Domain**. Supplied by **Clients** that intend to verify their domain in addition to the **Client Account**. See [Verifying the Client Domain](#verifying-the-client-domain). **Servers** should ignore this parameter if the **Server** does not support **Client Domain** verification, or the **Server** does not support verification for the specific **Client Domain** included in the request. |
@@ -487,11 +487,11 @@ the account address for accounts that do not exist.
 
 ### Verifying Contract Accounts
 
-A **Server** can verify a contract account if the contract has a `webauth` function that has a `require_auth` called on its own address.
+A **Server** can verify a contract account if the contract has a `web_auth_verify` function that has a `require_auth` called on its own address.
 
-When requesting the challenge the **Client** must include the `auth` parameter containing a prebuilt and presigned Soroban Authorization Entry to authorize a call to the contracts `webauth` function.
+When requesting the challenge the **Client** must include the `auth` parameter containing a prebuilt and presigned Soroban Authorization Entry to authorize a call to the contracts `web_auth_verify` function.
 
-The Soroban Authorization Entry should contain:
+The Soroban Authorization Entries should contain at least one entry that has:
 1. Credentials set to a Soroban Address Credentials with:
    1. Address set to the **Client Account**.
    1. Nonce set to a random value.
@@ -500,11 +500,17 @@ The Soroban Authorization Entry should contain:
 1. Root invocation with:
    1. Host Function set to `HOST_FUNCTION_TYPE_INVOKE_CONTRACT` with:
       1. Contract address set to the **Client Account**.
-      1. Function name set to `webauth_verify`.
+      1. Function name set to `web_auth_verify`.
       1. Args set to an empty list.
    1. Sub-invocations set as required.
 
-The server will consider the contract authenticated and authorized if the simulation of invoking its `webauth` function succeeds.
+The auth entries may contain other necessary auths for sub-invocations if they are present.
+
+The server will consider the contract authenticated and authorized if the simulation of invoking its `web_auth_verify` function succeeds.
+
+It is the clients responsibility to ensure the `web_auth_verify` succeeds only if a valid and appropriate auth and signature are provided alongside it's invocation.
+
+It is the **Servers** and Soroban Env's responsibility to ensure that if the `web_auth_verify` function is invoked with auth entries that are unused, or missing auth entries that the invocation requires using `require_auth`, that the simulation and auth fails.
 
 ### Verifying the Client Domain
 


### PR DESCRIPTION
### What
Add support for contracts to SEP-10 using Soroban Auth.

### Why
So that contract accounts can authenticate with SEP-24, SEP-30, etc.

### State
This PR is a early draft and idea for how SEP-10 could be modified.

cc @JakeUrban @tomerweller @philipliu @reecexlm @mtwtfss @dmkozh 

Related:
- https://github.com/stellar/stellar-protocol/pull/1492