### PR TITLE
SEP-9: add mobile money fields

### DIFF
--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -180,7 +180,7 @@ receive. Usually, application would require either `token`, or set of: `number`,
 ## Changelog
 
 - `v1.18.0`: Add `mobile_money_number`, `mobile_money_provider`, and `bank_name` fields to Financial Account Fields
-  ([]())
+  ([#1498](https://github.com/stellar/stellar-protocol/pull/1498))
 - `v1.17.0`: Add `mobile_number_format` field to Natural Person Fields
   ([#1481](https://github.com/stellar/stellar-protocol/pull/1481)).
 - `v1.16.0`: Add `external_transfer_memo` field to Financial Account Fields

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -103,19 +103,22 @@ any country, and some fields are specific to a given country, such as `cbu_numbe
 addition to other pieces of information. In order to optimize for the user's experience, it is recommended that
 applications use fields that are the most familiar, which are often specific to a given country or financial system.
 
-| Name                     | Type   | Description                                                                                                  |
-| ------------------------ | ------ | ------------------------------------------------------------------------------------------------------------ |
-| `bank_account_type`      | string | `checking` or `savings`                                                                                      |
-| `bank_account_number`    | string | Number identifying bank account                                                                              |
-| `bank_number`            | string | Number identifying bank in national banking system (routing number in US)                                    |
-| `bank_phone_number`      | string | Phone number with country code for bank                                                                      |
-| `bank_branch_number`     | string | Number identifying bank branch                                                                               |
-| `external_transfer_memo` | string | A destination tag/memo used to identify a transaction                                                        |
-| `clabe_number`           | string | Bank account number for Mexico                                                                               |
-| `cbu_number`             | string | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                                               |
-| `cbu_alias`              | string | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                               |
-| `crypto_address`         | string | Address for a cryptocurrency account                                                                         |
-| `crypto_memo`            | string | (**deprecated**, use `external_transfer_memo` instead) A destination tag/memo used to identify a transaction |
+| Name                     | Type   | Description                                                                                                                                                            |
+| ------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bank_name`              | string | Name of the bank. May be necessary in regions that don't have a unified routing system.                                                                                |
+| `bank_account_type`      | string | `checking` or `savings`                                                                                                                                                |
+| `bank_account_number`    | string | Number identifying bank account                                                                                                                                        |
+| `bank_number`            | string | Number identifying bank in national banking system (routing number in US)                                                                                              |
+| `bank_phone_number`      | string | Phone number with country code for bank                                                                                                                                |
+| `bank_branch_number`     | string | Number identifying bank branch                                                                                                                                         |
+| `external_transfer_memo` | string | A destination tag/memo used to identify a transaction                                                                                                                  |
+| `clabe_number`           | string | Bank account number for Mexico                                                                                                                                         |
+| `cbu_number`             | string | Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                                                                                                         |
+| `cbu_alias`              | string | The alias for a Clave Bancaria Uniforme (CBU) or Clave Virtual Uniforme (CVU).                                                                                         |
+| `mobile_money_number`    | string | Mobile phone number in `E.164` format with which a mobile money account is associated. Note that this number may be distinct from the same customer's `mobile_number`. |
+| `mobile_money_provider`  | string | Name of the mobile money service provider.                                                                                                                             |
+| `crypto_address`         | string | Address for a cryptocurrency account                                                                                                                                   |
+| `crypto_memo`            | string | (**deprecated**, use `external_transfer_memo` instead) A destination tag/memo used to identify a transaction                                                           |
 
 ## Organization Fields
 
@@ -176,6 +179,8 @@ receive. Usually, application would require either `token`, or set of: `number`,
 
 ## Changelog
 
+- `v1.18.0`: Add `mobile_money_number`, `mobile_money_provider`, and `bank_name` fields to Financial Account Fields
+  ([]())
 - `v1.17.0`: Add `mobile_number_format` field to Natural Person Fields
   ([#1481](https://github.com/stellar/stellar-protocol/pull/1481)).
 - `v1.16.0`: Add `external_transfer_memo` field to Financial Account Fields

--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
   },
   "devDependencies": {
     "prettier": "2.8.8"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }


### PR DESCRIPTION
Adds `mobile_money_number`, `mobile_money_provider`, and `bank_name` to the list of financial account fields. 

Customers of mobile money services can have accounts linked to a phone number that is not their personal mobile number, hence the need to add a new field as opposed to reusing `mobile_number`.