### PR TITLE
[ANCHOR-719] Update SEP31 to replace SEP12 with async kyc flow

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -86,16 +86,16 @@ sequenceDiagram
     Anchor-->>-Wallet: transaction id
 
     note right of Wallet: If User has already <br> been accepted, <br> KYC is unnecessary.
-    Wallet->>+Anchor: GET [SEP-12]/customer?transaction_id=<id>
+    Wallet->>+Anchor: GET [SEP-12]/customer?transaction_id=<id>&type=
     Anchor-->>-Wallet: fields required
     Wallet->>+User: requests fields
     User-->>-Wallet: provides field values
-    Wallet->>+Anchor: PUT [SEP-12]/customer?transaction_id=<id>
+    Wallet->>+Anchor: PUT [SEP-12]/customer?transaction_id=<id>&type=
     Anchor-->>Anchor: validates KYC values
     Anchor-->>-Wallet: id, ACCEPTED
 
     Wallet->>+Anchor: GET [SEP-6]/transaction?id=
-    Anchor-->>-Wallet: transaction object containing amount_in, receving account, memo
+    Anchor-->>-Wallet: transaction object containing amount_in, receiving account, memo
     note right of Wallet: Use the info amount_in returned <br> from GET [SEP-6]/transaction?id={id} <br> to make the stellar payment.
 
     Wallet->>+Stellar: submit Stellar payment

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -86,11 +86,11 @@ sequenceDiagram
     Anchor-->>-Wallet: transaction id
 
     note right of Wallet: If User has already <br> been accepted, <br> KYC is unnecessary.
-    Wallet->>+Anchor: GET [SEP-12]/customer?transaction_id=<id>&type=
+    Wallet->>+Anchor: GET [SEP-12]/customer?transaction_id=<id>
     Anchor-->>-Wallet: fields required
     Wallet->>+User: requests fields
     User-->>-Wallet: provides field values
-    Wallet->>+Anchor: PUT [SEP-12]/customer?transaction_id=<id>type=
+    Wallet->>+Anchor: PUT [SEP-12]/customer?transaction_id=<id>
     Anchor-->>Anchor: validates KYC values
     Anchor-->>-Wallet: id, ACCEPTED
 
@@ -1792,7 +1792,7 @@ object containing an error message.
 - `v4.1.0` Add `user_action_required_by` field to transaction responses and add new `on_hold` status
   ([#1484](https://github.com/stellar/stellar-protocol/pull/1484/))
 - `v4.0.0`: Update flow to delegate getting KYC fields to SEP-12
-  ([#1432](https://github.com/stellar/stellar-protocol/pull/1431))
+  ([#1432](https://github.com/stellar/stellar-protocol/pull/1432))
 - `v3.26.0`: Add `location_id` to deposit/withdrawal requests
   ([#1433](https://github.com/stellar/stellar-protocol/pull/1433))
 - `v3.25.0` Add `fee_details` field to the transaction object
@@ -1820,7 +1820,8 @@ object containing an error message.
   ([#1333](https://github.com/stellar/stellar-protocol/pull/1333))
 * `v3.16.0`: Add `refund_memo` and `refund_memo_type` to requests initiating transactions.
   ([#1321](https://github.com/stellar/stellar-protocol/pull/1321))
-* `v3.15.0`: Add `lang` to `/transactions` & `/transaction` parameters, update format to [RFC 4646]. ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
+* `v3.15.0`: Add `lang` to `/transactions` & `/transaction` parameters, update format to [RFC 4646].
+  ([#1320](https://github.com/stellar/stellar-protocol/pull/1320))
 * `v3.14.0`: Add `quote_id` to the transaction object schema.
   ([#1268](https://github.com/stellar/stellar-protocol/pull/1268))
 * `v3.13.0`: Add callback signature requirement. ([#1262](https://github.com/stellar/stellar-protocol/pull/1262))

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -32,15 +32,15 @@ Implementing a regulated asset requires these parts:
 
 - Issuer account with appropriate [authorization flags] set.
 - [SEP-1 stellar.toml] used for discovering [Approval Server].
-- [Approval Server] that validates client transactions according to the service's approval criteria. Validated transactions
-  are signed by the asset's issuing account.
+- [Approval Server] that validates client transactions according to the service's approval criteria. Validated
+  transactions are signed by the asset's issuing account.
 
 ## Regulated Assets Transaction Flow
 
 1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's an asset that requires authorization.
-   1. Wallet can detect whether an asset requires authorization by checking the [authorization flags] of the asset issuer's
-      account
+   1. Wallet can detect whether an asset requires authorization by checking the [authorization flags] of the asset
+      issuer's account
 3. Wallet detects that it's a regulated asset.
    1. Wallet can detect whether an asset is a regulated asset by checking for an approval server via [SEP-1
       stellar.toml] set up by the issuer
@@ -64,8 +64,8 @@ account. This allows the issuer to grant and revoke authorization to transact th
 
 ## SEP-1 stellar.toml
 
-Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the `[[CURRENCIES]]`
-section as different assets can have different requirements.
+Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the
+`[[CURRENCIES]]` section as different assets can have different requirements.
 
 ### Fields:
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -6,8 +6,8 @@ Title: KYC API
 Author: Interstellar
 Status: Active
 Created: 2018-09-11
-Updated: 2024-02-09
-Version 1.13.0
+Updated: 2024-07-23
+Version 1.14.0
 ```
 
 ## Abstract
@@ -141,7 +141,8 @@ returned in the response instead.
 Different types of customers may have different KYC requirements depending on the action a given customer wants to take.
 The `type` parameter is used to specify the action a customer wants to make so the server can identify what information
 must be collected. SEP-12 does not define what `type` values are accepted and instead leaves that to the other
-protocols, such as [SEP-31](sep-0031.md), that use SEP-12 for the actions associated with those protocols.
+protocols, such as [SEP-6](sep-0006.md) and [SEP-31](sep-0031.md), that use SEP-12 for the actions associated with those
+protocols.
 
 For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31
 receiver would require banking information in order to receive a direct deposit.
@@ -153,6 +154,9 @@ parameter when making requests to `GET /customer` or `PUT /customer`, even thoug
 for implementations that do not require `type`.
 
 If the implementor requires the same set of fields for all customers, there is no need for the `type` parameter.
+
+When the `type` parameter is used with `transaction_id`, it can only be `sep6`, `sep31-sender`, or `sep31-receiver`,
+respectively.
 
 ### Response
 
@@ -781,6 +785,7 @@ All responses should return `200 OK`. If no files are found for the identifer us
 
 ## Changelog
 
+- `v1.14.0`: Update SEP31 with async kyc flow ([#1502](https://github.com/stellar/stellar-protocol/pull/1502))
 - `v1.13.0`: Add `transaction_id` field to `/customer` `GET` and `PUT`
   ([#1432](https://github.com/stellar/stellar-protocol/pull/1432))
 - `v1.12.0`: Deprecate `PUT /verifcation` and update verification process

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -112,7 +112,7 @@ server still needs more info, or the server needs updated information, it should
 ### Request
 
 ```
-GET [KYC_SERVER]/customer&type=<customer-type>
+GET [KYC_SERVER]/customer?transaction_id=<transaction-id>&type=<customer-type>
 GET [KYC_SERVER]/customer?account=<stellar-account>&type=<customer-type>
 GET [KYC_SERVER]/customer?account=<stellar-account>&memo=<memo>&type=<customer-type>
 GET [KYC_SERVER]/customer?account=<muxed-account>&type=<customer-type>
@@ -140,21 +140,17 @@ returned in the response instead.
 
 Different types of customers may have different KYC requirements depending on the action a given customer wants to take.
 The `type` parameter is used to specify the action a customer wants to make so the server can identify what information
-must be collected. SEP-12 does not define what `type` values are accepted and instead leaves that to the other
-protocols, such as [SEP-6](sep-0006.md) and [SEP-31](sep-0031.md), that use SEP-12 for the actions associated with those
-protocols.
+must be collected.
 
 For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31
-receiver would require banking information in order to receive a direct deposit. The `type` parameter could also be used
-to indicate that a customer is an organization instead of a person.
+receiver would require banking information in order to receive a direct deposit.
 
 Note that it is possible for the same customer to have different `status` values for different `type` parameters. For
-example, a customer could have an `ACCEPTED` status for the `small-transaction-amount` `type` parameter but have a
-`NEEDS_INFO` status for the `large-transaction-amount` type. Therefore it is recommended to always pass the `type`
-parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accomodate
-for implementations that do not require `type`.
+example, a customer could have an `ACCEPTED` status for the `seo31-sender` `type` parameter but have a `NEEDS_INFO`
+status for the `sep31-receiver` type.
 
-If the implementor requires the same set of fields for all customers, there is no need for the `type` parameter.
+Currently, the use of the `type` parameter is limited to SEP-31 only, supporting only two types: `sep31-sender` and
+`sep31-receiver`, and must be used in conjunction with a SEP-31 `transaction_id` parameter.
 
 ### Response
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -140,17 +140,19 @@ returned in the response instead.
 
 Different types of customers may have different KYC requirements depending on the action a given customer wants to take.
 The `type` parameter is used to specify the action a customer wants to make so the server can identify what information
-must be collected.
+must be collected. SEP-12 does not define what `type` values are accepted and instead leaves that to the other
+protocols, such as [SEP-31](sep-0031.md), that use SEP-12 for the actions associated with those protocols.
 
 For example, if a customer is being KYC'd as a SEP-31 sender, they may only require full name and email, but a SEP-31
 receiver would require banking information in order to receive a direct deposit.
 
 Note that it is possible for the same customer to have different `status` values for different `type` parameters. For
-example, a customer could have an `ACCEPTED` status for the `seo31-sender` `type` parameter but have a `NEEDS_INFO`
-status for the `sep31-receiver` type.
+example, a customer could have an `ACCEPTED` status for the `small-transaction-amount` `type` parameter but have a
+`NEEDS_INFO` status for the `large-transaction-amount` type. Therefore, it is recommended to always pass the `type`
+parameter when making requests to `GET /customer` or `PUT /customer`, even though the field is optional to accommodate
+for implementations that do not require `type`.
 
-Currently, the use of the `type` parameter is limited to SEP-31 only, supporting only two types: `sep31-sender` and
-`sep31-receiver`, and must be used in conjunction with a SEP-31 `transaction_id` parameter.
+If the implementor requires the same set of fields for all customers, there is no need for the `type` parameter.
 
 ### Response
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -74,8 +74,8 @@ thresholds] to high 2, med 2, low 2, and assign weights 1 to both server signing
 
 A client can register with a single server and give the servers signing key a weight that is appropriate for the use
 case the client and server are targeting. For example, if a client intends to use a single server and give that server
-control of the account, then the client could configure [account thresholds] to high 1, med 1, low 1, and assign weight 1
-to the server signing key.
+control of the account, then the client could configure [account thresholds] to high 1, med 1, low 1, and assign weight
+1 to the server signing key.
 
 The signing flow is as follows:
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -83,17 +83,6 @@ sequenceDiagram
     Receiving Anchor-->>Receiving Anchor: verifies challenge
     Receiving Anchor-->>-Sending Anchor: authentication token
 
-    loop once for Sending Client, once of Receiving Client
-        note right of Sending Anchor: If Sending Client or Receiving Client <br >has already been <br> accepted, this section <br> is unnecessary.
-        Sending Anchor->>+Receiving Anchor: GET [SEP-12]/customer?type=
-        Receiving Anchor-->>-Sending Anchor: fields required
-        Sending Anchor->>+Sending Client: requests fields
-        Sending Client-->>-Sending Anchor: provides field values
-        Sending Anchor->>+Receiving Anchor: PUT [SEP-12]/customer?type=
-        Receiving Anchor-->>Receiving Anchor: validates KYC values
-        Receiving Anchor-->>-Sending Anchor: id, ACCEPTED
-    end
-
     Sending Anchor->>+Receiving Anchor: GET [SEP-38]/price
     Receiving Anchor-->>-Sending Anchor: exchange rate
     Sending Anchor->>+Sending Client: provides estimated rate
@@ -103,7 +92,16 @@ sequenceDiagram
 
     Sending Anchor->>+Receiving Anchor: POST [SEP-31]/transactions
     Receiving Anchor-->>Receiving Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
-    Receiving Anchor-->>-Sending Anchor: transaction id, receiving account & memo
+    Receiving Anchor-->>-Sending Anchor: transaction id
+
+    note right of Sending Anchor: If Sending Client or Receiving Client <br >has already been <br> accepted, this section <br> is unnecessary.
+    Sending Anchor->>+Receiving Anchor: GET [SEP-12]/customer?transaction_id=<id>&type=
+    Receiving Anchor-->>-Sending Anchor: fields required
+    Sending Anchor->>+Sending Client: requests fields
+    Sending Client-->>-Sending Anchor: provides field values
+    Sending Anchor->>+Receiving Anchor: PUT [SEP-12]/customer?transaction_id=<id>&type=
+    Receiving Anchor-->>Receiving Anchor: validates KYC values
+    Receiving Anchor-->>-Sending Anchor: id, ACCEPTED
 
     Sending Anchor->>+Receiving Anchor: GET [SEP-31]/transactions/:id
     Receiving Anchor-->>-Sending Anchor: transaction object containing amount_in, amount_in_asset, stellar_account_id, etc.
@@ -216,21 +214,11 @@ earlier than the quote's expiration.
 ### Detailed Sending Anchor Flow
 
 1. The Sending Client initiates a payment to the Receiving Client.
-1. The Sending Anchor identifies the Receiving Anchor it will use for the payment based on the receipient's location.
+1. The Sending Anchor identifies the Receiving Anchor it will use for the payment based on the recipient's location.
 1. The Sending Anchor makes a request to the Receiving Anchor's `GET /info` endpoint to collect asset information and
    the `transaction.fields` describing the transaction-related information required by the Receiving Anchor.
-1. The Sending Anchor fetches the relevant KYC `type` values from the `sep12` object for the Sending and Receiving
-   Client. If no `type` values are defined for either client, KYC information is not required for that client.
-1. The Sending Anchor makes [SEP-12 GET /customer?type=](sep-0012.md#customer-get) requests for the Sending and
-   Receiving Clients. The response includes the [SEP-9](sep-0009.md) KYC attributes required for registering a client of
-   the associated `type`.
-1. The Sending Anchor collects all required information from the Sending Client. This includes the custom fields listed
-   in the Receiving Anchor's `GET /info` response as well as the KYC fields described in the `GET /customer` responses
-   for both the Sending and Receiving Clients. How the Sending Anchor collects this information from the Sending Client
-   is out of the scope of this document, but the Receving Client should not be required to take any action in order for
-   the Sending Client to make the payment to the Receiving Anchor.
-1. The Sending Anchor makes [SEP-12 PUT /customer](sep-0012.md#customer-put) requests containing the collected
-   information for each client.
+1. Optionally the Sending Anchor can pre-register clients using [SEP-12 PUT /customer](sep-0012.md#customer-put) and
+   obtain the `id`s for each client.
 1. If the Receiving Anchor supports the [SEP-38 Anchor RFQ API](sep-0038.md), the Sending Anchor can request a quote
    from the Receiving Anchor. See the [Receiving Anchor Asset Conversion](#receiving-anchor-asset-conversion) section
    for more information.
@@ -329,32 +317,7 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
-      "max_amount": 1000,
-      "sep12": {
-        "sender": {
-          "types": {
-            "sep31-sender": {
-              "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
-            },
-            "sep31-large-sender": {
-              "description": "U.S. citizens that do not have sending limits"
-            },
-            "sep31-foreign-sender": {
-              "description": "non-U.S. citizens sending payments of less than $10,000 in value"
-            }
-          }
-        },
-        "receiver": {
-          "types": {
-            "sep31-receiver": {
-              "description": "U.S. citizens receiving USD"
-            },
-            "sep31-foreign-receiver": {
-              "description": "non-U.S. citizens receiving USD"
-            }
-          }
-        }
-      }
+      "max_amount": 1000
     }
   }
 }
@@ -371,36 +334,19 @@ the corresponding off-chain asset, after fees have been applied.
 
 #### Asset Object Schema
 
-| Name                  | Type    | Description                                                                                                                                                                                                                                             |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sep12`               | object  | An object containing `sender` and `receiver` keys.                                                                                                                                                                                                      |
-| `min_amount`          | number  | (optional) Minimum amount. No limit if not specified.                                                                                                                                                                                                   |
-| `max_amount`          | number  | (optional) Maximum amount. No limit if not specified.                                                                                                                                                                                                   |
-| `fee_fixed`           | number  | (optional) A fixed fee in units of the Stellar asset. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                                             |
-| `fee_percent`         | number  | (optional) A percentage fee in percentage points. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                                                 |
-| `sender_sep12_type`   | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a value from `sep12.sender.types` instead if any are present.    |
-| `receiver_sep12_type` | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a values from `sep12.receiver.types` instead if any are present. |
-| `fields`              | object  | (**deprecated**, optional) An object containing the per-transaction parameters required in `POST /transactions` requests. Pass [SEP-9](sep-0009.md) fields via [SEP-12 PUT /customer](sep-0012.md#customer-put) instead.                                |
-| `quotes_supported`    | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                                                            |
-| `quotes_required`     | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                                                         |
+| Name                  | Type    | Description                                                                                                                                                                                                              |
+| --------------------- | ------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sep12`               | object  | An object containing `sender` and `receiver` keys.                                                                                                                                                                       |
+| `min_amount`          | number  | (optional) Minimum amount. No limit if not specified.                                                                                                                                                                    |
+| `max_amount`          | number  | (optional) Maximum amount. No limit if not specified.                                                                                                                                                                    |
+| `fee_fixed`           | number  | (optional) A fixed fee in units of the Stellar asset. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                              |
+| `fee_percent`         | number  | (optional) A percentage fee in percentage points. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                  |
+| `sender_sep12_type`   | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. The value can only be `sep31-sender`, or ommited if no KYC is necessary.                |
+| `receiver_sep12_type` | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. The value can only be `sep31-receiver`, or omitted if no KYC is necessary.              |
+| `fields`              | object  | (**deprecated**, optional) An object containing the per-transaction parameters required in `POST /transactions` requests. Pass [SEP-9](sep-0009.md) fields via [SEP-12 PUT /customer](sep-0012.md#customer-put) instead. |
+| `quotes_supported`    | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                             |
+| `quotes_required`     | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                          |
 
-#### `sep12` Object Schema
-
-| Name       | Type   | Description                                                                                                  |
-| ---------- | ------ | ------------------------------------------------------------------------------------------------------------ |
-| `sender`   | object | An object containing a `types` key if KYC information is required for the Sending Client, empty otherwise.   |
-| `receiver` | object | An object containing a `types` key if KYC information is required for the Receiving Client, empty otherwise. |
-
-#### `types` Object Schema
-
-| Name    | Type   | Description                                                                                                                                                                           |
-| ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `types` | object | (optional) An object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests. Each key should map to an object with a human-readable `description`. |
-
-If KYC is required for a Sending or Receiving client in some cases but not others, it is recommended to provide values
-in the respective `types` object for all cases and return an empty `fields` object from
-[SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) for
-the cases where no KYC is necessary.
 
 #### `fields` Object Schema
 
@@ -857,9 +803,16 @@ In certain cases the Receiving Anchor might need to request updated information 
 the bank tells the Receiving Anchor that the provided Receiving Client's name is incorrect or missing a middle initial.
 Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` state
 until the Sending Anchor makes another `SEP-12 PUT /customer` request to update. The Sending Anchor can check which
-fields need to be updated by making a `SEP-12 GET /customer` request including the `id` or `account` & `memo`
-parameters. The Receiving Anchor should respond with a `NEEDS_INFO` status and `last_name` included in the fields
-described.
+fields need to be updated by making a `SEP-12 GET /customer` request including either the customer id `id`, or a
+combination of SEP-31 transaction id `transaction_id` and customer type `type`, which can only be `sep31-sender` or `sep31-receiver`. The Receiving Anchor should respond with a `NEEDS_INFO` status, a `provided_fields` including all provided
+fields, and a `fields` including all fields need to be updated .
+
+1. `GET /transaction` and verify transaction status is `pending_customer_info_update`
+2. Get required fields via [SEP-12] `GET /customer` request. Note, that you must pass `transaction_id` and customer type
+   `type` (limited to `sep31-sender` and `sep31-receiver`) as part of the request.
+3. Collect user input for the required fields and use [SEP-12] `PUT /customer?transaction_id=?type=` endpoint to transfer the data
+4. Repeat steps 2-3 until customer's response status becomes `ACCEPTED`
+5. `GET /transaction` should transition into `pending_receiver` status.
 
 #### Pending Transaction Info Update (Deprecated)
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -6,8 +6,8 @@ Title: Cross-Border Payments API
 Author: SDF
 Status: Active
 Created: 2020-04-07
-Updated: 2024-02-09
-Version 2.6.0
+Updated: 2024-07-23
+Version 3.0.0
 ```
 
 ## Simple Summary
@@ -858,7 +858,7 @@ updated .
 
 1. `GET /transaction` and verify transaction status is `pending_customer_info_update`
 2. Get required fields via [SEP-12] `GET /customer` request. It is recommended to use the combination of
-   `transaction_id` and customer type `type` as part of the request.
+   `transaction_id` and customer type `type` (`sep31-sender` and `sep31-receiver`) as part of the request.
 3. Collect user input for the required fields and use [SEP-12] `PUT /customer` endpoint to transfer the data
 4. Repeat steps 2-3 until customer's response status becomes `ACCEPTED`.
 5. `GET /transaction` should transition into `pending_receiver` status.
@@ -1036,7 +1036,9 @@ unexpected downtime, it is recommended to poll all in-progress transactions to f
 
 ## Changelog
 
-- `v2.6.0`: Add `fee_details` field to the transaction object ([]())
+- `v3.0.0`: Update SEP31 with async kyc flow ([#1502](https://github.com/stellar/stellar-protocol/pull/1502))
+- `v2.6.0`: Add `fee_details` field to the transaction object
+  ([#1429](https://github.com/stellar/stellar-protocol/pull/1429))
 - `v2.5.0`: Deprecate and make optional the use of per-transaction `fields` objects
   ([#1387](https://github.com/stellar/stellar-protocol/pull/1387))
 - `v2.4.0`: Add `updated_at` to `GET /transactions/:id` response

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -335,7 +335,7 @@ the corresponding off-chain asset, after fees have been applied.
 #### Asset Object Schema
 
 | Name                  | Type    | Description                                                                                                                                                                                                              |
-| --------------------- | ------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `sep12`               | object  | An object containing `sender` and `receiver` keys.                                                                                                                                                                       |
 | `min_amount`          | number  | (optional) Minimum amount. No limit if not specified.                                                                                                                                                                    |
 | `max_amount`          | number  | (optional) Maximum amount. No limit if not specified.                                                                                                                                                                    |
@@ -346,7 +346,6 @@ the corresponding off-chain asset, after fees have been applied.
 | `fields`              | object  | (**deprecated**, optional) An object containing the per-transaction parameters required in `POST /transactions` requests. Pass [SEP-9](sep-0009.md) fields via [SEP-12 PUT /customer](sep-0012.md#customer-put) instead. |
 | `quotes_supported`    | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                             |
 | `quotes_required`     | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                          |
-
 
 #### `fields` Object Schema
 
@@ -804,13 +803,15 @@ the bank tells the Receiving Anchor that the provided Receiving Client's name is
 Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` state
 until the Sending Anchor makes another `SEP-12 PUT /customer` request to update. The Sending Anchor can check which
 fields need to be updated by making a `SEP-12 GET /customer` request including either the customer id `id`, or a
-combination of SEP-31 transaction id `transaction_id` and customer type `type`, which can only be `sep31-sender` or `sep31-receiver`. The Receiving Anchor should respond with a `NEEDS_INFO` status, a `provided_fields` including all provided
-fields, and a `fields` including all fields need to be updated .
+combination of SEP-31 transaction id `transaction_id` and customer type `type`, which can only be `sep31-sender` or
+`sep31-receiver`. The Receiving Anchor should respond with a `NEEDS_INFO` status, a `provided_fields` including all
+provided fields, and a `fields` including all fields need to be updated .
 
 1. `GET /transaction` and verify transaction status is `pending_customer_info_update`
 2. Get required fields via [SEP-12] `GET /customer` request. Note, that you must pass `transaction_id` and customer type
    `type` (limited to `sep31-sender` and `sep31-receiver`) as part of the request.
-3. Collect user input for the required fields and use [SEP-12] `PUT /customer?transaction_id=?type=` endpoint to transfer the data
+3. Collect user input for the required fields and use [SEP-12] `PUT /customer?transaction_id=&type=` endpoint to
+   transfer the data
 4. Repeat steps 2-3 until customer's response status becomes `ACCEPTED`
 5. `GET /transaction` should transition into `pending_receiver` status.
 

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -94,14 +94,15 @@ sequenceDiagram
     Receiving Anchor-->>Receiving Anchor: checks customer statuses, <br> links quote, <br> creates transaction record
     Receiving Anchor-->>-Sending Anchor: transaction id
 
-    note right of Sending Anchor: If Sending Client or Receiving Client <br >has already been <br> accepted, this section <br> is unnecessary.
-    Sending Anchor->>+Receiving Anchor: GET [SEP-12]/customer?transaction_id=<id>&type=
-    Receiving Anchor-->>-Sending Anchor: fields required
-    Sending Anchor->>+Sending Client: requests fields
-    Sending Client-->>-Sending Anchor: provides field values
-    Sending Anchor->>+Receiving Anchor: PUT [SEP-12]/customer?transaction_id=<id>&type=
-    Receiving Anchor-->>Receiving Anchor: validates KYC values
-    Receiving Anchor-->>-Sending Anchor: id, ACCEPTED
+    loop once for Sending Client, once of Receiving Client
+        note right of Sending Anchor: If Sending Client or Receiving Client <br >has already been <br> accepted, this section <br> is unnecessary.
+        Sending Anchor->>+Receiving Anchor: GET [SEP-12]/customer?transaction_id=<id>&type=
+        Receiving Anchor-->>-Sending Anchor: fields required
+        Sending Anchor->>+Sending Client: requests fields
+        Sending Client-->>-Sending Anchor: provides field values
+        Sending Anchor->>+Receiving Anchor: PUT [SEP-12]/customer?transaction_id=<id>&type=
+        Receiving Anchor-->>Receiving Anchor: validates KYC values
+        Receiving Anchor-->>-Sending Anchor: id, ACCEPTED
 
     Sending Anchor->>+Receiving Anchor: GET [SEP-31]/transactions/:id
     Receiving Anchor-->>-Sending Anchor: transaction object containing amount_in, amount_in_asset, stellar_account_id, etc.
@@ -228,6 +229,12 @@ earlier than the quote's expiration.
    to check the transaction data and status.
 1. Optionally, the Sending Anchor makes a `PUT /transactions/:id/callback` request to register a URL that the Receiving
    Anchor will make requests to when the transaction's status changes.
+1. The Sending Anchor makes `GET /customer/transaction_id=<id>&type=<customer_type>` request to the Receiving Anchor for
+   each of the Sending and Receiving Client. The response includes the customer `status` and the [SEP-9](sep-0009.md)
+   KYC attributes required for registering a client of the associated `type`.
+1. If the customer `status` is not `ACCEPTED`, the Sending Anchor must collect the required KYC information from the
+   Sending Client and make a `PUT /customer` request to the Receiving Anchor. Repeat until customer's response `status`
+   becomes `ACCEPTED`
 1. The Sending Anchor makes a `GET /transactions/:id` request to ensure the status is `pending_sender`. If it is not,
    the Sending Anchor must wait until it receives a callback request or poll the `GET /transactions/:id` endpoint until
    the status becomes `pending_sender`.
@@ -317,7 +324,32 @@ The response should be a JSON object like:
       "fee_fixed": 5,
       "fee_percent": 1,
       "min_amount": 0.1,
-      "max_amount": 1000
+      "max_amount": 1000,
+      "sep12": {
+        "sender": {
+          "types": {
+            "sep31-sender": {
+              "description": "U.S. citizens limited to sending payments of less than $10,000 in value"
+            },
+            "sep31-large-sender": {
+              "description": "U.S. citizens that do not have sending limits"
+            },
+            "sep31-foreign-sender": {
+              "description": "non-U.S. citizens sending payments of less than $10,000 in value"
+            }
+          }
+        },
+        "receiver": {
+          "types": {
+            "sep31-receiver": {
+              "description": "U.S. citizens receiving USD"
+            },
+            "sep31-foreign-receiver": {
+              "description": "non-U.S. citizens receiving USD"
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -334,18 +366,36 @@ the corresponding off-chain asset, after fees have been applied.
 
 #### Asset Object Schema
 
-| Name                  | Type    | Description                                                                                                                                                                                                              |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sep12`               | object  | An object containing `sender` and `receiver` keys.                                                                                                                                                                       |
-| `min_amount`          | number  | (optional) Minimum amount. No limit if not specified.                                                                                                                                                                    |
-| `max_amount`          | number  | (optional) Maximum amount. No limit if not specified.                                                                                                                                                                    |
-| `fee_fixed`           | number  | (optional) A fixed fee in units of the Stellar asset. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                              |
-| `fee_percent`         | number  | (optional) A percentage fee in percentage points. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                  |
-| `sender_sep12_type`   | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. The value can only be `sep31-sender`, or ommited if no KYC is necessary.                |
-| `receiver_sep12_type` | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. The value can only be `sep31-receiver`, or omitted if no KYC is necessary.              |
-| `fields`              | object  | (**deprecated**, optional) An object containing the per-transaction parameters required in `POST /transactions` requests. Pass [SEP-9](sep-0009.md) fields via [SEP-12 PUT /customer](sep-0012.md#customer-put) instead. |
-| `quotes_supported`    | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                             |
-| `quotes_required`     | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                          |
+| Name                  | Type    | Description                                                                                                                                                                                                                                             |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sep12`               | object  | An object containing `sender` and `receiver` keys.                                                                                                                                                                                                      |
+| `min_amount`          | number  | (optional) Minimum amount. No limit if not specified.                                                                                                                                                                                                   |
+| `max_amount`          | number  | (optional) Maximum amount. No limit if not specified.                                                                                                                                                                                                   |
+| `fee_fixed`           | number  | (optional) A fixed fee in units of the Stellar asset. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                                             |
+| `fee_percent`         | number  | (optional) A percentage fee in percentage points. Leave blank if there is no fee or fee calculation cannot be modeled using a fixed and percentage fee.                                                                                                 |
+| `sender_sep12_type`   | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a value from `sep12.sender.types` instead if any are present.    |
+| `receiver_sep12_type` | string  | (**deprecated**, optional) The value of the `type` parameter the Sending Anchor should use for a `SEP-12 GET /customer` request. This field can be omitted if no KYC is necessary. Use a values from `sep12.receiver.types` instead if any are present. |
+| `fields`              | object  | (**deprecated**, optional) An object containing the per-transaction parameters required in `POST /transactions` requests. Pass [SEP-9](sep-0009.md) fields via [SEP-12 PUT /customer](sep-0012.md#customer-put) instead.                                |
+| `quotes_supported`    | boolean | (optional) If true, the Receiving Anchor can deliver the off-chain assets listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                                                            |
+| `quotes_required`     | boolean | (optional) If true, the Receiving Anchor can only deliver an off-chain asset listed in the [`SEP-38 GET /prices`](sep-0038.md#get-prices) response in exchange for receiving the Stellar asset.                                                         |
+
+#### `sep12` Object Schema
+
+| Name       | Type   | Description                                                                                                  |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------------------ |
+| `sender`   | object | An object containing a `types` key if KYC information is required for the Sending Client, empty otherwise.   |
+| `receiver` | object | An object containing a `types` key if KYC information is required for the Receiving Client, empty otherwise. |
+
+#### `types` Object Schema
+
+| Name    | Type   | Description                                                                                                                                                                           |
+| ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `types` | object | (optional) An object containing the accepted values for the `type` parameter in [SEP-12](sep-0012.md) requests. Each key should map to an object with a human-readable `description`. |
+
+If KYC is required for a Sending or Receiving client in some cases but not others, it is recommended to provide values
+in the respective `types` object for all cases and return an empty `fields` object from
+[SEP-12 GET /customer](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#customer-get) for
+the cases where no KYC is necessary.
 
 #### `fields` Object Schema
 
@@ -802,17 +852,15 @@ In certain cases the Receiving Anchor might need to request updated information 
 the bank tells the Receiving Anchor that the provided Receiving Client's name is incorrect or missing a middle initial.
 Since this information was sent via SEP-12, the transaction should go into the `pending_customer_info_update` state
 until the Sending Anchor makes another `SEP-12 PUT /customer` request to update. The Sending Anchor can check which
-fields need to be updated by making a `SEP-12 GET /customer` request including either the customer id `id`, or a
-combination of SEP-31 transaction id `transaction_id` and customer type `type`, which can only be `sep31-sender` or
-`sep31-receiver`. The Receiving Anchor should respond with a `NEEDS_INFO` status, a `provided_fields` including all
-provided fields, and a `fields` including all fields need to be updated .
+fields need to be updated by making a `SEP-12 GET /customer` request. The Receiving Anchor should respond with a
+`NEEDS_INFO` status, a `provided_fields` including all provided fields, and a `fields` including all fields need to be
+updated .
 
 1. `GET /transaction` and verify transaction status is `pending_customer_info_update`
-2. Get required fields via [SEP-12] `GET /customer` request. Note, that you must pass `transaction_id` and customer type
-   `type` (limited to `sep31-sender` and `sep31-receiver`) as part of the request.
-3. Collect user input for the required fields and use [SEP-12] `PUT /customer?transaction_id=&type=` endpoint to
-   transfer the data
-4. Repeat steps 2-3 until customer's response status becomes `ACCEPTED`
+2. Get required fields via [SEP-12] `GET /customer` request. It is recommended to use the combination of
+   `transaction_id` and customer type `type` as part of the request.
+3. Collect user input for the required fields and use [SEP-12] `PUT /customer` endpoint to transfer the data
+4. Repeat steps 2-3 until customer's response status becomes `ACCEPTED`.
 5. `GET /transaction` should transition into `pending_receiver` status.
 
 #### Pending Transaction Info Update (Deprecated)


### PR DESCRIPTION
### What's Changed:

**SEP-6, 8, 30** 
Nits and prettify
    
**SEP-12** 
Nits
 
 **SEP-31**
1. KYC completion is no longer required before creating a SEP-31 transaction. Sending anchor can optionally pre-register customers and use the obtained `sender_id` or `receiver_id` to create transaction, or leave these fields empty. 

2. After the transaction is created, the Sending anchor will call `GET /customer?transaction_id=<sep31-txn-id>&type=` to determine the required fields for each type of client, and then make a `PUT` call to the same endpoint to update the information
    