### PR TITLE
Add CAP-58 - support for contract constructors.

### DIFF
--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -1,0 +1,226 @@
+## Preamble
+
+```
+CAP: 0058
+Title: Constructors for Soroban contracts
+Working Group:
+    Owner: Dmytro Kozhevin <@dmkozh>
+    Authors: Dmytro Kozhevin <@dmkozh>
+    Consulted:
+Status: Draft
+Created: 2024-07-17
+Discussion: https://github.com/stellar/stellar-protocol/discussions/1501
+Protocol version: 22
+```
+
+## Simple Summary
+
+Introduce 'constructor' feature for Soroban smart contracts: a mechanism that
+ensures that the contract will run custom initialization logic whenever atomically
+during instantiation.
+
+## Working Group
+
+As specified in the Preamble.
+
+## Motivation
+
+Constructor support improves usability of Soroban for the contract and SDK developers:
+
+- A contract with a constructor is guaranteed to always be initialized, so there is never a need to ensure that initialization at run time, thus reducing the contract size, CPU usage, and potentially the contract storage needs
+- Using constructors makes it harder for developers to accidentally make their contracts prone to front-running the initialization (in case if factory is not being used), thus improving  security
+- Constructors are supported in other smart contract frameworks/languages (such as Solidity), which both makes Soroban more compatible with the new SDKs (see [discussion](https://github.com/stellar/stellar-protocol/discussions/1501)), and also is more intuitive for developer on-boarding
+- Constructors make contract instantiation cheaper and faster, as only a single transaction is necessary vs multiple transactions or a factory (that requires an additional contract invocation)
+
+### Goals Alignment
+
+This CAP is aligned with the following Stellar Network Goals:
+
+  - The Stellar Network should make it easy for developers of Stellar projects to create highly usable products.
+
+## Abstract
+
+This CAP introduces the set of the necessary changes to support defining the constructors and executing them, specifically:
+
+- Reserve a new special contract function `__init` that may only be called by the Soroban host environment. The environment will call `__init` function if and only if the 
+- Introduce a new host function `create_contract_with_constructor` in Soroban environment that allows constracts to instantiate other contracts with constructors
+- Introduce a new `HostFunction` XDR variant `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` that acts in the same way as `HOST_FUNCTION_TYPE_CREATE_CONTRACT`, but also allows users to specify the constructor arguments
+- Introduce a new `SorobanAuthorizedFunction` XDR variant `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` that allows users to sign the authorization payload corresponding to `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` host function calls
+
+## Specification
+
+### XDR Changes
+
+```
+diff --git a/Stellar-transaction.x b/Stellar-transaction.x
+index 87dd32d..346e384 100644
+--- a/Stellar-transaction.x
++++ b/Stellar-transaction.x
+@@ -476,7 +476,8 @@ enum HostFunctionType
+ {
+     HOST_FUNCTION_TYPE_INVOKE_CONTRACT = 0,
+     HOST_FUNCTION_TYPE_CREATE_CONTRACT = 1,
+-    HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM = 2
++    HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM = 2,
++    HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2 = 3
+ };
+ 
+ enum ContractIDPreimageType
+@@ -503,6 +504,16 @@ struct CreateContractArgs
+     ContractExecutable executable;
+ };
+ 
++struct CreateContractArgsV2
++{
++    ContractIDPreimage contractIDPreimage;
++    ContractExecutable executable;
++    // Arguments of the contract's constructor.
++    // Must be not set for contracts that don't have a constructor
++    // (empty vector represents a constructor with no arguments).
++    SCVal* constructorArgs<>;
++};
++
+ struct InvokeContractArgs {
+     SCAddress contractAddress;
+     SCSymbol functionName;
+@@ -517,12 +528,15 @@ case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
+     CreateContractArgs createContract;
+ case HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM:
+     opaque wasm<>;
++case HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2:
++    CreateContractArgsV2 createContractV2;
+ };
+ 
+ enum SorobanAuthorizedFunctionType
+ {
+     SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN = 0,
+-    SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN = 1
++    SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN = 1,
++    SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN = 2
+ };
+ 
+ union SorobanAuthorizedFunction switch (SorobanAuthorizedFunctionType type)
+@@ -531,6 +545,8 @@ case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN:
+     InvokeContractArgs contractFn;
+ case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN:
+     CreateContractArgs createContractHostFn;
++case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN:
++    CreateContractArgsV2 createContractV2HostFn;
+ };
+ 
+ struct SorobanAuthorizedInvocation
+```
+
+### Semantics
+
+#### Constructor function
+
+Every Wasm that exports `__init` function is considered to have a constructor. `__init` function may take an arbitrary number of arbitrary `SCVal`(XDR)/`Val`(Soroban host) arguments (0 arguments are supported as well). The constructor has the following semantics from the Soroban host standpoint:
+
+- For any Wasm with Soroban environment version less than 22, `__init` function is treated as any other Soroban 'reserved' function (any contract function that has name starting with double `_`), i.e. it can be exported, but can not be invoked.
+    - Keep in mind, that it is not possible to upload Wasm with v22 environment prior to v22 protocol upgrade, thus it is guaranteed that for any given Wasm uploaded on-chain either all of, or none of the instances have constructor support (depending on the env version)
+- For any Wasm with Soroban environment version 22 or greater `__init` is treated as constructor function:
+    - When a new contract is created from that Wasm, the enviornment calls `__init` with user-provided arguments immediately after create a contract instance entry in the storage (without returning control to the caller)
+        -  If `__init` hasn't finished successfully (i.e. if VM traps, or a function returns an error), the instantiation fails
+    - If a contract with constructor is instantiated by a function that doesn't allow specifying the constructor arguments (i.e. the initial contract creation host functions),
+    the instantiation fails
+    - If a contract without constructor has any constructor arguments passed to it (even a 0-size vector), the instantiation fails
+
+Other than the semantics described above, `__init` behaves as a normal contract function that can manipulate contract storage, do cross-contract calls etc.
+
+#### `create_contract_with_constructor` host function
+
+A new function, `create_contract_with_constructor`, with export name `e` in module `l` ('ledger' module) is added to the Soroban environment's exported interface.
+
+The `env.json` in `rs-soroban-env` will be modified as so:
+
+```json
+{
+    "export": "e",
+    "name": "create_contract_with_constructor",
+    "args": [
+        {
+            "name": "deployer",
+            "type": "AddressObject"
+        },
+        {
+            "name": "wasm_hash",
+            "type": "BytesObject"
+        },
+        {
+            "name": "salt",
+            "type": "BytesObject"
+        },
+        {
+            "name": "constructor_args",
+            "type": "VecObject"
+        }
+    ],
+    "return": "AddressObject",
+    "docs": "Creates the contract instance on behalf of `deployer`. Created contract must be created from a Wasm that has a constructor. `deployer` must authorize this call via Soroban auth framework, i.e. this calls `deployer.require_auth` with respective arguments. `wasm_hash` must be a hash of the contract code that has already been uploaded on this network. `salt` is used to create a unique contract id. `constructor_args` are forwarded into created contract's constructor (`__init`) fucntion. Returns the address of the created contract.",
+    "min_supported_protocol": 22
+}
+```
+
+The `deployer` (`AddressObject`), `wasm_hash` (`BytesObject`), and `salt` (`BytesObject`) semantics have exactly the same semantics as for the existing `create_contract` host function. `constructor_args` is a host vector of `Val`s containing the arguments to use in constructor.
+
+The function creates a contract from Wasm that has a constructor defined and will panic if called for a Wasm without a constructor, as per constructor semantics.
+
+#### `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` host function
+
+The new variant of the XDR `HostFunction` for the `InvokeHostFunctionOp` (`HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` defined in XDR changes section) allows users to create contracts both with and without constructors via a single transaction. The function is only supported from protocol 22 onwards.
+
+Contracts can be created from any valid Wasm on-chain with this function, i.e. pre-22 Wasms are supported as well and are always treated as contracts without a constructor (even if they happened to have `__init` function defined).
+
+`constructorArgs` argument of `CreateContractArgsV2` is an optional vector of arguments that has to be unset for contracts without constructors, and has to be set for any contract that has a constructor (as per semantics described above).
+The host function implementation is routed to either `create_contract`, or `create_contract_with_constructor` host function, depending on the presense of `constructorArgs`.
+
+The 'legacy' `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function will be preserved in protocol 22 for the sake of backwards compatibility. It will only work with the contracts that don't have constructors defined.
+
+#### Authorization support
+
+`SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` allows users to authorize both `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` (when called directly from `InvokeHostFunctionOp`), and `create_contract`/`create_contract_with_constructor` host functions starting from protocol 22.
+
+For `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` exactly the same `CreateContractArgsV2` structure as in the `HostFunction` definition has to be authorized.
+
+For `create_contract` calls respective XDR with unset `constructorArgs` has to be authorized, and for `create_contract_with_constructor` `constructorArgs` has to be set to a respective (maybe empty) vector of arguments.
+
+Starting from protocol 22 `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` will only be supported to authorize `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function. It will no longer be considered valid for authorizing the `create_contract` calls as to prevent signature malleability.
+
+## Design Rationale
+
+### Constructor vs Factory
+
+Factory contracts can be used as an alternative to constructors and they are already supported by the protocol. However, factory contracts don't provide a guarantee that every contract instance has been initialized via a factory.
+
+In theory, we could standardize certain generic factory contract, build it into the protocol and provide initialization guarantees. While that approach would allow us to avoid adding new interfaces, it is much less straightforward to use - some (constructor-less) contracts would still be created via `create_contract`/`HOST_FUNCTION_TYPE_CREATE_CONTRACT`, while other(constructor-enabled) contracts would be created via `call`/`HOST_FUNCTION_TYPE_INVOKE_CONTRACT`.
+
+### Only a single constructor function is allowed
+
+Allowing to overload constructors would be pretty tricky as Wasm doesn't support overloading fucntions.
+
+If 'overload' behavior is necessary, it can be implemented in custom fashion via e.g. using a single `enum` argument with different variants containing different sets of arguments.
+
+### `create_contract` host function is not deprecated
+
+We could deprecate `create_contract` host function and allow providing an optional argument in `create_contract_with_constructor`, however optional arguments are awkward in host functions due to lack of `Option` host type. The optional argument can be implemented at the higher level in the SDK.
+
+There is also not much benefit to deprecating the host functions as they have to be maintained for the sake of supporting the contracts that have been built for the old host environment versions.
+
+### `HOST_FUNCTION_TYPE_CREATE_CONTRACT` is deprecated
+
+Unlike the `create_contract` host function, the optional argument is much more natural in XDR and it's also harder to support two very similar XDR variants in the client SDKs. Thus we deprecate the old function version.
+
+## Security Concerns
+
+Constructors ensure atomic contract initialization that has to be authorized by the deployer of the contract (via `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` authorization payload). Thus, deployed contract can't have their initialization to be frontrun.
+
+Executing `__init` function from within host allows contracts to execute arbitrary logic while being called from a host function. However, the risk surface is not really increased compared to regular contract calls, as the caller acknowledges that constructor will be called, similarly to how the caller acknowledges that a different contract's method is going to be called.
+
+## Test Cases
+
+To be implemented. The tests should cover the newly introduced host function and the invariants described in the 'Semantics' section.
+
+## Implementation
+
+To be implemented.

--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -16,7 +16,7 @@ Protocol version: 22
 ## Simple Summary
 
 Introduce 'constructor' feature for Soroban smart contracts: a mechanism that
-ensures that the contract will run custom initialization logic whenever atomically
+ensures that the contract will run custom initialization logic atomically
 during instantiation.
 
 ## Working Group
@@ -42,7 +42,7 @@ This CAP is aligned with the following Stellar Network Goals:
 
 This CAP introduces the set of the necessary changes to support defining the constructors and executing them, specifically:
 
-- Reserve a new special contract function `__init` that may only be called by the Soroban host environment. The environment will call `__init` function if and only if the 
+- Reserve a new special contract function `__init` that may only be called by the Soroban host environment. The environment will call `__init` function if and only if the contract is being created from a Wasm exporting that function
 - Introduce a new host function `create_contract_with_constructor` in Soroban environment that allows constracts to instantiate other contracts with constructors
 - Introduce a new `HostFunction` XDR variant `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` that acts in the same way as `HOST_FUNCTION_TYPE_CREATE_CONTRACT`, but also allows users to specify the constructor arguments
 - Introduce a new `SorobanAuthorizedFunction` XDR variant `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` that allows users to sign the authorization payload corresponding to `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` host function calls
@@ -120,7 +120,7 @@ Every Wasm that exports `__init` function is considered to have a constructor. `
 - For any Wasm with Soroban environment version less than 22, `__init` function is treated as any other Soroban 'reserved' function (any contract function that has name starting with double `_`), i.e. it can be exported, but can not be invoked.
     - Keep in mind, that it is not possible to upload Wasm with v22 environment prior to v22 protocol upgrade, thus it is guaranteed that for any given Wasm uploaded on-chain either all of, or none of the instances have constructor support (depending on the env version)
 - For any Wasm with Soroban environment version 22 or greater `__init` is treated as constructor function:
-    - When a new contract is created from that Wasm, the enviornment calls `__init` with user-provided arguments immediately after create a contract instance entry in the storage (without returning control to the caller)
+    - When a new contract is created from that Wasm, the environment calls `__init` with user-provided arguments immediately after create a contract instance entry in the storage (without returning control to the caller)
         -  If `__init` hasn't finished successfully (i.e. if VM traps, or a function returns an error), the instantiation fails
     - If a contract with constructor is instantiated by a function that doesn't allow specifying the constructor arguments (i.e. the initial contract creation host functions),
     the instantiation fails
@@ -197,7 +197,7 @@ In theory, we could standardize certain generic factory contract, build it into 
 
 ### Only a single constructor function is allowed
 
-Allowing to overload constructors would be pretty tricky as Wasm doesn't support overloading fucntions.
+Allowing to overload constructors would be pretty tricky as Wasm doesn't support overloading functions.
 
 If 'overload' behavior is necessary, it can be implemented in custom fashion via e.g. using a single `enum` argument with different variants containing different sets of arguments.
 


### PR DESCRIPTION
The CAP specifies the necessary protocol changes for supporting contract constructors in Soroban. The CAP is motivated by the following discussion: https://github.com/stellar/stellar-protocol/discussions/1501