### PR TITLE
Updates to CAP-58 based on protocol discussion:

### DIFF
--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -42,7 +42,7 @@ This CAP is aligned with the following Stellar Network Goals:
 
 This CAP introduces the set of the necessary changes to support defining the constructors and executing them, specifically:
 
-- Reserve a new special contract function `__init` that may only be called by the Soroban host environment. The environment will call `__init` function if and only if the contract is being created from a Wasm exporting that function
+- Reserve a new special contract function `__constructor` that may only be called by the Soroban host environment. The environment will call `__constructor` function if and only if the contract is being created from a Wasm exporting that function
 - Introduce a new host function `create_contract_with_constructor` in Soroban environment that allows constracts to instantiate other contracts with constructors
 - Introduce a new `HostFunction` XDR variant `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` that acts in the same way as `HOST_FUNCTION_TYPE_CREATE_CONTRACT`, but also allows users to specify the constructor arguments
 - Introduce a new `SorobanAuthorizedFunction` XDR variant `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` that allows users to sign the authorization payload corresponding to `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` host function calls
@@ -52,8 +52,12 @@ This CAP introduces the set of the necessary changes to support defining the con
 ### XDR Changes
 
 ```
+---
+ Stellar-transaction.x | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
 diff --git a/Stellar-transaction.x b/Stellar-transaction.x
-index 87dd32d..346e384 100644
+index 87dd32d..7da2f1d 100644
 --- a/Stellar-transaction.x
 +++ b/Stellar-transaction.x
 @@ -476,7 +476,8 @@ enum HostFunctionType
@@ -66,7 +70,7 @@ index 87dd32d..346e384 100644
  };
  
  enum ContractIDPreimageType
-@@ -503,6 +504,16 @@ struct CreateContractArgs
+@@ -503,6 +504,14 @@ struct CreateContractArgs
      ContractExecutable executable;
  };
  
@@ -75,15 +79,13 @@ index 87dd32d..346e384 100644
 +    ContractIDPreimage contractIDPreimage;
 +    ContractExecutable executable;
 +    // Arguments of the contract's constructor.
-+    // Must be not set for contracts that don't have a constructor
-+    // (empty vector represents a constructor with no arguments).
-+    SCVal* constructorArgs<>;
++    SCVal constructorArgs<>;
 +};
 +
  struct InvokeContractArgs {
      SCAddress contractAddress;
      SCSymbol functionName;
-@@ -517,12 +528,15 @@ case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
+@@ -517,12 +526,15 @@ case HOST_FUNCTION_TYPE_CREATE_CONTRACT:
      CreateContractArgs createContract;
  case HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM:
      opaque wasm<>;
@@ -100,7 +102,7 @@ index 87dd32d..346e384 100644
  };
  
  union SorobanAuthorizedFunction switch (SorobanAuthorizedFunctionType type)
-@@ -531,6 +545,8 @@ case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN:
+@@ -531,6 +543,8 @@ case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN:
      InvokeContractArgs contractFn;
  case SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN:
      CreateContractArgs createContractHostFn;
@@ -109,24 +111,28 @@ index 87dd32d..346e384 100644
  };
  
  struct SorobanAuthorizedInvocation
+-- 
 ```
 
 ### Semantics
 
 #### Constructor function
 
-Every Wasm that exports `__init` function is considered to have a constructor. `__init` function may take an arbitrary number of arbitrary `SCVal`(XDR)/`Val`(Soroban host) arguments (0 arguments are supported as well). The constructor has the following semantics from the Soroban host standpoint:
+Every Wasm that exports `__constructor` function is considered to have a constructor. `__constructor` function may take an arbitrary number of arbitrary `SCVal`(XDR)/`Val`(Soroban host) arguments (0 arguments are supported as well). The constructor has the following semantics from the Soroban host standpoint:
 
-- For any Wasm with Soroban environment version less than 22, `__init` function is treated as any other Soroban 'reserved' function (any contract function that has name starting with double `_`), i.e. it can be exported, but can not be invoked.
+- For any Wasm with Soroban environment version less than 22, `__constructor` function is treated as any other unused Soroban 'reserved' function (any contract function that has name starting with double `_`), i.e. it can be exported, but can not be invoked. These contracts are considered to not have any constructor, even past protocol 22.
     - Keep in mind, that it is not possible to upload Wasm with v22 environment prior to v22 protocol upgrade, thus it is guaranteed that for any given Wasm uploaded on-chain either all of, or none of the instances have constructor support (depending on the env version)
-- For any Wasm with Soroban environment version 22 or greater `__init` is treated as constructor function:
-    - When a new contract is created from that Wasm, the environment calls `__init` with user-provided arguments immediately after create a contract instance entry in the storage (without returning control to the caller)
-        -  If `__init` hasn't finished successfully (i.e. if VM traps, or a function returns an error), the instantiation fails
-    - If a contract with constructor is instantiated by a function that doesn't allow specifying the constructor arguments (i.e. the initial contract creation host functions),
-    the instantiation fails
-    - If a contract without constructor has any constructor arguments passed to it (even a 0-size vector), the instantiation fails
+- For any Wasm with Soroban environment version 22 or greater `__constructor` is treated as constructor function:
+    - When a new contract is created from that Wasm, the environment calls `__constructor` with user-provided arguments immediately after create a contract instance entry in the storage (without returning control to the caller)
+        -  If `__constructor` hasn't finished successfully (i.e. if VM traps, or a function returns an error), the instantiation fails
+    - If a contract with constructor is instantiated by a function that doesn't allow specifying the constructor arguments, then constuctor is called with 0 arguments.
+    - If a contract without constructor has any constructor arguments passed to it (i.e. >=1 arguments), the instantiation fails
 
-Other than the semantics described above, `__init` behaves as a normal contract function that can manipulate contract storage, do cross-contract calls etc.
+Other than the semantics described above, `__constructor` behaves as a normal contract function that can manipulate contract storage, do cross-contract calls etc.
+
+##### 'Default' constructor
+
+The semantics of contracts that don't have a constructor (i.e. those created before protocol 22 and those that simply don't have `__constructor` defined) can be significantly simplified by treating them as having a 'default' constructor that accepts no arguments and performs no operations. This streamlines the user experience as it makes calling the contracts without constructor to behave exactly the same as contracts with a 0-argument constructor. That's why, for example, it is possible to instantiate a constructor-less contract with a function that expects constructor arguments, but only as long as 0 arguments are passed (passing >0 arguments to the 'default' constructor would cause it to fail).
 
 ##### Interaction with contract updates
 
@@ -163,23 +169,24 @@ The `env.json` in `rs-soroban-env` will be modified as so:
         }
     ],
     "return": "AddressObject",
-    "docs": "Creates the contract instance on behalf of `deployer`. Created contract must be created from a Wasm that has a constructor. `deployer` must authorize this call via Soroban auth framework, i.e. this calls `deployer.require_auth` with respective arguments. `wasm_hash` must be a hash of the contract code that has already been uploaded on this network. `salt` is used to create a unique contract id. `constructor_args` are forwarded into created contract's constructor (`__init`) fucntion. Returns the address of the created contract.",
+    "docs": "Creates the contract instance on behalf of `deployer`. Created contract must be created from a Wasm that has a constructor. `deployer` must authorize this call via Soroban auth framework, i.e. this calls `deployer.require_auth` with respective arguments. `wasm_hash` must be a hash of the contract code that has already been uploaded on this network. `salt` is used to create a unique contract id. `constructor_args` are forwarded into created contract's constructor (`__constructor`) function. Returns the address of the created contract.",
     "min_supported_protocol": 22
 }
 ```
 
 The `deployer` (`AddressObject`), `wasm_hash` (`BytesObject`), and `salt` (`BytesObject`) semantics have exactly the same semantics as for the existing `create_contract` host function. `constructor_args` is a host vector of `Val`s containing the arguments to use in constructor.
 
-The function creates a contract from Wasm that has a constructor defined and will panic if called for a Wasm without a constructor, as per constructor semantics.
+The function creates a contract from Wasm and calls its constructor with the provided `constructor_args`. Contracts with no constructor may be created by this function as well, but no arguments have to be provided.
 
 #### `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` host function
 
 The new variant of the XDR `HostFunction` for the `InvokeHostFunctionOp` (`HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` defined in XDR changes section) allows users to create contracts both with and without constructors via a single transaction. The function is only supported from protocol 22 onwards.
 
-Contracts can be created from any valid Wasm on-chain with this function, i.e. pre-22 Wasms are supported as well and are always treated as contracts without a constructor (even if they happened to have `__init` function defined).
+Contracts can be created from any valid Wasm on-chain with this function, i.e. pre-22 Wasms are supported as well and are always treated as contracts with a default constructor (even if they happened to have `__constructor` function defined before).
 
-`constructorArgs` argument of `CreateContractArgsV2` is an optional vector of arguments that has to be unset for contracts without constructors, and has to be set for any contract that has a constructor (as per semantics described above).
-The host function implementation is routed to either `create_contract`, or `create_contract_with_constructor` host function, depending on the presense of `constructorArgs`.
+`constructorArgs` argument of `CreateContractArgsV2` is a vector of arguments to pass to the constructor function.
+
+The host function implementation is routed to `create_contract_with_constructor` host function.
 
 The 'legacy' `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function will be preserved in protocol 22 for the sake of backwards compatibility. It will only work with the contracts that don't have constructors defined.
 
@@ -189,9 +196,9 @@ The 'legacy' `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function will be pres
 
 For `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` exactly the same `CreateContractArgsV2` structure as in the `HostFunction` definition has to be authorized.
 
-For `create_contract` calls respective XDR with unset `constructorArgs` has to be authorized, and for `create_contract_with_constructor` `constructorArgs` has to be set to a respective (maybe empty) vector of arguments.
+For `create_contract` calls the respective XDR with 0 `constructorArgs` has to be authorized, and for `create_contract_with_constructor` `constructorArgs` has to be set to respective respective vector of arguments.
 
-Starting from protocol 22 `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` will only be supported to authorize `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function. It will no longer be considered valid for authorizing the `create_contract` calls as to prevent signature malleability.
+Starting from protocol 22 `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` will be deprecated and no longer accepted for authorizing any contract creation calls (including `HOST_FUNCTION_TYPE_CREATE_CONTRACT`).
 
 ## Design Rationale
 
@@ -207,27 +214,25 @@ Allowing to overload constructors would be pretty tricky as Wasm doesn't support
 
 If 'overload' behavior is necessary, it can be implemented in custom fashion via e.g. using a single `enum` argument with different variants containing different sets of arguments.
 
-### `create_contract` host function is not deprecated
-
-We could deprecate `create_contract` host function and allow providing an optional argument in `create_contract_with_constructor`, however optional arguments are awkward in host functions due to lack of `Option` host type. The optional argument can be implemented at the higher level in the SDK.
-
-There is also not much benefit to deprecating the host functions as they have to be maintained for the sake of supporting the contracts that have been built for the old host environment versions.
-
-### `HOST_FUNCTION_TYPE_CREATE_CONTRACT` is deprecated
-
-Unlike the `create_contract` host function, the optional argument is much more natural in XDR and it's also harder to support two very similar XDR variants in the client SDKs. Thus we deprecate the old function version.
-
 ### Constructor is not called when Wasm is updated
 
 Contract re-initialization is risky for a lot of cases, e.g. for contracts with complex ownership model (DAO), multisig smart wallets, or contracts that have a part of state assumed to be constant. For all such scenarios a malicious or non-malicious buggy interaction may break the important invariants, used to revert contract to no longer state or even simply break it for everyone.
 
 While in some cases additional initialization may be required after Wasm has been updated, we deem the risks of allowing it to be higher than the benefits for such cases. Unlike initialization, atomicity is not as important, because the authorization priviliges don't change between the call to update the contract and the call to re-initialize it. Thus a programmatic, contract-specific solution should be feasible.
 
+### `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` deprecation
+
+In order to prevent signature malleability, an auth payload has to match to a specific action (e.g. we can't just accept both v1 and v2 payloads to authorize `CREATE_CONTRACT_HOST_FN`). So `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` has to be used in some very specific contexts and it's not immediately obvious for the user why in certain context v1 has to be used vs why v2 should be used. That's why for the sake of clarity we deprecate `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` in protocol 22.
+
+Since most of the Soroban interactions happen via RPC simulation, we don't expect significant client discruption. However, the RPC clients will have to update their XDR definitions in order to be able to handle the new varint of the auth payload.
+
+There is also a small chance that a transaction gets rejected when being applied right after the upgrade, but that's an improbable and one-time event (contract instantiations are much more rare than regular contract interactions).
+
 ## Security Concerns
 
 Constructors ensure atomic contract initialization that has to be authorized by the deployer of the contract (via `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_V2_HOST_FN` authorization payload). Thus, deployed contract can't have their initialization to be frontrun.
 
-Executing `__init` function from within host allows contracts to execute arbitrary logic while being called from a host function. However, the risk surface is not really increased compared to regular contract calls, as the caller acknowledges that constructor will be called, similarly to how the caller acknowledges that a different contract's method is going to be called.
+Executing `__constructor` function from within host allows contracts to execute arbitrary logic while being called from a host function. However, the risk surface is not really increased compared to regular contract calls, as the caller acknowledges that constructor will be called, similarly to how the caller acknowledges that a different contract's method is going to be called.
 
 ## Test Cases
 


### PR DESCRIPTION
- `__init`->`__constructor` rename, based on community vote: https://github.com/stellar/stellar-protocol/discussions/1507
- Made behavior more forgiving for contracts that don't have a constructor defined (add a 'default constructor' to these)
- Un-deprecated the old `CREATE_CONTRACT` host fn variant, but still deprecate the corresponding auth payload