### PR TITLE
📌 Specify exact ClaimableBalanceID.v0 arithmetic

### DIFF
--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -342,15 +342,18 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
     - `amount` as specified in the operation
     - `reserve` equal to `claimants.size() * baseReserve`
 
-[^id-arithmatic]: ```
-    OperationID = (
-      sourceAccount ||
-      seqNum ||
-      opNum
+[^id-arithmatic]: ```javascript
+    HashIDPreimage = (
+      sourceAccount;
+      seqNum;
+      opNum;
     )
-    balanceID.v0() = hex(sha256(OperationID))
+    OperationID = sha256(HashIDPreimage)
+    balanceID.v0() = OperationID // Hash
+    clientDisplayID = hex(HashIDPreimage)
     ```
-    - `OperationID`: a union within the new `type` `ENVELOPE_TYPE_OP_ID`
+    - `HashIDPreimage`: a switch within the new `type` `ENVELOPE_TYPE_OP_ID`
+    - `OperationID`: hash of `ENVELOPE_TYPE_OP_ID` precomputation data
     - `sourceAccount`: unmuxed public key of the transaction's source
     - `seqNum`: the transaction source account's sequence number
     - `opNum`: position index of this operation in the transaction

--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -351,7 +351,7 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
     balanceID.v0() = hex(sha256(OperationID))
     ```
     - `OperationID`: a union within the new `type` `ENVELOPE_TYPE_OP_ID`
-    - `sourceAccount`: public key of the transaction's source account
+    - `sourceAccount`: unmuxed public key of the transaction's source
     - `seqNum`: the transaction source account's sequence number
     - `opNum`: position index of this operation in the transaction
 

--- a/core/cap-0023.md
+++ b/core/cap-0023.md
@@ -331,11 +331,8 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
    not have at least `amount` available balance of `asset`
 6. Deduct `amount` of `asset` from `sourceAccount`
 7. Create a claimable balance entry with the following properties:
-    - `balanceID` of type `CLAIMABLE_BALANCE_ID_TYPE_V0`. `balanceID.v0()` equal to the SHA256 hash
-       of the `OperationID`, which is created with the `type` `ENVELOPE_TYPE_OP_ID`, `sourceAccount` 
-       of the transaction (not the operation), the `seqNum` of the transaction, and the index of this operation
-       in the transaction as `opNum`.
-    - `createdBy = sourceAccount`
+    - `balanceID` of type `CLAIMABLE_BALANCE_ID_TYPE_V0`.[^id-arithmatic]
+    - `createdBy = sourceAccount` (of the transaction, not the operation)
     - `claimants` as specified, with the exception that
         - `CLAIM_PREDICATE_BEFORE_RELATIVE_TIME` will be converted to
           `CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME` by adding `relBefore` to
@@ -344,6 +341,20 @@ The behavior of `CreateClaimableBalanceOp` is as follows:
     - `asset` as specified in the operation
     - `amount` as specified in the operation
     - `reserve` equal to `claimants.size() * baseReserve`
+
+[^id-arithmatic]: ```
+    OperationID = (
+      sourceAccount ||
+      seqNum ||
+      opNum
+    )
+    balanceID.v0() = hex(sha256(OperationID))
+    ```
+    - `OperationID`: a union within the new `type` `ENVELOPE_TYPE_OP_ID`
+    - `sourceAccount`: public key of the transaction's source account
+    - `seqNum`: the transaction source account's sequence number
+    - `opNum`: position index of this operation in the transaction
+
 8. Succeed with `CREATE_CLAIMABLE_BALANCE_SUCCESS` and the `balanceID` from the previous step.
 
 `CreateClaimableBalanceOp` requires medium threshold because it can be used to


### PR DESCRIPTION
The existing lines 227–230 do not clearly define the logic for claimable balance IDs, per #1512. However, thanks to [clarification](https://github.com/stellar/stellar-docs/issues/836#issuecomment-2264080490) from @Shaptic, this update clarifies the innovative calculations deployed. Lastly, the revisions polish what was otherwise an excessive run-on dependent clause of mathematical relations from lines 334–337.