### PR TITLE
Update prettier job

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,3 @@
-# https://github.com/marketplace/actions/prettier-action
 name: 'Prettier for SEP files'
 
 on:
@@ -7,12 +6,10 @@ on:
 jobs:
   prettier:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Check code
-        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1
+      - uses: actions/checkout@v3
+      - name: sep-check
+        uses: DerYeger/yarn-setup-action@18fb87f9a712d8cc8ad1e7407a06470b397b4a7d
         with:
-          prettier_options: --check ecosystem/*.md
+          node-version: 20
+      - run: yarn sep-check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "sep-prettify": "prettier ecosystem/*.md --write"
+    "sep-prettify": "prettier ecosystem/*.md --write",
+    "sep-check": "prettier ecosystem/*.md --check"
   },
   "devDependencies": {
     "prettier": "2.8.8"


### PR DESCRIPTION
We saw some failures with original job in https://github.com/stellar/stellar-protocol/pull/1515#event-13782930566
Which shouldn't fail (and doesn't fail locally), I think it's something with `prettier-action` so replaced it with more straightforward approach of just calling yarn script