### PR TITLE
Add asset name to SAC events

### DIFF
--- a/core/cap-0046-06.md
+++ b/core/cap-0046-06.md
@@ -179,7 +179,7 @@ fn allowance(e: &Host, from: Address, spender: Address) -> Result<i128, HostErro
 /// # Events
 ///
 /// Emits an event with topics `["approve", from: Address,
-/// spender: Address], data = [amount: i128, expiration_ledger: u32]`
+/// spender: Address, sep0011_asset: String], data = [amount: i128, expiration_ledger: u32]`
 fn approve(
         e: &Host,
         from: Address,
@@ -214,7 +214,7 @@ fn authorized(env: Env, id: Address) -> bool;
 ///
 /// # Events
 ///
-/// Emits an event with topics `["transfer", from: Address, to: Address],
+/// Emits an event with topics `["transfer", from: Address, to: Address, sep0011_asset: String],
 /// data = [amount: i128]`
 fn transfer(env: Env, from: Address, to: Address, amount: i128);
 
@@ -232,7 +232,7 @@ fn transfer(env: Env, from: Address, to: Address, amount: i128);
 ///
 /// # Events
 ///
-/// Emits an event with topics `["transfer", from: Address, to: Address],
+/// Emits an event with topics `["transfer", from: Address, to: Address, sep0011_asset: String],
 /// data = [amount: i128]`
 fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128);
 
@@ -246,7 +246,7 @@ fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount:
 ///
 /// # Events
 ///
-/// Emits an event with topics `["burn", from: Address], data = [amount:
+/// Emits an event with topics `["burn", from: Address, sep0011_asset: String], data = [amount:
 /// i128]`
 fn burn(env: Env, from: Address, amount: i128);
 
@@ -262,7 +262,7 @@ fn burn(env: Env, from: Address, amount: i128);
 ///
 /// # Events
 ///
-/// Emits an event with topics `["burn", from: Address], data = [amount:
+/// Emits an event with topics `["burn", from: Address, sep0011_asset: String], data = [amount:
 /// i128]`
 fn burn_from(env: Env, spender: Address, from: Address, amount: i128);
 ```
@@ -287,7 +287,7 @@ compliance functionality.
 ///
 /// # Events
 ///
-/// Emits an event with topics `["set_admin", admin: Address], data =
+/// Emits an event with topics `["set_admin", admin: Address, sep0011_asset: String], data =
 /// [new_admin: Address]`
 fn set_admin(env: Env, new_admin: Address);
 
@@ -308,7 +308,7 @@ fn admin(env: Env) -> Address;
 ///
 /// # Events
 ///
-/// Emits an event with topics `["set_authorized", id: Address], data =
+/// Emits an event with topics `["set_authorized", id: Address, sep0011_asset: String], data =
 /// [authorize: bool]`
 fn set_authorized(env: Env, id: Address, authorize: bool);
 
@@ -321,7 +321,7 @@ fn set_authorized(env: Env, id: Address, authorize: bool);
 ///
 /// # Events
 ///
-/// Emits an event with topics `["mint", admin: Address, to: Address], data
+/// Emits an event with topics `["mint", admin: Address, to: Address, sep0011_asset: String], data
 /// = [amount: i128]`
 fn mint(env: Env, to: Address, amount: i128);
 
@@ -336,7 +336,7 @@ fn mint(env: Env, to: Address, amount: i128);
 ///
 /// # Events
 ///
-/// Emits an event with topics `["clawback", admin: Address, to: Address],
+/// Emits an event with topics `["clawback", admin: Address, to: Address, sep0011_asset: String],
 /// data = [amount: i128]`
 fn clawback(env: Env, from: Address, amount: i128);
 ```


### PR DESCRIPTION
The implementation emits this event. This PR just brings the CAP up to date.