### PR TITLE
Small updates of CAP-58

### DIFF
--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -203,7 +203,7 @@ For `HOST_FUNCTION_TYPE_CREATE_CONTRACT_V2` exactly the same `CreateContractArgs
 
 For `create_contract` calls the respective XDR with 0 `constructorArgs` has to be authorized, and for `create_contract_with_constructor` `constructorArgs` has to be set to respective respective vector of arguments.
 
-Starting from protocol 22 `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` will be deprecated and no longer accepted for authorizing any contract creation calls (including `HOST_FUNCTION_TYPE_CREATE_CONTRACT`).
+`SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` payload may still be used to authorize creation of contracts that with 0 constructor arguments (i.e. contracts with 'default' constructor and contracts with explicity 0-argument constructor).
 
 ##### Authorization context for custom accounts
 
@@ -276,14 +276,6 @@ Note, that returning an error-type value (`Val::Error`) has the same consequence
 Contract re-initialization is risky for a lot of cases, e.g. for contracts with complex ownership model (DAO), multisig smart wallets, or contracts that have a part of state assumed to be constant. For all such scenarios a malicious or non-malicious buggy interaction may break the important invariants, used to revert contract to no longer state or even simply break it for everyone.
 
 While in some cases additional initialization may be required after Wasm has been updated, we deem the risks of allowing it to be higher than the benefits for such cases. Unlike initialization, atomicity is not as important, because the authorization priviliges don't change between the call to update the contract and the call to re-initialize it. Thus a programmatic, contract-specific solution should be feasible.
-
-### `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` deprecation
-
-In order to prevent signature malleability, an auth payload has to match to a specific action (e.g. we can't just accept both v1 and v2 payloads to authorize `CREATE_CONTRACT_HOST_FN`). So `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` has to be used in some very specific contexts and it's not immediately obvious for the user why in certain context v1 has to be used vs why v2 should be used. That's why for the sake of clarity we deprecate `SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN` in protocol 22.
-
-Since most of the Soroban interactions happen via RPC simulation, we don't expect significant client discruption. However, the RPC clients will have to update their XDR definitions in order to be able to handle the new varint of the auth payload.
-
-There is also a small chance that a transaction gets rejected when being applied right after the upgrade, but that's an improbable and one-time event (contract instantiations are much more rare than regular contract interactions).
 
 ## Security Concerns
 

--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -193,7 +193,7 @@ Contracts can be created from any valid Wasm on-chain with this function, i.e. p
 
 The host function implementation is routed to `create_contract_with_constructor` host function.
 
-The 'legacy' `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function will be preserved in protocol 22 for the sake of backwards compatibility. It will only work with the contracts that don't have constructors defined.
+The 'legacy' `HOST_FUNCTION_TYPE_CREATE_CONTRACT` XDR host function will be preserved in protocol 22 for the sake of backwards compatibility. It will work with the contracts that don't require providing the constructor arguments, i.e. the contracts that have a 'default' constructor (no explicit constructor defined) and contracts that have an explicitly defined constructor that accepts 0 input arguments.
 
 #### Authorization support
 


### PR DESCRIPTION
- Update for supporting v1 'create contract' auth payload 
- Clarify the semantics of CREATE_CONTRACT_HOST_FN w.r.t constructor support.