### PR TITLE
SEP-6: Fix typos and update `instructions` example

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -799,7 +799,7 @@ Example:
 
 If the anchor supports [SEP-38] quotes, it can provide a deposit that makes a bridge between non-equivalent assets by
 receiving, for instance BRL via bank transfer and in return sending the equivalent value (minus fees) as USDC to the
-user's Stellar account. A
+user's Stellar account.
 
 The `/deposit-exchange` endpoint allows a wallet to get deposit information from an anchor when the user intends to make
 a conversion between non-equivalent assets. With this endpoint, a user has all the information needed to initiate a

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -419,7 +419,7 @@ Request Parameters:
 | `country_code`                | string                  | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.                                                                                                                                                                                                                                       |
 | `claimable_balance_supported` | string                  | (optional) `true` if the client supports receiving deposit transactions as a claimable balance, `false` otherwise.                                                                                                                                                                                                                                                                                                                                                    |
 | `customer_id`                 | string                  | (optional) id of an off-chain account (managed by the anchor) associated with this user's Stellar account (identified by the JWT's `sub` field). If the anchor supports [SEP-12], the `customer_id` field should match the [SEP-12] customer's id. `customer_id` should be passed only when the off-chain id is know to the client, but the relationship between this id and the user's Stellar account is not known to the Anchor.                                   |
-| `location_id`                 | string                  | (optional) optional) id of the chosen location to drop off cash                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `location_id`                 | string                  | (optional) id of the chosen location to drop off cash                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 The request parameters also must include the required fields from the `/info` endpoint.
 
@@ -523,7 +523,7 @@ Ripple response example:
       "value": "rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrHGbf",
       "description": "Ripple address"
     },
-    "organization.crypto_memo": {
+    "organization.external_transfer_memo": {
       "value": "88",
       "description": "Ripple tag"
     }
@@ -777,7 +777,7 @@ asynchonously.
 | `memo_type`   | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.                                                                                                                                          |
 | `memo`        | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. The anchor should use this memo to match the Stellar transaction with the database entry associated created to represent it. |
 | `id`          | string | (optional) The anchor's ID for this withdrawal. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.                                        |
-| `eta`         | int    | ( Estimate of how long the withdrawal will take to credit in seconds.                                                                                                                                                     |
+| `eta`         | int    | (optional) Estimate of how long the withdrawal will take to credit in seconds.                                                                                                                                            |
 | `min_amount`  | float  | (optional) Minimum amount of an asset that a user can withdraw.                                                                                                                                                           |
 | `max_amount`  | float  | (optional) Maximum amount of asset that a user can withdraw.                                                                                                                                                              |
 | `fee_fixed`   | float  | (optional) If there is a fee for withdraw. In units of the withdrawn asset.                                                                                                                                               |
@@ -1282,7 +1282,7 @@ An anchor should also indicate in the `/info` response if they support the `GET 
 ##### Fee Info
 
 Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short
-explaination of how fees are calculated so client applications will be able to display this message to their users. This
+explanation of how fees are calculated so client applications will be able to display this message to their users. This
 is especially important if the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage
 values for each Stellar asset.
 
@@ -1493,7 +1493,7 @@ Each object in the `transactions` array should have the following fields:
 | --------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `total`   | string | The total amount of fee applied.                                                                                                                                      |
 | `asset`   | string | The asset in which the fee is applied, represented through the [Asset Identification Format](sep-0038.md#asset-identification-format).                                |
-| `details` | array  | (optional) An array of objects detailing the fees that were used to calculate the conversion price. This can be used to datail the price components for the end-user. |
+| `details` | array  | (optional) An array of objects detailing the fees that were used to calculate the conversion price. This can be used to detail the price components for the end-user. |
 
 #### Fee Details Details Object Schema
 

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -380,11 +380,11 @@ anchor implementation working with minimal effort while providing a great user e
 
 ## Deposit
 
-A deposit is when a user sends an external token (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by
-an anchor. In return, the anchor sends an equal amount of an equivalent token on the Stellar network (minus fees) to the
+A deposit is when a user sends an external asset (BTC via Bitcoin, USD via bank transfer, etc...) to an address held by
+an anchor. In return, the anchor sends an equal amount of an equivalent asset on the Stellar network (minus fees) to the
 user's Stellar account.
 
-If the anchor supports [SEP-38] quotes, it can also provide a bridge between non-equivalent tokens. For example, the
+If the anchor supports [SEP-38] quotes, it can also provide a bridge between non-equivalent assets. For example, the
 anchor can receive ARS via bank transfer and in return send the equivalent value (minus fees) as USDC on the Stellar
 network to the user's Stellar account. That kind of deposit is covered in [`GET /deposit-exchange`](#deposit-exchange).
 
@@ -406,7 +406,7 @@ Request Parameters:
 | Name                          | Type                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | ----------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `asset_code`                  | string                  | The code of the on-chain asset the user wants to get from the Anchor after doing an off-chain deposit. The value passed must match one of the codes listed in the [/info](#info) response's deposit object.                                                                                                                                                                                                                                                           |
-| `account`                     | `G...` or `M...` string | The stellar or muxed account ID of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.                                                                                                                                                                                                                                                |
+| `account`                     | `G...` or `M...` string | The stellar or muxed account ID of the user that wants to deposit. This is where the Stellar asset will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.                                                                                                                                                                                                                                              |
 | `memo_type`                   | string                  | (optional) Type of memo that the anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.                                                                                                                                                                                                                                                                                                                                              |
 | `memo`                        | string                  | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. Because a memo can be specified in the SEP-10 JWT for [Shared Accounts](#shared-omnibus-or-pooled-accounts), this field as well as `memo_type` can be different than the values included in the SEP-10 JWT. For example, a client application could use the value passed for this parameter as a reference number used to match payments made to `account`.              |
 | `email_address`               | string                  | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.                                                                                                                                                                                                                                                                                                                                        |
@@ -419,7 +419,7 @@ Request Parameters:
 | `country_code`                | string                  | (optional) The [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the user's current address. This field may be necessary for the anchor to determine what KYC information is necessary to collect.                                                                                                                                                                                                                                       |
 | `claimable_balance_supported` | string                  | (optional) `true` if the client supports receiving deposit transactions as a claimable balance, `false` otherwise.                                                                                                                                                                                                                                                                                                                                                    |
 | `customer_id`                 | string                  | (optional) id of an off-chain account (managed by the anchor) associated with this user's Stellar account (identified by the JWT's `sub` field). If the anchor supports [SEP-12], the `customer_id` field should match the [SEP-12] customer's id. `customer_id` should be passed only when the off-chain id is know to the client, but the relationship between this id and the user's Stellar account is not known to the Anchor.                                   |
-| `location_id`                 | string                  | (optional) id of the chosen location to drop off cash                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `location_id`                 | string                  | (optional) optional) id of the chosen location to drop off cash                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 The request parameters also must include the required fields from the `/info` endpoint.
 
@@ -523,7 +523,7 @@ Ripple response example:
       "value": "rNXEkKCxvfLcM1h4HJkaj2FtmYuAWrHGbf",
       "description": "Ripple address"
     },
-    "organization.external_transfer_memo": {
+    "organization.crypto_memo": {
       "value": "88",
       "description": "Ripple tag"
     }
@@ -566,9 +566,9 @@ The Anchor can add this minimal funding amount to the service fee, but this requ
 minimum funding amount in units of the requested asset.
 
 Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset
-before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to
-establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the
-account in Stellar to complete the deposit.
+before the anchor can send the requested asset to the user's account. The anchor should listen for the user to establish
+this trust line. Once the trust line is there, the anchor should send the requested asset to the account in Stellar to
+complete the deposit.
 
 If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return
 a `400 Bad Request` error in the [deposit](#deposit-2) response. The response body should be a JSON object containing an
@@ -692,7 +692,7 @@ are no predicate preferences, `UNCONDITIONAL` allows accounts to claim balances 
 A withdraw is when a user redeems an asset currently on the Stellar network for its equivalent off-chain asset via the
 Anchor. For instance, a user redeeming their NGNT in exchange for fiat NGN.
 
-If the anchor supports [SEP-38] quotes, it can also provide a bridge between non-equivalent tokens. For example, the
+If the anchor supports [SEP-38] quotes, it can also provide a bridge between non-equivalent assets. For example, the
 anchor can receive USDC from the Stellar network and in return send the equivalent value (minus fees) as NGN to the
 user's bank account. That kind of withdrawal is covered in [`GET /withdraw-exchange`](#withdraw-exchange).
 
@@ -767,7 +767,7 @@ The response body should be a JSON object with the following fields:
 
 | Name         | Type          | Description                                                                                                                                                        |
 | ------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `account_id` | `G...` string | (optional) The account the user should send its token back to. This field can be omitted if the anchor cannot provide this information at the time of the request. |
+| `account_id` | `G...` string | (optional) The account the user should send its asset back to. This field can be omitted if the anchor cannot provide this information at the time of the request. |
 
 In this case, the wallet should query the [`/transaction`](#single-historical-transaction) endpoint to get this
 asynchonously.
@@ -777,7 +777,7 @@ asynchonously.
 | `memo_type`   | string | (optional) Type of memo to attach to transaction, one of `text`, `id` or `hash`.                                                                                                                                          |
 | `memo`        | string | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. The anchor should use this memo to match the Stellar transaction with the database entry associated created to represent it. |
 | `id`          | string | (optional) The anchor's ID for this withdrawal. The wallet will use this ID to query the [`/transaction`](#single-historical-transaction) endpoint to check status of the request.                                        |
-| `eta`         | int    | (optional) Estimate of how long the withdrawal will take to credit in seconds.                                                                                                                                            |
+| `eta`         | int    | ( Estimate of how long the withdrawal will take to credit in seconds.                                                                                                                                                     |
 | `min_amount`  | float  | (optional) Minimum amount of an asset that a user can withdraw.                                                                                                                                                           |
 | `max_amount`  | float  | (optional) Maximum amount of asset that a user can withdraw.                                                                                                                                                              |
 | `fee_fixed`   | float  | (optional) If there is a fee for withdraw. In units of the withdrawn asset.                                                                                                                                               |
@@ -797,12 +797,12 @@ Example:
 
 ## Deposit Exchange
 
-If the anchor supports [SEP-38] quotes, it can provide a deposit that makes a bridge between non-equivalent tokens by
+If the anchor supports [SEP-38] quotes, it can provide a deposit that makes a bridge between non-equivalent assets by
 receiving, for instance BRL via bank transfer and in return sending the equivalent value (minus fees) as USDC to the
-user's Stellar account.
+user's Stellar account. A
 
 The `/deposit-exchange` endpoint allows a wallet to get deposit information from an anchor when the user intends to make
-a conversion between non-equivalent tokens. With this endpoint, a user has all the information needed to initiate a
+a conversion between non-equivalent assets. With this endpoint, a user has all the information needed to initiate a
 deposit and it also lets the anchor specify additional information (if desired) that the user must submit via
 [SEP-12](sep-0012.md).
 
@@ -820,7 +820,7 @@ Request Parameters:
 | `source_asset`                | string                  | The off-chain asset the Anchor will receive from the user. The value must match one of the `asset` values included in a [`SEP-38 GET /prices?buy_asset=stellar:<destination_asset>:<asset_issuer>`](sep-0038.md#get-prices) response using [SEP-38 Asset Identification Format](sep-0038.md#asset-identification-format).                                                                                                                                             |
 | `quote_id`                    | string                  | (optional) The `id` returned from a `SEP-38 POST /quote` response. If this parameter is provided and the user delivers the deposit funds to the Anchor before the quote expiration, the Anchor should respect the conversion rate agreed in that quote. If the values of `destination_asset`, `source_asset` and `amount` conflict with the ones used to create the [SEP-38] quote, this request should be rejected with a `400`.                                     |
 | `amount`                      | string                  | The amount of the `source_asset` the user would like to deposit to the anchor's off-chain account. This field may be necessary for the anchor to determine what KYC information is necessary to collect. Should be equals to `quote.sell_amount` if a `quote_id` was used.                                                                                                                                                                                            |
-| `account`                     | `G...` or `M...` string | The stellar or muxed account ID of the user that wants to deposit. This is where the asset token will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.                                                                                                                                                                                                                                                |
+| `account`                     | `G...` or `M...` string | The stellar or muxed account ID of the user that wants to deposit. This is where the Stellar asset will be sent. Note that the account specified in this request could differ from the account authenticated via SEP-10.                                                                                                                                                                                                                                              |
 | `memo_type`                   | string                  | (optional) Type of memo that the anchor should attach to the Stellar payment transaction, one of `text`, `id` or `hash`.                                                                                                                                                                                                                                                                                                                                              |
 | `memo`                        | string                  | (optional) Value of memo to attach to transaction, for `hash` this should be base64-encoded. Because a memo can be specified in the SEP-10 JWT for [Shared Accounts](#shared-omnibus-or-pooled-accounts), this field as well as `memo_type` can be different than the values included in the SEP-10 JWT. For example, a client application could use the value passed for this parameter as a reference number used to match payments made to `account`.              |
 | `email_address`               | string                  | (optional) Email address of depositor. If desired, an anchor can use this to send email updates to the user about the deposit.                                                                                                                                                                                                                                                                                                                                        |
@@ -850,12 +850,12 @@ The expected response as well as the special cases are the same ones covered in 
 
 ## Withdraw Exchange
 
-If the anchor supports [SEP-38] quotes, it can provide a withdraw that makes a bridge between non-equivalent tokens by
+If the anchor supports [SEP-38] quotes, it can provide a withdraw that makes a bridge between non-equivalent assets by
 receiving, for instance USDC from the Stellar network and in return sending the equivalent value (minus fees) as NGN to
 the user's bank account.
 
 The `/withdraw-exchange` endpoint allows a wallet to get withdraw information from an anchor when the user intends to
-make a conversion between non-equivalent tokens. With this endpoint, a user has all the information needed to initiate a
+make a conversion between non-equivalent assets. With this endpoint, a user has all the information needed to initiate a
 withdraw and it also lets the anchor specify additional information (if desired) that the user must submit via
 [SEP-12](sep-0012.md).
 
@@ -1282,7 +1282,7 @@ An anchor should also indicate in the `/info` response if they support the `GET 
 ##### Fee Info
 
 Anchors are encouraged to add a `description` field to the `fee` object returned in `GET /info` containing a short
-explanation of how fees are calculated so client applications will be able to display this message to their users. This
+explaination of how fees are calculated so client applications will be able to display this message to their users. This
 is especially important if the `GET /fee` endpoint is not supported and fees cannot be models using fixed and percentage
 values for each Stellar asset.
 
@@ -1493,7 +1493,7 @@ Each object in the `transactions` array should have the following fields:
 | --------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `total`   | string | The total amount of fee applied.                                                                                                                                      |
 | `asset`   | string | The asset in which the fee is applied, represented through the [Asset Identification Format](sep-0038.md#asset-identification-format).                                |
-| `details` | array  | (optional) An array of objects detailing the fees that were used to calculate the conversion price. This can be used to detail the price components for the end-user. |
+| `details` | array  | (optional) An array of objects detailing the fees that were used to calculate the conversion price. This can be used to datail the price components for the end-user. |
 
 #### Fee Details Details Object Schema
 


### PR DESCRIPTION
This also updates the `instructions` example to use the `organization.external_transfer_memo` field over `organization.crypto_memo`