### PR TITLE
SEP-41, SEP-44, CAP-61: Add optional token name to token event topics

### DIFF
--- a/core/cap-0061.md
+++ b/core/cap-0061.md
@@ -63,7 +63,7 @@ The Stellar Asset Contract interface is extended with one function:
 ///
 /// # Events
 ///
-/// Emits an event with topics `["transfer", from: Address, to: Address, memo: u64, sep0011_asset: String],
+/// Emits an event with topics `["transfer", from: Address, to: Address, sep0011_asset: String, memo: u64],
 /// data = amount: i128`
 fn transfer_memo(env: Env, from: Address, to: Address, amount: i128, memo: u64);
 ```

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -74,7 +74,7 @@ pub trait TokenInterface {
     /// spender: Address], data = [amount: i128, live_until_ledger: u32]`
     ///
     /// Emits an event with:
-    /// - topics - `["approve", from: Address, spender: Address]`
+    /// - topics - `["approve", from: Address, spender: Address, name: String (optional)]`
     /// - data - `[amount: i128, live_until_ledger: u32]`
     fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
@@ -98,7 +98,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["transfer", from: Address, to: Address]`
+    /// - topics - `["transfer", from: Address, to: Address, name: String (optional)]`
     /// - data - `amount: i128`
     fn transfer(env: Env, from: Address, to: Address, amount: i128);
 
@@ -117,7 +117,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["transfer", from: Address, to: Address]`
+    /// - topics - `["transfer", from: Address, to: Address, name: String (optional)]`
     /// - data - `amount: i128`
     fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128);
 
@@ -132,7 +132,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["burn", from: Address]`
+    /// - topics - `["burn", from: Address, name: String (optional)]`
     /// - data - `amount: i128`
     fn burn(env: Env, from: Address, amount: i128);
 
@@ -149,7 +149,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["burn", from: Address]`
+    /// - topics - `["burn", from: Address, name: String (optional)]`
     /// - data - `amount: i128`
     fn burn_from(env: Env, spender: Address, from: Address, amount: i128);
 

--- a/ecosystem/sep-0044.md
+++ b/ecosystem/sep-0044.md
@@ -43,7 +43,7 @@ pub trait TokenExtMemoInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["transfer", from: Address, to: Address, memo: u64]`
+    /// - topics - `["transfer", from: Address, to: Address, name: String, memo: u64]`
     /// - data - `amount: i128`
     fn transfer_memo(env: Env, from: Address, to: Address, amount: i128, memo: u64);
 }


### PR DESCRIPTION
### What
In [SEP-41] add an optional token name to the topic list of all events.

### Why
The built-in implementation of the token interface, the Stellar Asset Contract ([CAP-46-6]), already outputs the asset name in the topic list.

In SEP-44 we propose adding a new topic value to transfer events, the memo, but it is difficult to do so with [SEP-41] not specifying a fourth topic when [CAP-46-6] does.

cc @tomerweller 