### PR TITLE
SEP-44, CAP-61: Move memo into fifth event topic

### DIFF
--- a/core/cap-0061.md
+++ b/core/cap-0061.md
@@ -63,7 +63,7 @@ The Stellar Asset Contract interface is extended with one function:
 ///
 /// # Events
 ///
-/// Emits an event with topics `["transfer", from: Address, to: Address, memo: u64, sep0011_asset: String],
+/// Emits an event with topics `["transfer", from: Address, to: Address, sep0011_asset: String, memo: u64],
 /// data = amount: i128`
 fn transfer_memo(env: Env, from: Address, to: Address, amount: i128, memo: u64);
 ```

--- a/ecosystem/sep-0044.md
+++ b/ecosystem/sep-0044.md
@@ -64,7 +64,7 @@ The event has topics:
 - `Symbol` with value `"transfer"`
 - `Address` the address holding the balance of tokens that was drawn from.
 - `Address` the address that received the tokens.
-- `_` any value the token already emits as the fourth topic.
+- `Val` any value the token already emits as the fourth topic.
 - `u64` the memo.
 
 The event has data:

--- a/ecosystem/sep-0044.md
+++ b/ecosystem/sep-0044.md
@@ -43,8 +43,11 @@ pub trait TokenExtMemoInterface {
     /// # Events
     ///
     /// Emits an event with:
-    /// - topics - `["transfer", from: Address, to: Address, memo: u64]`
+    /// - topics - `["transfer", from: Address, to: Address, _: Val, memo: u64]`
     /// - data - `amount: i128`
+    /// The events fourth topic can be any Val as defined by other standards or
+    /// custom contract behavior. If the contract does not currently emit any
+    /// value in the fourth topic field, it can simply emit `()`, the Void Val.
     fn transfer_memo(env: Env, from: Address, to: Address, amount: i128, memo: u64);
 }
 ```
@@ -61,6 +64,7 @@ The event has topics:
 - `Symbol` with value `"transfer"`
 - `Address` the address holding the balance of tokens that was drawn from.
 - `Address` the address that received the tokens.
+- `_` any value the token already emits as the fourth topic.
 - `u64` the memo.
 
 The event has data:
@@ -81,11 +85,11 @@ The memo is limited to the `u64` type because previous research on the topic whe
 uses of memos were integers, or were compatible with integers.
 
 The [SEP-41] `transfer` event is reused and extended rather than a new event introduced because [SEP-41] uses the
-`transfer` event for all account to account transfers and while possible it seems best to continue emit the same event
-in the new case which is really only an annotation. One challenge of this is that the [CAP-46-6] implementation of
-[SEP-41] already extended the `transfer` event topic list, and so applications will need to distinguish between the
-`u64` memo and a [SEP-11] asset string in the context of the Stellar Asset Contract. Given the topics are typed this
-distinguishing is trivial.
+`transfer` event for all account to account transfers and while possible it seems best to continue to emit the same
+event in the new case which is really only an annotation. One challenge is that the [CAP-46-6] implementation of
+[SEP-41] already extended the `transfer` event topic list. For this reason the fourth field of the event topic list is
+assumed present with any value as defined by the token contract or other standards and this proposal has no opinion of
+its type and purpose. The memo is expected in the fifth field.
 
 ## Changelog
 


### PR DESCRIPTION
### What
Move memo into fifth event topic field in SEP-44 and CAP-61.

### Why
The fourth event topic already being used in the built-in token implementation is problematic as it causes existing applications already ingesting transfer events to need to change which topic field they expect the sep11 asset name to be in.

Moving the memo to the fifth topic field is a small change that increases the chance SEP-44 is a forward compatible change.