### PR TITLE
Update CAPs state to FCP: Accepted

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -91,9 +91,9 @@
 | [CAP-0044](cap-0044.md) | SPEEDEX - Configuration | Jonathan Jove | Draft |
 | [CAP-0045](cap-0045.md) | SPEEDEX - Pricing | Jonathan Jove | Draft |
 | [CAP-0057](cap-0057.md) | State Archival Persistent Entry Eviction | Garand Tyson | Draft |
-| [CAP-0058](cap-0058.md) | Constructors for Soroban Contracts | Dmytro Kozhevin | Awaiting Decision |
-| [CAP-0059](cap-0059.md) | Host functions for BLS12-381 | Jay Geng | Awaiting Decision |
-| [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Awaiting Decision |
+| [CAP-0058](cap-0058.md) | Constructors for Soroban Contracts | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0059](cap-0059.md) | Host functions for BLS12-381 | Jay Geng | FCP: Accepted |
+| [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | FCP: Accepted |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0051.md
+++ b/core/cap-0051.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Leigh McCulloch <@leighmcculloch>
     Authors: Leigh McCulloch <@leighmcculloch>
     Consulted: Graydon Hoare <@graydon>, Riad S. Wahby <@kwantam>
-Status: Implemented
+Status: Final
 Created: 2023-01-30
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1435
 Protocol version: 21

--- a/core/cap-0053.md
+++ b/core/cap-0053.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Anup Pani <@anupsdf>
     Authors: Tommaso De Ponti <@heytdep>
     Consulted: Leigh McCulloch <@leighmcculloch>, Dmytro Kozhevin <@dmkozh>
-Status: Implemented
+Status: Final
 Created: 2023-03-06
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1447
 Protocol version: 21

--- a/core/cap-0054.md
+++ b/core/cap-0054.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Jay Geng <@jayz22>, Dmytro Kozhevin <@dmkozh>
-Status: Implemented
+Status: Final
 Created: 2024-03-11
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1460
 Protocol version: 21

--- a/core/cap-0055.md
+++ b/core/cap-0055.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Jay Geng <@jayz22>, Dmytro Kozhevin <@dmkozh>
-Status: Implemented
+Status: Final
 Created: 2024-03-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1460
 Protocol version: 21

--- a/core/cap-0056.md
+++ b/core/cap-0056.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Jay Geng <@jayz22>, Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>, Tomer Weller <@tomerweller>
-Status: Implemented
+Status: Final
 Created: 2024-03-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1460
 Protocol version: 21

--- a/core/cap-0058.md
+++ b/core/cap-0058.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: Draft
+Status: FCP: Accepted
 Created: 2024-07-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1501
 Protocol version: 22

--- a/core/cap-0059.md
+++ b/core/cap-0059.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Jay Geng <@jayz22>
     Authors: Jay Geng <@jayz22>
     Consulted: Rohit Sinha <@rsinha>, Iftach Haitner <@iftachh>, Tomer Weller <@tomerweller>, Riad S. Wahby <@kwantam>, Nicolas Barry <@MonsieurNicolas>, Anup Pani <@anupsdf>, Naman Kumar <@namankumar>
-Status: Draft
+Status: FCP: Accepted
 Created: 2024-08-15
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1500
 Protocol version: 22

--- a/core/cap-0060.md
+++ b/core/cap-0060.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Dmytro Kozhevin <@dmkozh>, Siddharth Suresh <@sisuresh>, Nicolas Barry <@MonsieurNicolas>, Tomer Weller <@tomerweller>
-Status: Draft
+Status: FCP: Accepted
 Created: 2024-08-19
 Discussion: https://github.com/stellar/stellar-protocol/discussions
 Protocol version: 22


### PR DESCRIPTION
Updated state of the following CAPs to "FCP: Accepted" following the unanimous approval from the CAP Core Team over email to the stellar developer mailing list.

1. [CAP-0058](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0058.md): Addition of a constructor to Soroban's flavor of Rust.
2. [CAP-0059](https://github.com/stellar/stellar-protocol/blob/9995d73a0d9739ead56f57334fab499eaf55fc0f/core/cap-0059.md): Addition of BLS12-381 curve and required field arithmetics.
3. [CAP-0060](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0060.md): Increase performance by upgrading Soroban's VM.