### PR TITLE
SEP-43: add the 'addToken' method to the interface

### DIFF
--- a/ecosystem/sep-0043.md
+++ b/ecosystem/sep-0043.md
@@ -99,7 +99,7 @@ interface Error {
     opts?: {
       networkPassphrase?: string
     }
-    ) => 
+    ) =>
     Promise<{} & error?: Error>,
 }
 ```
@@ -209,7 +209,7 @@ confirm that they are building a transaction for the correct network.
 ### addToken
 
 `addToken` enables requesters to prompt the user to add a token compatible with [SEP-41][sep41] to their wallet. This
-improves the user's exeperience when interacting with a token for the first time, allowing them to review and approve 
+improves the user's exeperience when interacting with a token for the first time, allowing them to review and approve
 the addition of a token to their wallet, rather than having to initiate the addition of the token to their wallet
 themselves.
 

--- a/ecosystem/sep-0043.md
+++ b/ecosystem/sep-0043.md
@@ -7,7 +7,7 @@ Authors: Piyal Basu <piyal@stellar.org>, Leigh McCulloch <@leighmcculloch>, Geor
 Track: Standard
 Status: Draft
 Created: 2024-04-11
-Version: 1.2.1
+Version: 1.3.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1467
 ```
 
@@ -92,7 +92,15 @@ interface Error {
     Promise<{
       network: string,
       networkPassphrase: string
-    } & error?: Error>
+    } & error?: Error>,
+
+  addToken: (
+    tokenAddress: string,
+    opts?: {
+      networkPassphrase?: string
+    }
+    ) => 
+    Promise<{} & error?: Error>,
 }
 ```
 
@@ -198,6 +206,13 @@ If a wallet holds numerous addresses, it can use this param to ensure it is sign
 `getNetwork` provides details about the network that the wallet is currently configured to. This allows a dapp to
 confirm that they are building a transaction for the correct network.
 
+### addToken
+
+`addToken` enables requesters to prompt the user to add a token compatible with [SEP-41][sep41] to their wallet. This
+improves the user's exeperience when interacting with a token for the first time, allowing them to review and approve 
+the addition of a token to their wallet, rather than having to initiate the addition of the token to their wallet
+themselves.
+
 ### Errors
 
 Error messaging provides clear errors to the requester. The `message` field provides an informative, human readable
@@ -213,3 +228,5 @@ useful for their users.
 - [`v1.2.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/445f96ad78afa0c7a83a573a1d887dee27a894ee)
 - [`v1.1.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/790ee6730296eeae0b619a82abfb43a2db3202eb)
 - [`v1.0.0`](https://github.com/stellar/stellar-protocol/blob/fe1abbd181fb8a69213a7d711d19f4b31fd9b853/ecosystem/sep-0043.md)
+
+[sep41]: sep-0041.md

--- a/ecosystem/sep-0043.md
+++ b/ecosystem/sep-0043.md
@@ -98,8 +98,7 @@ interface Error {
     tokenAddress: string,
     opts?: {
       networkPassphrase?: string
-    }
-    ) =>
+    }) =>
     Promise<{} & error?: Error>,
 }
 ```
@@ -225,7 +224,7 @@ useful for their users.
 
 ## Changelog
 
-- [`v1.3.0](https://github.com/stellar/stellar-protocol/pull/1559)
+- [`v1.3.0`](https://github.com/stellar/stellar-protocol/pull/1559)
 - [`v1.2.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/445f96ad78afa0c7a83a573a1d887dee27a894ee)
 - [`v1.1.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/790ee6730296eeae0b619a82abfb43a2db3202eb)
 - [`v1.0.0`](https://github.com/stellar/stellar-protocol/blob/fe1abbd181fb8a69213a7d711d19f4b31fd9b853/ecosystem/sep-0043.md)

--- a/ecosystem/sep-0043.md
+++ b/ecosystem/sep-0043.md
@@ -225,6 +225,7 @@ useful for their users.
 
 ## Changelog
 
+- [`v1.3.0](https://github.com/stellar/stellar-protocol/pull/1559)
 - [`v1.2.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/445f96ad78afa0c7a83a573a1d887dee27a894ee)
 - [`v1.1.0`](https://github.com/stellar/stellar-protocol/pull/1478/commits/790ee6730296eeae0b619a82abfb43a2db3202eb)
 - [`v1.0.0`](https://github.com/stellar/stellar-protocol/blob/fe1abbd181fb8a69213a7d711d19f4b31fd9b853/ecosystem/sep-0043.md)


### PR DESCRIPTION
This PR adds the `addToken` method to the interface, enabling dapps to prompt the user to add a token to their wallet in a manner similar to how dapps prompt the user to sign transactions, auth entries, or other messages.

Without this method, dapps have to describe the steps the user must take themselves in order to add the relevant token to their wallet.