### PR TITLE
SEP-45: Fix server auth entry verification

### DIFF
--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -103,12 +103,11 @@ The authentication flow is as follows:
 1. The **Server** verifies that the `function_name` in each authorization entry is `web_auth_verify`
 1. The **Server** verifies that the `args` map in each authorization entry match the expected values and are the same
    across all authorization entries:
-   1. The `account` value matches the **Client Account** address
    1. The `home_domain` value matches the **Home Domain**
    1. The `home_domain_address` value matches the **Home Domain Address**
    1. The `web_auth_domain` value matches the **Server**'s domain
-   1. The `client_domain_address` value matches the **Client Domain Address** if the **Client** included a
-      `client_domain` in the request, otherwise it is not present
+   1. The `client_domain` is present if `client_domain_address` is present
+   1. The `client_domain_address` value matches the **Client Domain Address** if `client_domain` is present
 1. (Optional) The **Server** verifies that the `nonce` argument is the same across all authorization entries and is
    unique
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Home Domain


### PR DESCRIPTION
The server does not know about the origin request when verifying the challenge returned by the client. It cannot verify that the `account` matched the original request. This also adds a check for the presence of the `client_domain`.