### PR TITLE
CAP-64: Modify XDR field ordering in `SorobanAddressCredentialsV2`

### DIFF
--- a/core/cap-0064.md
+++ b/core/cap-0064.md
@@ -78,9 +78,9 @@ index 7d32481..763531c 100644
 +
 +    SCAddress address;
 +    int64 nonce;
-+    Memo txMemo;
 +    uint32 signatureExpirationLedger;    
 +    SCVal signature;
++    Memo txMemo;
 +};
 +
  enum SorobanCredentialsType


### PR DESCRIPTION
I'm not sure if this was intentional or not but I think it's a mistake since it doesn't match the later section which has the memo last. This will increase binary compatibility across the two credential types.