### PR TITLE
Reorder fields in CAP-64 XDR changes.

### DIFF
--- a/core/cap-0064.md
+++ b/core/cap-0064.md
@@ -78,8 +78,8 @@ index 7d32481..763531c 100644
 +
 +    SCAddress address;
 +    int64 nonce;
++    uint32 signatureExpirationLedger;
 +    Memo txMemo;
-+    uint32 signatureExpirationLedger;    
 +    SCVal signature;
 +};
 +
@@ -113,8 +113,8 @@ index 7d32481..763531c 100644
 +        Hash networkID;
 +        int64 nonce;
 +        uint32 signatureExpirationLedger;
-+        SorobanAuthorizedInvocation invocation;
 +        Memo txMemo;
++        SorobanAuthorizedInvocation invocation;
 +    } sorobanAuthorizationV2;
  };
  


### PR DESCRIPTION
This is just a cosmetic change for more logical field grouping (payload, then signature for credentials; network, then credentials, then execution-related fields for the signature payload preimage).