### PR TITLE
SEP-45: Replay prevention + argument name fixes

### DIFF
--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -76,10 +76,10 @@ The authentication flow is as follows:
    1. The `account` value matches the **Client Account** address
    1. The `home_domain` value matches the **Home Domain**
    1. The `web_auth_domain` value matches the **Server**'s domain
-   1. The `web_auth_domain_signer` value matches the **Server Account**
+   1. The `web_auth_domain_account` value matches the **Server Account**
    1. If the **Client** included a `client_domain` in the request:
       1. The `client_domain` value matches the **Client**'s domain
-      1. The `client_domain_signer` value matches the **Client Domain Account**
+      1. The `client_domain_account` value matches the **Client Domain Account**
 1. The **Client** verifies that there is an authorization entry where `credentials.address.address` is the **Server
    Account** and contains a valid signature from the **Server Account**
 1. The **Client** signs the authorization entry where `credentials.address.address` is the **Client Account** using the
@@ -106,8 +106,8 @@ The authentication flow is as follows:
    1. The `account` value matches the **Client Account** address
    1. The `home_domain` value matches the **Home Domain**
    1. The `web_auth_domain` value matches the **Server**'s domain
-   1. The `web_auth_domain_signer` value matches the **Server Account**
-   1. The `client_domain_signer` value matches the **Client Domain Account** if the **Client** included a
+   1. The `web_auth_domain_account` value matches the **Server Account**
+   1. The `client_domain_account` value matches the **Client Domain Account** if the **Client** included a
       `client_domain` in the request, otherwise it is not present
 1. The **Server** verifies that the `nonce` argument is the same across all authorization entries and is unique
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Server
@@ -199,10 +199,10 @@ Each entry's `root_invocation` function is a `contract_fn` with no sub-invocatio
   - `account` matches the `account` from the request
   - `home_domain` matches the `home_domain` from the request
   - `web_auth_domain` matches the **Server**'s domain
-  - `web_auth_domain_signer` matches the **Server Account**
+  - `web_auth_domain_account` matches the **Server Account**
   - `client_domain` matches the **Client**'s domain if the **Client** included a `client_domain` in the request and the
     server supports [Verifying the Client Domain](#verifying-the-client-domain)
-  - `client_domain_signer` matches the **Client Domain Account** if the **Client** included a `client_domain` in the
+  - `client_domain_account` matches the **Client Domain Account** if the **Client** included a `client_domain` in the
     request and the server supports [Verifying the Client Domain](#verifying-the-client-domain)
   - `nonce` is a unique value that is the same across all authorization entries
 - `network_passphrase`: (optional but recommended) Stellar network passphrase used by the **Server**. This allows a
@@ -213,13 +213,13 @@ Example:
 
 ```json
 {
-  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9j69r6Er/9BUAAAAAAAAAAEAAAAAAAAAAUiNUb+nXPuiZvaGzSpq7HLMEuE5D/ebV4Zm0bwSrPiaAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjEwNDQ2NTUwMzcAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAWd2ViX2F1dGhfZG9tYWluX3NpZ25lcgAAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trWVvMW7KdQxXAA1t9QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDEktg4YWJj0X5R2QlP3dxbnDe58WrfimT4C481xHjAVoGb0efZ30mqPDf4m+j0vvgFlG0eSFttEZlGkKpazu0CAAAAAAAAAAFIjVG/p1z7omb2hs0qauxyzBLhOQ/3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoxMDQ0NjU1MDM3AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA",
+  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9mdGTObL5paKAAAAAAAAAAEAAAAAAAAAAZ772JA0Yoyrj61SFsabc9PKM1/yhpd9BlEdlU3DXUXXAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIzMTg0NDg1NjEAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAXd2ViX2F1dGhfZG9tYWluX2FjY291bnQAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trRSX5y0czfjiABlOXQAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEBtWcnlsiHoLNhWnTo4YvvqrUKrtOvtfGdZhux3uFl1MXKAI4HJvQZzd8TW8y6N5CltNcMibyuLJhjBrtAMGZUPAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyMzE4NDQ4NTYxAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA",
   "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```
 
 You can examine the example challenge in the
-[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9j69r6Er//9BUAAAAAAAAAAEAAAAAAAAAAUiNUb+nXPuiZvaGzSpq7HLMEuE5D//ebV4Zm0bwSrPiaAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjEwNDQ2NTUwMzcAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAWd2ViX2F1dGhfZG9tYWluX3NpZ25lcgAAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trWVvMW7KdQxXAA1t9QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDEktg4YWJj0X5R2QlP3dxbnDe58WrfimT4C481xHjAVoGb0efZ30mqPDf4m+j0vvgFlG0eSFttEZlGkKpazu0CAAAAAAAAAAFIjVG//p1z7omb2hs0qauxyzBLhOQ//3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoxMDQ0NjU1MDM3AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA&type=SorobanAuthorizationEntry;;)
+[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9mdGTObL5paKAAAAAAAAAAEAAAAAAAAAAZ772JA0Yoyrj61SFsabc9PKM1//yhpd9BlEdlU3DXUXXAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIzMTg0NDg1NjEAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAXd2ViX2F1dGhfZG9tYWluX2FjY291bnQAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trRSX5y0czfjiABlOXQAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEBtWcnlsiHoLNhWnTo4YvvqrUKrtOvtfGdZhux3uFl1MXKAI4HJvQZzd8TW8y6N5CltNcMibyuLJhjBrtAMGZUPAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyMzE4NDQ4NTYxAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA&type=SorobanAuthorizationEntry;;)
 
 ##### Error
 
@@ -254,15 +254,15 @@ fail, then the authentication request must be rejected — that is, treated by t
    entries:
    1. The `home_domain` value matches the **Home Domain**;
    1. The `web_auth_domain` value matches the **Server**'s domain;
-   1. The `web_auth_domain_signer` value matches the **Server Account**;
+   1. The `web_auth_domain_account` value matches the **Server Account**;
    1. The `client_domain` is present if `client_domain_address` is present;
-   1. The `client_domain_signer` value matches the **Client Domain Account** if `client_domain` is present;
+   1. The `client_domain_account` value matches the **Client Domain Account** if `client_domain` is present;
 1. Verify that the `nonce` argument is the same across all authorization entries and is valid;
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Server Account** and
    contains a valid signature from the **Server Account**;
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Account** address
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Domain Account** if
-   the arguments included a `client_domain_signer`.
+   the arguments included a `client_domain_account`.
 1. Construct a transaction with a single Invoke Host Function operation where the contract address is
    `WEB_AUTH_CONTRACT_ID` and the function is `web_auth_verify` using the previously extracted arguments and the
    authorization entries returned by the client;
@@ -310,12 +310,12 @@ Example:
 
 ```json
 {
-  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9hkIHjaHHUrOAA1uEAAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu/mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAECp1BOXU7cMGlLHreuOVtW1ViMG35W+ddffWV1WkCrO1RDVuVM116VfmcQrCb7dpCM0Hb0gduLxOS/vjLBDk5sGAAAAAAAAAAFIjVG/p1z7omb2hs0qauxyzBLhOQ/3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyODAwMzA3NDE4AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra18BezQ1/TMvQANbgcAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAJQ6tyKk8igNCVGb46rx/0lY8XUc/EQhytIElC8LiN2oG+H5c1y1OA/khmpn55ckVJGdqcKsB7uSgdvEnow9aDAAAAAAAAAABSI1Rv6dc+6Jm9obNKmrscswS4TkP95tXhmbRvBKs+JoAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjgwMDMwNzQxOAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABZ3ZWJfYXV0aF9kb21haW5fc2lnbmVyAAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA=="
+  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9jnVl00v1o8vABlOdgAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu/mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEAUCPvkdgmqobRCmmEeEJiX5FFEGPjrYDakjZRQBOfMVxtNcrmSG+dE+Me4d8OFPVCJpEpfbqI/QsKr8XdBVsIEAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAkzMjIyMjEzOTkAAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0V53XfNd2YRwAZTm0AAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABA90lI/BzqTlvfexRtV09ZnIw07nKImxTH4r6BZzCx3vcaofxjB3tJ7NIceggUHay9HwMzAJARKCHud5UrbqiOBgAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX/KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAJMzIyMjIxMzk5AAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA=="
 }
 ```
 
 You can examine the example signed entries in the
-[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9hkIHjaHHUrOAA1uEAAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu//mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAECp1BOXU7cMGlLHreuOVtW1ViMG35W+ddffWV1WkCrO1RDVuVM116VfmcQrCb7dpCM0Hb0gduLxOS//vjLBDk5sGAAAAAAAAAAFIjVG//p1z7omb2hs0qauxyzBLhOQ//3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyODAwMzA3NDE4AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra18BezQ1//TMvQANbgcAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAJQ6tyKk8igNCVGb46rx//0lY8XUc//EQhytIElC8LiN2oG+H5c1y1OA//khmpn55ckVJGdqcKsB7uSgdvEnow9aDAAAAAAAAAABSI1Rv6dc+6Jm9obNKmrscswS4TkP95tXhmbRvBKs+JoAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjgwMDMwNzQxOAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABZ3ZWJfYXV0aF9kb21haW5fc2lnbmVyAAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA==&type=SorobanAuthorizationEntry;;)
+[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9jnVl00v1o8vABlOdgAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu//mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEAUCPvkdgmqobRCmmEeEJiX5FFEGPjrYDakjZRQBOfMVxtNcrmSG+dE+Me4d8OFPVCJpEpfbqI//QsKr8XdBVsIEAAAAAAAAAAGe+9iQNGKMq4+tUhbGm3PTyjNf8oaXfQZRHZVNw11F1wAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAkzMjIyMjEzOTkAAAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAF3dlYl9hdXRoX2RvbWFpbl9hY2NvdW50AAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0V53XfNd2YRwAZTm0AAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABA90lI//BzqTlvfexRtV09ZnIw07nKImxTH4r6BZzCx3vcaofxjB3tJ7NIceggUHay9HwMzAJARKCHud5UrbqiOBgAAAAAAAAABnvvYkDRijKuPrVIWxptz08ozX//KGl30GUR2VTcNdRdcAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAJMzIyMjIxMzk5AAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABd3ZWJfYXV0aF9kb21haW5fYWNjb3VudAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA==&type=SorobanAuthorizationEntry;;)
 
 #### Response
 
@@ -382,9 +382,9 @@ impl WebAuthContract {
     /// - account: The client account address
     /// - home_domain: The home domain
     /// - web_auth_domain: The server's domain
-    /// - web_auth_domain_signer: The server's SIGNING_KEY
+    /// - web_auth_domain_account: The server's SIGNING_KEY
     /// - client_domain: The client domain (optional)
-    /// - client_domain_signer: The client domain's SIGNING_KEY (optional)
+    /// - client_domain_account: The client domain's SIGNING_KEY (optional)
     /// - nonce: A random string generated by the server to prevent replay attacks
     pub fn web_auth_verify(env: Env, args: Map<Symbol, String>) -> Result<(), WebAuthError> {
         if let Some(address) = args.get(Symbol::new(&env, "account")) {
@@ -394,16 +394,16 @@ impl WebAuthContract {
             return Err(WebAuthError::MissingArgument);
         }
 
-        if let Some(web_auth_domain_signer) = args.get(Symbol::new(&env, "web_auth_domain_signer")) {
-            let addr = Address::from_string(&web_auth_domain_signer);
+        if let Some(web_auth_domain_account) = args.get(Symbol::new(&env, "web_auth_domain_account")) {
+            let addr = Address::from_string(&web_auth_domain_account);
             addr.require_auth();
         } else {
             return Err(WebAuthError::MissingArgument);
         }
 
         // Optional client domain verification
-        if let Some(client_domain_signer) = args.get(Symbol::new(&env, "client_domain_signer")) {
-            let addr = Address::from_string(&client_domain_signer);
+        if let Some(client_domain_account) = args.get(Symbol::new(&env, "client_domain_account")) {
+            let addr = Address::from_string(&client_domain_account);
             addr.require_auth();
         }
 

--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -40,16 +40,16 @@ It involves the following components:
 
 - A **Home Domain**: a domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`
   (URL), `WEB_AUTH_CONTRACT_ID`, and `SIGNING_KEY` (`G...`).
-  - The `SIGNING_KEY` from this domain is referred to as the **Home Domain Address** in this document.
 - A **Server**: a server providing the `WEB_AUTH_FOR_CONTRACTS_ENDPOINT` that implements the GET and POST operations
   discussed in this document. The server's domain may be the **Home Domain**, a sub-domain of the **Home Domain**, or a
   different domain.
+  - The `SIGNING_KEY` from this domain is referred to as the **Server Account** in this document.
 - A **Client Account**: the account being authenticated.
   - A Stellar contract account (`C...`).
 - A **Client**: the software used by the holder of the **Client Account** being authenticated by the **Server**.
 - A **Client Domain** (optional): a domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `SIGNING_KEY` used
   for [Verifying the Client Domain](#verifying-the-client-domain)
-  - The `SIGNING_KEY` from this domain is referred to as the **Client Domain Address** in this document.
+  - The `SIGNING_KEY` from this domain is referred to as the **Client Domain Account** in this document.
 - A **Web Auth Contract**: a contract that implements the `web_auth_verify` function as described in this document. The
   contract must be deployed at the `WEB_AUTH_CONTRACT_ID` address specified in the **Server**'s `stellar.toml`.
 
@@ -64,7 +64,7 @@ The authentication flow is as follows:
 
 1. The **Client** requests a unique [`challenge`](#challenge) from the **Server** which includes a list of authorization
    entries XDR-encoded strings
-1. If the request contains a `client_domain` parameter, the **Server** may fetch the **Client Domain Address** and
+1. If the request contains a `client_domain` parameter, the **Server** may fetch the **Client Domain Account** and
    generate the challenge with an additional authorization entry as described in the [Response](#response) section.
 1. The **Server** responds with the challenge
 1. The **Client** verifies that each authorization entry does not contain any sub-invocations
@@ -75,27 +75,27 @@ The authentication flow is as follows:
    across all authorization entries:
    1. The `account` value matches the **Client Account** address
    1. The `home_domain` value matches the **Home Domain**
-   1. The `home_domain_address` value matches the **Home Domain Address**
    1. The `web_auth_domain` value matches the **Server**'s domain
+   1. The `web_auth_domain_signer` value matches the **Server Account**
    1. If the **Client** included a `client_domain` in the request:
       1. The `client_domain` value matches the **Client**'s domain
-      1. The `client_domain_address` value matches the **Client Domain Address**
-1. The **Client** verifies that there is an authorization entry where `credentials.address.address` is the **Home Domain
-   Address** and contains a valid signature from the **Home Domain Address**
+      1. The `client_domain_signer` value matches the **Client Domain Account**
+1. The **Client** verifies that there is an authorization entry where `credentials.address.address` is the **Server
+   Account** and contains a valid signature from the **Server Account**
 1. The **Client** signs the authorization entry where `credentials.address.address` is the **Client Account** using the
    secret key(s) of the signer(s) for the **Client Account**
    - Note: **Client** signatures may not be required if the contract's `__check_auth` implementation does not require
      them
-1. The **Client** obtains a signature from the **Client Domain Address** for the authorization entry where
-   `credentials.address.address` is the **Client Domain Address** if the **Client** included a client domain in the
+1. The **Client** obtains a signature from the **Client Domain Account** for the authorization entry where
+   `credentials.address.address` is the **Client Domain Account** if the **Client** included a client domain in the
    request
 1. The **Client** simulates the transaction with the signed authorization entries and verifies the following to ensure
    the transaction does not have any unintended side effects:
    - The transaction's ledger footprint `read_write` set contains only `contract_data` entries where:
      - The `contract` is the **Client Account** address, and the `key` is `ledger_key_nonce`.
-     - The `contract` is the **Home Domain Address**, and the `key` is `ledger_key_nonce`.
-     - (Optional) if an authorization entry for the **Client Domain Address** was present in the challenge, the
-       `contract` is the **Client Domain Address**, and the `key` is `ledger_key_nonce`.
+     - The `contract` is the **Server Account**, and the `key` is `ledger_key_nonce`.
+     - (Optional) if an authorization entry for the **Client Domain Account** was present in the challenge, the
+       `contract` is the **Client Domain Account**, and the `key` is `ledger_key_nonce`.
 1. The **Client** submits the signed authorization entries back to the **Server** using [`token`](#token) endpoint
 1. The **Server** extracts the arguments from the authorization entries returned by the client
 1. The **Server** verifies that the `contract_address` in each authorization entry matches the `WEB_AUTH_CONTRACT_ID`
@@ -105,14 +105,13 @@ The authentication flow is as follows:
    across all authorization entries:
    1. The `account` value matches the **Client Account** address
    1. The `home_domain` value matches the **Home Domain**
-   1. The `home_domain_address` value matches the **Home Domain Address**
    1. The `web_auth_domain` value matches the **Server**'s domain
-   1. The `client_domain_address` value matches the **Client Domain Address** if the **Client** included a
+   1. The `web_auth_domain_signer` value matches the **Server Account**
+   1. The `client_domain_signer` value matches the **Client Domain Account** if the **Client** included a
       `client_domain` in the request, otherwise it is not present
-1. (Optional) The **Server** verifies that the `nonce` argument is the same across all authorization entries and is
-   unique
-1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Home Domain
-   Address** and contains a valid signature from the **Home Domain Address**
+1. The **Server** verifies that the `nonce` argument is the same across all authorization entries and is unique
+1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Server
+   Account** and contains a valid signature from the **Server Account**
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Client
    Account** address
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Client
@@ -126,7 +125,7 @@ The authentication flow is as follows:
 The flow achieves several things:
 
 - Both **Client** and **Server** can be implemented using well-established Stellar libraries
-- The **Client** can verify that the **Server** holds the secret key to the **Home Domain Address**
+- The **Client** can verify that the **Server** holds the secret key to the **Server Account**
 - The **Server** can verify that the **Client** is authorized by the contract account to create an authenticated session
 - The **Server** can choose its own timeout for the authenticated session
 - The **Server** can choose to include other application-specific claims
@@ -158,9 +157,9 @@ implemented in all the endpoints that support Cross-Origin.
 This endpoint must respond with authorization entries to be signed by the **Client**. The **Client** signs the entries
 using standard Stellar libraries and submit it to [`token`](#token) endpoint to prove that it controls the **Client
 Account**. This approach is compatible with hardware wallets such as Ledger. The **Client Application** must also verify
-the server's signature to be sure the challenge is signed by the **Home Domain Address**, that the home domain argument
-in the function invocation is the **Home Domain**, and that the web auth domain argument in the function invocation is
-the **Server** domain.
+the server's signature to be sure the challenge is signed by the **Server Account**, that the home domain argument in
+the function invocation is the **Home Domain**, and that the web auth domain argument in the function invocation is the
+**Server** domain.
 
 #### Request
 
@@ -189,8 +188,8 @@ GET https://auth.example.com/?account=CCIBUCGPOHWMMMFPFTDWBSVHQRT4DIBJ7AD6BZJYDI
 On success the endpoint must return `200 OK` HTTP status code and a JSON object with the following fields:
 
 - `authorization_entries`: an XDR-encoded array of `SorobanAuthorizationEntry`s. It contains an entry for the **Client
-  Account** in addition to a signed entry from the **Home Domain Address** and optionally the **Client Domain Address**.
-  The entries are not guaranteed to be in any specific order.
+  Account** in addition to a signed entry from the **Server Account** and optionally the **Client Domain Account**. The
+  entries are not guaranteed to be in any specific order.
 
 Each entry's `root_invocation` function is a `contract_fn` with no sub-invocations and the following values:
 
@@ -199,13 +198,13 @@ Each entry's `root_invocation` function is a `contract_fn` with no sub-invocatio
 - An `args` map containing the following Symbol to String pairs:
   - `account` matches the `account` from the request
   - `home_domain` matches the `home_domain` from the request
-  - `home_domain_address` matches the **Home Domain Address**
   - `web_auth_domain` matches the **Server**'s domain
+  - `web_auth_domain_signer` matches the **Server Account**
   - `client_domain` matches the **Client**'s domain if the **Client** included a `client_domain` in the request and the
     server supports [Verifying the Client Domain](#verifying-the-client-domain)
-  - `client_domain_address` matches the **Client Domain Address** if the **Client** included a `client_domain` in the
+  - `client_domain_signer` matches the **Client Domain Account** if the **Client** included a `client_domain` in the
     request and the server supports [Verifying the Client Domain](#verifying-the-client-domain)
-  - (Optional) `nonce` is a unique value that is the same across all authorization entries
+  - `nonce` is a unique value that is the same across all authorization entries
 - `network_passphrase`: (optional but recommended) Stellar network passphrase used by the **Server**. This allows a
   **Client** to verify that it's using the correct passphrase when signing and is useful for identifying when a
   **Client** or **Server** have been configured incorrectly.
@@ -214,13 +213,13 @@ Example:
 
 ```json
 {
-  "authorization_entries": "AAAAAQAAAAHDwFN8u4knndhlRcZmGC28sL8G7WJnadYNY88ZwAICiAhjuHNQ4DVQAAAAAAAAAAEAAAAAAAAAAX6lC8GUFNGjTHdg8uQyeJvi1taYAbI3H1Ss91/oUNawAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0RCNEFVMzRYT0VTUEhPWU1WQzRNWlFZRlc2TEJQWUc1VlJHTzJPV0JWUjQ2R09BQUlCSVE0R0QAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAATaG9tZV9kb21haW5fYWRkcmVzcwAAAAAOAAAAOEdESkxCWVlLTUNYTlZWTkFCT0U2Nk5ZWFFHSUE1QUM1RDIyM1oyS0Y2WkVZSzRVQkNBN0ZLTFRHAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjA2MDIxNDExNQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAAAAAAAAEAAAAAAAAAANKw4wpgrtrVoAuJ7zcXgZAOgF0etbzpRfZJhXKBED5VHSLrhXQ/QVwAAaLlAAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAApwdWJsaWNfa2V5AAAAAAANAAAAINKw4wpgrtrVoAuJ7zcXgZAOgF0etbzpRfZJhXKBED5VAAAADwAAAAlzaWduYXR1cmUAAAAAAAANAAAAQDUYC2mj/RW0NcGfY66p+eltjwflRSmwc8ZZ7as2HAUvu4k/bY2ZHIhhS6M7Ufx74XmV9QlxHPv6vXUA/j9uRAwAAAAAAAAAAX6lC8GUFNGjTHdg8uQyeJvi1taYAbI3H1Ss91/oUNawAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0RCNEFVMzRYT0VTUEhPWU1WQzRNWlFZRlc2TEJQWUc1VlJHTzJPV0JWUjQ2R09BQUlCSVE0R0QAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAATaG9tZV9kb21haW5fYWRkcmVzcwAAAAAOAAAAOEdESkxCWVlLTUNYTlZWTkFCT0U2Nk5ZWFFHSUE1QUM1RDIyM1oyS0Y2WkVZSzRVQkNBN0ZLTFRHAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjA2MDIxNDExNQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAAAA==",
+  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9j69r6Er/9BUAAAAAAAAAAEAAAAAAAAAAUiNUb+nXPuiZvaGzSpq7HLMEuE5D/ebV4Zm0bwSrPiaAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjEwNDQ2NTUwMzcAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAWd2ViX2F1dGhfZG9tYWluX3NpZ25lcgAAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trWVvMW7KdQxXAA1t9QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDEktg4YWJj0X5R2QlP3dxbnDe58WrfimT4C481xHjAVoGb0efZ30mqPDf4m+j0vvgFlG0eSFttEZlGkKpazu0CAAAAAAAAAAFIjVG/p1z7omb2hs0qauxyzBLhOQ/3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoxMDQ0NjU1MDM3AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA",
   "network_passphrase": "Test SDF Network ; September 2015"
 }
 ```
 
 You can examine the example challenge in the
-[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAHDwFN8u4knndhlRcZmGC28sL8G7WJnadYNY88ZwAICiAhjuHNQ4DVQAAAAAAAAAAEAAAAAAAAAAX6lC8GUFNGjTHdg8uQyeJvi1taYAbI3H1Ss91//oUNawAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0RCNEFVMzRYT0VTUEhPWU1WQzRNWlFZRlc2TEJQWUc1VlJHTzJPV0JWUjQ2R09BQUlCSVE0R0QAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAATaG9tZV9kb21haW5fYWRkcmVzcwAAAAAOAAAAOEdESkxCWVlLTUNYTlZWTkFCT0U2Nk5ZWFFHSUE1QUM1RDIyM1oyS0Y2WkVZSzRVQkNBN0ZLTFRHAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjA2MDIxNDExNQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAAAAAAAAEAAAAAAAAAANKw4wpgrtrVoAuJ7zcXgZAOgF0etbzpRfZJhXKBED5VHSLrhXQ//QVwAAaLlAAAAEAAAAAEAAAABAAAAEQAAAAEAAAACAAAADwAAAApwdWJsaWNfa2V5AAAAAAANAAAAINKw4wpgrtrVoAuJ7zcXgZAOgF0etbzpRfZJhXKBED5VAAAADwAAAAlzaWduYXR1cmUAAAAAAAANAAAAQDUYC2mj//RW0NcGfY66p+eltjwflRSmwc8ZZ7as2HAUvu4k//bY2ZHIhhS6M7Ufx74XmV9QlxHPv6vXUA//j9uRAwAAAAAAAAAAX6lC8GUFNGjTHdg8uQyeJvi1taYAbI3H1Ss91//oUNawAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0RCNEFVMzRYT0VTUEhPWU1WQzRNWlFZRlc2TEJQWUc1VlJHTzJPV0JWUjQ2R09BQUlCSVE0R0QAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAATaG9tZV9kb21haW5fYWRkcmVzcwAAAAAOAAAAOEdESkxCWVlLTUNYTlZWTkFCT0U2Nk5ZWFFHSUE1QUM1RDIyM1oyS0Y2WkVZSzRVQkNBN0ZLTFRHAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjA2MDIxNDExNQAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAAAA==&type=SorobanAuthorizationEntry;;)
+[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9j69r6Er//9BUAAAAAAAAAAEAAAAAAAAAAUiNUb+nXPuiZvaGzSpq7HLMEuE5D//ebV4Zm0bwSrPiaAAAAD3dlYl9hdXRoX3ZlcmlmeQAAAAABAAAAEQAAAAEAAAAFAAAADwAAAAdhY2NvdW50AAAAAA4AAAA4Q0NMSEJVUllPNEIySkZVNFlCWlVRWktKUTJaMzcyM0RQWFRXVTZZRFBYTjRUWjNLSFZRN05PVUwAAAAPAAAAC2hvbWVfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjEwNDQ2NTUwMzcAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAA8AAAAWd2ViX2F1dGhfZG9tYWluX3NpZ25lcgAAAAAADgAAADhHQ0hMSERCT0tHMkpXTUpRQlRMU0w1WEc2Tk83RVNYSTJUQVFLWlhDWFdYQjVXSTJYNlcyMzNQUgAAAAAAAAABAAAAAAAAAACOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trWVvMW7KdQxXAA1t9QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCOs4wuUbSbMTAM1yX25vNd8kro1MEFZuK9rh7ZGr+trQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDEktg4YWJj0X5R2QlP3dxbnDe58WrfimT4C481xHjAVoGb0efZ30mqPDf4m+j0vvgFlG0eSFttEZlGkKpazu0CAAAAAAAAAAFIjVG//p1z7omb2hs0qauxyzBLhOQ//3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoxMDQ0NjU1MDM3AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAA&type=SorobanAuthorizationEntry;;)
 
 ##### Error
 
@@ -254,16 +253,16 @@ fail, then the authentication request must be rejected — that is, treated by t
 1. Verify that the `args` in each authorization entry match the expected values and is the same across all authorization
    entries:
    1. The `home_domain` value matches the **Home Domain**;
-   1. The `home_domain_address` value matches the **Home Domain Address**;
    1. The `web_auth_domain` value matches the **Server**'s domain;
+   1. The `web_auth_domain_signer` value matches the **Server Account**;
    1. The `client_domain` is present if `client_domain_address` is present;
-   1. The `client_domain_address` value matches the **Client Domain Address** if `client_domain` is present;
-1. (Optional) Verify that the `nonce` argument is the same across all authorization entries and is valid;
-1. Verify that there is an authorization entry where `credentials.address.address` is the **Home Domain Address** and
-   contains a valid signature from the **Home Domain Address**;
+   1. The `client_domain_signer` value matches the **Client Domain Account** if `client_domain` is present;
+1. Verify that the `nonce` argument is the same across all authorization entries and is valid;
+1. Verify that there is an authorization entry where `credentials.address.address` is the **Server Account** and
+   contains a valid signature from the **Server Account**;
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Account** address
-1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Domain Address** if
-   the arguments included a `client_domain_address`.
+1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Domain Account** if
+   the arguments included a `client_domain_signer`.
 1. Construct a transaction with a single Invoke Host Function operation where the contract address is
    `WEB_AUTH_CONTRACT_ID` and the function is `web_auth_verify` using the previously extracted arguments and the
    authorization entries returned by the client;
@@ -310,16 +309,13 @@ Request Parameters:
 Example:
 
 ```json
-POST https://auth.example.com/
-Content-Type: application/json
-
 {
-  "authorization_entries": "AAAAAQAAAAHDwFN8u4knndhlRcZmGC28sL8G7WJnadYNY88ZwAICiAhjuHNQ4DVQAAGi7gAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCLcZbWB5Tc+LwIlJMazXz6KECPC89cSo589hUfJAOrhwAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDIHVoFpnEUUmqOzTCzsYqu3naPvxUh1BmreIjoBbgXcbsCulvxQQdWKq40JWxNuacxOnoiOy1qyRD2ylTbirgBAAAAAAAAAAF+pQvBlBTRo0x3YPLkMnib4tbWmAGyNx9UrPdf6FDWsAAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENEQjRBVTM0WE9FU1BIT1lNVkM0TVpRWUZXNkxCUFlHNVZSR08yT1dCVlI0NkdPQUFJQklRNEdEAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAE2hvbWVfZG9tYWluX2FkZHJlc3MAAAAADgAAADhHREpMQllZS01DWE5WVk5BQk9FNjZOWVhRR0lBNUFDNUQyMjNaMktGNlpFWUs0VUJDQTdGS0xURwAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIwNjAyMTQxMTUAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAAAAAAABAAAAAAAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VR0i64V0P0FcAAGi5QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACDSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEA1GAtpo/0VtDXBn2OuqfnpbY8H5UUpsHPGWe2rNhwFL7uJP22NmRyIYUujO1H8e+F5lfUJcRz7+r11AP4/bkQMAAAAAAAAAAF+pQvBlBTRo0x3YPLkMnib4tbWmAGyNx9UrPdf6FDWsAAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENEQjRBVTM0WE9FU1BIT1lNVkM0TVpRWUZXNkxCUFlHNVZSR08yT1dCVlI0NkdPQUFJQklRNEdEAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAE2hvbWVfZG9tYWluX2FkZHJlc3MAAAAADgAAADhHREpMQllZS01DWE5WVk5BQk9FNjZOWVhRR0lBNUFDNUQyMjNaMktGNlpFWUs0VUJDQTdGS0xURwAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIwNjAyMTQxMTUAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAAA="
+  "authorization_entries": "AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9hkIHjaHHUrOAA1uEAAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu/mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAECp1BOXU7cMGlLHreuOVtW1ViMG35W+ddffWV1WkCrO1RDVuVM116VfmcQrCb7dpCM0Hb0gduLxOS/vjLBDk5sGAAAAAAAAAAFIjVG/p1z7omb2hs0qauxyzBLhOQ/3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyODAwMzA3NDE4AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra18BezQ1/TMvQANbgcAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq/ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAJQ6tyKk8igNCVGb46rx/0lY8XUc/EQhytIElC8LiN2oG+H5c1y1OA/khmpn55ckVJGdqcKsB7uSgdvEnow9aDAAAAAAAAAABSI1Rv6dc+6Jm9obNKmrscswS4TkP95tXhmbRvBKs+JoAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjgwMDMwNzQxOAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABZ3ZWJfYXV0aF9kb21haW5fc2lnbmVyAAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA=="
 }
 ```
 
-You can examine the example credentials in the
-[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAHDwFN8u4knndhlRcZmGC28sL8G7WJnadYNY88ZwAICiAhjuHNQ4DVQAAGi7gAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACCLcZbWB5Tc+LwIlJMazXz6KECPC89cSo589hUfJAOrhwAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEDIHVoFpnEUUmqOzTCzsYqu3naPvxUh1BmreIjoBbgXcbsCulvxQQdWKq40JWxNuacxOnoiOy1qyRD2ylTbirgBAAAAAAAAAAF+pQvBlBTRo0x3YPLkMnib4tbWmAGyNx9UrPdf6FDWsAAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENEQjRBVTM0WE9FU1BIT1lNVkM0TVpRWUZXNkxCUFlHNVZSR08yT1dCVlI0NkdPQUFJQklRNEdEAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAE2hvbWVfZG9tYWluX2FkZHJlc3MAAAAADgAAADhHREpMQllZS01DWE5WVk5BQk9FNjZOWVhRR0lBNUFDNUQyMjNaMktGNlpFWUs0VUJDQTdGS0xURwAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIwNjAyMTQxMTUAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAAAAAAABAAAAAAAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VR0i64V0P0FcAAGi5QAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACDSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAEA1GAtpo//0VtDXBn2OuqfnpbY8H5UUpsHPGWe2rNhwFL7uJP22NmRyIYUujO1H8e+F5lfUJcRz7+r11AP4//bkQMAAAAAAAAAAF+pQvBlBTRo0x3YPLkMnib4tbWmAGyNx9UrPdf6FDWsAAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENEQjRBVTM0WE9FU1BIT1lNVkM0TVpRWUZXNkxCUFlHNVZSR08yT1dCVlI0NkdPQUFJQklRNEdEAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAE2hvbWVfZG9tYWluX2FkZHJlc3MAAAAADgAAADhHREpMQllZS01DWE5WVk5BQk9FNjZOWVhRR0lBNUFDNUQyMjNaMktGNlpFWUs0VUJDQTdGS0xURwAAAA8AAAAFbm9uY2UAAAAAAAAOAAAACjIwNjAyMTQxMTUAAAAAAA8AAAAPd2ViX2F1dGhfZG9tYWluAAAAAA4AAAAObG9jYWxob3N0OjgwODAAAAAAAAA=&type=SorobanAuthorizationEntry;;)
+You can examine the example signed entries in the
+[XDR Viewer](https://lab.stellar.org/xdr/view?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;&xdr$blob=AAAAAQAAAAGWcNI4dwOklpzAc0hlSYazv+tjfedqewN928nnaj1h9hkIHjaHHUrOAA1uEAAAABAAAAABAAAAAQAAABEAAAABAAAAAgAAAA8AAAAKcHVibGljX2tleQAAAAAADQAAACBz0HEh6FBFytJtXlRaOYPu//mZmtR5jgxw2rwoFDUgFXAAAAA8AAAAJc2lnbmF0dXJlAAAAAAAADQAAAECp1BOXU7cMGlLHreuOVtW1ViMG35W+ddffWV1WkCrO1RDVuVM116VfmcQrCb7dpCM0Hb0gduLxOS//vjLBDk5sGAAAAAAAAAAFIjVG//p1z7omb2hs0qauxyzBLhOQ//3m1eGZtG8Eqz4mgAAAA93ZWJfYXV0aF92ZXJpZnkAAAAAAQAAABEAAAABAAAABQAAAA8AAAAHYWNjb3VudAAAAAAOAAAAOENDTEhCVVJZTzRCMkpGVTRZQlpVUVpLSlEyWjM3MjNEUFhUV1U2WURQWE40VFozS0hWUTdOT1VMAAAADwAAAAtob21lX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAABW5vbmNlAAAAAAAADgAAAAoyODAwMzA3NDE4AAAAAAAPAAAAD3dlYl9hdXRoX2RvbWFpbgAAAAAOAAAADmxvY2FsaG9zdDo4MDgwAAAAAAAPAAAAFndlYl9hdXRoX2RvbWFpbl9zaWduZXIAAAAAAA4AAAA4R0NITEhEQk9LRzJKV01KUUJUTFNMNVhHNk5PN0VTWEkyVEFRS1pYQ1hXWEI1V0kyWDZXMjMzUFIAAAAAAAAAAQAAAAAAAAAAjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra18BezQ1//TMvQANbgcAAAAQAAAAAQAAAAEAAAARAAAAAQAAAAIAAAAPAAAACnB1YmxpY19rZXkAAAAAAA0AAAAgjrOMLlG0mzEwDNcl9ubzXfJK6NTBBWbiva4e2Rq//ra0AAAAPAAAACXNpZ25hdHVyZQAAAAAAAA0AAABAJQ6tyKk8igNCVGb46rx//0lY8XUc//EQhytIElC8LiN2oG+H5c1y1OA//khmpn55ckVJGdqcKsB7uSgdvEnow9aDAAAAAAAAAABSI1Rv6dc+6Jm9obNKmrscswS4TkP95tXhmbRvBKs+JoAAAAPd2ViX2F1dGhfdmVyaWZ5AAAAAAEAAAARAAAAAQAAAAUAAAAPAAAAB2FjY291bnQAAAAADgAAADhDQ0xIQlVSWU80QjJKRlU0WUJaVVFaS0pRMlozNzIzRFBYVFdVNllEUFhONFRaM0tIVlE3Tk9VTAAAAA8AAAALaG9tZV9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAAAVub25jZQAAAAAAAA4AAAAKMjgwMDMwNzQxOAAAAAAADwAAAA93ZWJfYXV0aF9kb21haW4AAAAADgAAAA5sb2NhbGhvc3Q6ODA4MAAAAAAADwAAABZ3ZWJfYXV0aF9kb21haW5fc2lnbmVyAAAAAAAOAAAAOEdDSExIREJPS0cySldNSlFCVExTTDVYRzZOTzdFU1hJMlRBUUtaWENYV1hCNVdJMlg2VzIzM1BSAAAAAA==&type=SorobanAuthorizationEntry;;)
 
 #### Response
 
@@ -357,12 +353,12 @@ verification and nonce handling.
 
 The contract must implement the `web_auth_verify` function with the following signature. Within this function, the
 contract should call `require_auth` on the address to ensure the client has authorized the operation, and call
-`require_auth` on the home domain address so that the **Server** can verify that the challenge has not been tampered.
+`require_auth` on the **Server Account** so that the **Server** can verify that the challenge has not been tampered.
 
-If the **Server** supports client domain verification, the contract can optionally require a signature from the
-`client_domain_address`. All other arguments are ignored by the contract.
+If the **Server** supports client domain verification, the contract can optionally call `require_auth` on the client
+domain address. All other arguments are ignored by the contract.
 
-The server can optionally include a `nonce` in the `web_auth_verify` function arguments. The `nonce` is a random string
+The server should include a `nonce` in the `web_auth_verify` function arguments. The `nonce` is a random string
 generated by the **Server** and included in the challenge transaction. The `nonce` is verified when the **Client**
 submits signed challenge to the **Server**. The `nonce` is used to prevent replay attacks.
 
@@ -384,11 +380,12 @@ impl WebAuthContract {
     ///
     /// Arguments:
     /// - account: The client account address
-    /// - home_domain_address: The home domain address
+    /// - home_domain: The home domain
     /// - web_auth_domain: The server's domain
+    /// - web_auth_domain_signer: The server's SIGNING_KEY
     /// - client_domain: The client domain (optional)
-    /// - client_domain_address: The client domain address (optional)
-    /// - nonce: A random string generated by the server to prevent replay attacks (optional)
+    /// - client_domain_signer: The client domain's SIGNING_KEY (optional)
+    /// - nonce: A random string generated by the server to prevent replay attacks
     pub fn web_auth_verify(env: Env, args: Map<Symbol, String>) -> Result<(), WebAuthError> {
         if let Some(address) = args.get(Symbol::new(&env, "account")) {
             let addr = Address::from_string(&address);
@@ -397,17 +394,17 @@ impl WebAuthContract {
             return Err(WebAuthError::MissingArgument);
         }
 
-        if let Some(home_domain_address) = args.get(Symbol::new(&env, "home_domain_address")) {
-            let home_domain_addr = Address::from_string(&home_domain_address);
-            home_domain_addr.require_auth();
+        if let Some(web_auth_domain_signer) = args.get(Symbol::new(&env, "web_auth_domain_signer")) {
+            let addr = Address::from_string(&web_auth_domain_signer);
+            addr.require_auth();
         } else {
             return Err(WebAuthError::MissingArgument);
         }
 
         // Optional client domain verification
-        if let Some(client_domain_address) = args.get(Symbol::new(&env, "client_domain_address")) {
-            let client_domain_addr = Address::from_string(&client_domain_address);
-            client_domain_addr.require_auth();
+        if let Some(client_domain_signer) = args.get(Symbol::new(&env, "client_domain_signer")) {
+            let addr = Address::from_string(&client_domain_signer);
+            addr.require_auth();
         }
 
         Ok(())
@@ -415,17 +412,26 @@ impl WebAuthContract {
 }
 ```
 
-## Client Recommendations
+## Replay Prevention
 
-To prevent unintended side effects in case the `web_auth_verify` invocation operation is executed on the network, the
-**Client** should consider implementing the following recommendations in addition to verifying the function arguments
-and sub-invocations.
+A replay attack is when an attacker uses a previously signed challenge to impersonate a **Client** after the original
+authentication was completed. Both the **Server** and the **Client** share responsibility for preventing replay attacks.
+Using only one of these approaches described below is insufficient to protect against replay attacks; both must be
+implemented together for complete protection.
 
-### Signature Expiration Ledger
+### Nonce Verification
 
-When signing the authorization entries, the **Client** should set the signature expiration ledger to the current ledger
-plus a buffer. This ensures the signature remains valid for an appropriate duration while preventing replay attacks.
-Setting this to the current ledger plus 1 is a reasonable default.
+The **Server** must generate unique nonces for each challenge request and include them in the challenge response. The
+**Server** must verify that the nonce is present in the signed challenge and has not been used before. This ensures that
+a signed challenge can only be used once. Additionally, the **Server** should reject any [token](#token) requests that
+include a nonce that is too old. This limits the time window an attack can use a signed challenge if intercepted or
+stolen.
+
+### Setting Signature Expiration Ledger
+
+The **Client** should set the signature expiration ledger to a near-future ledger, minimizing the window where a
+signature can be reused if nonces verification is improperly implemented. Setting this to the current ledger plus 1 is a
+reasonable default.
 
 ## Verification
 
@@ -435,7 +441,7 @@ A web service requiring SEP-45 authentication may want to attribute each HTTP re
 **Client** software. For example, a web service may want to offer reduced fees for the users of a specific **Client**.
 
 In order to use this optional feature, the organization that provides the **Client** must host a
-[SEP-1 stellar.toml](sep-0001.md) file containing a `SIGNING_KEY` attribute (i.e. the **Client Domain Address**). The
+[SEP-1 stellar.toml](sep-0001.md) file containing a `SIGNING_KEY` attribute (i.e. the **Client Domain Account**). The
 `SIGNING_KEY` attribute must be a Stellar public key in the form of a `G` address. The secret key paired with the
 `SIGNING_KEY` should be protected as anyone in possession of the secret can verify the **Client Domain**.
 

--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -57,8 +57,8 @@ The discovery flow is as follows:
 
 1. The **Client** retrieves the `stellar.toml` from the **Home Domain** in accordance with
    [SEP-1 stellar.toml](sep-0001.md).
-1. The **Client** looks up the `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID` and `SIGNING_KEY` (i.e. **Home
-   Domain Address**) from the `stellar.toml`.
+1. The **Client** looks up the `WEB_AUTH_FOR_CONTRACTS_ENDPOINT`, `WEB_AUTH_CONTRACT_ID` and `SIGNING_KEY` (i.e.
+   **Server Account**) from the `stellar.toml`.
 
 The authentication flow is as follows:
 
@@ -84,8 +84,8 @@ The authentication flow is as follows:
    Account** and contains a valid signature from the **Server Account**
 1. The **Client** signs the authorization entry where `credentials.address.address` is the **Client Account** using the
    secret key(s) of the signer(s) for the **Client Account**
-   - Note: **Client** signatures may not be required if the contract's `__check_auth` implementation does not require
-     them
+   - Note: **Client** signatures may not be required if the **Client** contract's `__check_auth` implementation does not
+     require them
 1. The **Client** obtains a signature from the **Client Domain Account** for the authorization entry where
    `credentials.address.address` is the **Client Domain Account** if the **Client** included a client domain in the
    request

--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -421,17 +421,26 @@ implemented together for complete protection.
 
 ### Nonce Verification
 
-The **Server** must generate unique nonces for each challenge request and include them in the challenge response. The
-**Server** must verify that the nonce is present in the signed challenge and has not been used before. This ensures that
-a signed challenge can only be used once. Additionally, the **Server** should reject any [token](#token) requests that
-include a nonce that is too old. This limits the time window an attack can use a signed challenge if intercepted or
-stolen.
+The **Server** must provide a nonce for each challenge request. The nonce should be a unique value, even for the
+identical requests. The **Server** should verify that the nonce is present in the signed challenge and has not been used
+before. This ensures that a signed challenge can only be used once. Additionally, the **Server** should reject any
+[token](#token) requests that include a nonce that is too old. This limits the time window an attack can use a signed
+challenge if intercepted or stolen.
+
+Storing and verifying all nonces for uniqueness might not be practical for every implementation. Therefore, servers
+should not depend solely on nonce verification.
 
 ### Setting Signature Expiration Ledger
 
-The **Client** should set the signature expiration ledger to a near-future ledger, minimizing the window where a
-signature can be reused if nonces verification is improperly implemented. Setting this to the current ledger plus 1 is a
-reasonable default.
+- **Client Side:** The **Client** should set the signature expiration ledger to a near-future ledger (for example, the
+  current ledger plus 1). This limits the window in which a signature can be reused.
+- **Server Side:** The **Server** should either:
+  - Use its own signature expiration ledger on its challenge signature to restrict its validity, and/or
+  - Reject client signatures that use a signature expiration ledger that it deems too old.
+
+In summary, even though nonces are always included in challenge requests to ensure signature uniqueness, both the
+**Server** and the **Client** must, at a minimum, enforce signature expiration ledgers to effectively narrow the replay
+window.
 
 ## Verification
 


### PR DESCRIPTION
- Rename `Home Domain Address` to `Server Account`
- Rename `Client Domain Address` to `Client Domain Account`
- Rename `home_domain_address` argument to `web_auth_domain_account`
- Rename `client_domain_address` argument to `client_domain_account`
- Add `home_domain` argument to `web_auth_verify` function
- Mark nonce verification as required and add a replay prevention section
- Clarify client domain signing sentence