### PR TITLE
Update TTL reconciliation logic in CAP-63.

### DIFF
--- a/core/cap-0063.md
+++ b/core/cap-0063.md
@@ -212,33 +212,51 @@ Then all the operations must be applied and the changes in *non-TTL* ledger entr
 
 Currently the changes to the entry TTL are immediately applied to the ledger state, in the same way as changes to any other ledger entry. However, the protocol allows increasing the TTL even for the entries that have been declared in the footprint as read-only. Thus if we wanted to preserve the current behavior, all the read-only footprint entries would potentially be read-write, and thus only transactions with non-overlapping footprints could belong to different clusters. This is not optimal for parallelization, given that common entries such as Stellar Asset Contract instances and some popular Wasms can be referenced by multiple transactions, but they're always or almost only read-only.
 
-Thus, this CAP proposes a new way for applying the TTLs changes that makes changes to read-only entries' TTL changes commutative. The proposed TTL update algorithm is based on two ideas:
-- For any key, a TTL update should only be observed either when corresponding entry is being modified (i.e. is a part of the read-write footprint), or after executing all the transactions.
-- Reduce fee waste - if a TTL change is not immediately observed, it should be accumulated instead and applied later instead (as opposed to e.g. just using the maximum TTL extension among all the transactions).
+Thus, this CAP proposes a new way for applying the TTLs changes that makes changes to read-only entries' TTL changes commutative. The proposed TTL update algorithm ensures that the TTL changes are only observable in the following cases:
+- When the corresponding entry is being modified in the transaction (i.e. is a part of the read-write footprint)
+- After executing all the transactions
 
 The detailed new algorithm is as follows:
 
 - After fees have been withdrawn, but before applying any operations:    
   - Snapshot the initial `liveUntilLedger` of every entry within the stage's footprint and store it in 'current TTL map' keyed by the TTL entry keys
-  - Also initialize an empty 'TTL extension map' that has a value of 0 for every key in the footprint
+  - Also prepare an empty 'read-only update map' that contains the results values of `liveUntilLedgers`.
 - When applying a Soroban operation:
+    - Observe the relevant TTL changes thus far. For every key in the read-write footprint:
+      - If 'read-only update map' contains the key, set the value in 'current TTL map' to the value from 'read-only update map'
+        - Note, that this can't decrease the current TTL of the entry
+      - Remove the key from 'read-only update map'
   - Before applying the actual operation logic:
-    - When reading the initial state of the entries, use 'current TTL map' to determine the `liveUntilLedger` of every entry in the footprint.
-    - For every key in the read-write footprint: 
-      - Add the value corresponding to the key in 'TTL extension map' to the `liveUntilLedger` of the entry
-      - Set the value corresponding to the key in 'TTL extension map' to 0
+    - When reading the initial state of the entries, use 'current TTL map' to determine the `liveUntilLedger` of every entry in the footprint
   - If an operation succeeds and ledger changes caused by the operation must be materialized:
-    - For every key in the read-only footprint that had its `liveUntilLedger` increased:
-      - Add the `new_liveUntilLedger - initial_liveUntilLedger` to the value corresponding to the key in 'TTL extension map'
-      - Clamp the updated value in the map to at most `maxEntryTTL` from the `StateArchivalSettings` configuration setting entry
-    - For every key in the read-write footprint (unconditionally):        
-      - Set the value corresponding to the key in 'current TTL map' to the new `liveUntilLedger` of the entry
+    - For every key in the read-only footprint that had its `liveUntilLedger` updated:
+      - Set the the value corresponding to the key in 'read-only update map' to `max(updated_liveUntilLedger, existing_value_liveUntilLedger)` (if key is missing from the map, just use `updated_liveUntilLedger`)
+    - For every key in the read-write footprint (unconditionally):
+      - If the entry still exists, set the value corresponding to the key in 'current TTL map' to the new `liveUntilLedger` of the entry
+      - If the entry was deleted, also removed the key from 'current TTL map'      
     - _unchanged_ The effective rent fee for the operation is still computed based on the initial state of the entry at operation start and the end state of the entry.
       - Notice, however, that the initial TTL of the entry itself is defined differently now.
-- After applying all the operations in the phase:
-  - Add the values in 'TTL extension map' to `liveUntilLedger` of the corresponding entries
+- After applying all the Soroban operations in the phase:
+  - Iterate all the remaining keys in the 'read-only update map' and update the `liveUntilLedger` for the corresponding entries with the value from the map
+    - Note, that this can't decrease the current TTL of the entry
 
 Notice, that while the algorithm is defined in terms of a single mutable 'current TTL map', in implementation it can actually be separated into 2 parts: a fully immutable part for the entries that are always read-only within a stage, and a mutable part that may only be modified while applying transactions in a single cluster. Thus when applying transactions in parallel, no locking is necessary to update the maps during the operation application. The entries might move between maps only in-between the stages. 
+
+##### TTL ledger change semantics
+
+Transaction meta for every Soroban transaction will contain a 'correct' TTL change from the perspective of that transaction. That means that the initial entry TTLs are what the transaction has observed before execution, the final TTLs are what the transaction has updated them too, and the rent fee corresponds to the TTL changes. However, if a meta consumer wants to track the TTL of the entry after applying _all_ the transactions in the ledger, they will need to never decrease the TTL of the entries they track. For example:
+
+- Transaction 1 extends the TTL for entry E by 1000 ledgers and sets it `liveUntilLedger` to `currentLedgerSeq + 1000`
+- Transaction 2 extends the TTL for entry E by 500 ledgers and sets it `liveUntilLedger` to `currentLedgerSeq + 500`
+- The final `liveUntilLedger` for E is `currentLedgerSeq + 1000`
+
+The only way the TTL of an entry can ever go down after applying a ledger is if an entry has been deleted by one transaction and then recreated by another transaction. Thus the conceptual algorithm for tracking entry TTLs using the transaction meta is as follows:
+
+- Maintain a map from TTL keys to the corresponding `liveUntilLedger` values
+- For every transaction in apply order:
+  - For every TTL entry update:
+    - If TTL has been updated, set the value corresponding to the TTL key to `max(updated_liveUntilLedger, existing_value_liveUntilLedger)` (if key is missing from the map, just use `updated_liveUntilLedger`)
+    - If a TTL entry has been removed, remove the corresponding key from the map
 
 #### Parallel application of operations
 


### PR DESCRIPTION
Unfortunately, cumulative updates would require some significant meta structure changes. That's why I'm using the max aggregation instead. I've also added a section on the updated meta semantics (unfortunately there is no way to make the meta processing completely trivial for TTL).