### PR TITLE
SEP-23: Add Liquidity Pool and Claimable Balance Strkeys

### DIFF
--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -7,8 +7,8 @@ Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcc
 Track: Standard
 Status: Active
 Created: 2019-09-16
-Updated: 2022-12-02
-Version: 1.2.0
+Updated: 2025-02-07
+Version: 1.3.0
 Discussion: https://groups.google.com/g/stellar-dev
 ```
 
@@ -38,15 +38,17 @@ Each strkey has its type encoded in the top 5 bits of the version byte, which is
 possible "base" values (top 5 bits) of the version byte, which determine the first character of the base-32 encoding of
 the key, are listed here:
 
-| Key type              | Base value | First char | Muxed | Alg  |
-| --------------------- | ---------- | ---------- | ----- | ---- |
-| STRKEY_PUBKEY         | 6 << 3     | G          | no    | PK   |
-| STRKEY_MUXED          | 12 << 3    | M          | yes   | PK   |
-| STRKEY_PRIVKEY        | 18 << 3    | S          | no    | PK   |
-| STRKEY_PRE_AUTH_TX    | 19 << 3    | T          | no    | Hash |
-| STRKEY_HASH_X         | 23 << 3    | X          | no    | Hash |
-| STRKEY_SIGNED_PAYLOAD | 15 << 3    | P          | no    | PK   |
-| STRKEY_CONTRACT       | 2 << 3     | C          | no    | Hash |
+| Key type                 | Base value | First char | Muxed | Alg  |
+| ------------------------ | ---------- | ---------- | ----- | ---- |
+| STRKEY_PUBKEY            | 6 << 3     | G          | no    | PK   |
+| STRKEY_MUXED             | 12 << 3    | M          | yes   | PK   |
+| STRKEY_PRIVKEY           | 18 << 3    | S          | no    | PK   |
+| STRKEY_PRE_AUTH_TX       | 19 << 3    | T          | no    | Hash |
+| STRKEY_HASH_X            | 23 << 3    | X          | no    | Hash |
+| STRKEY_SIGNED_PAYLOAD    | 15 << 3    | P          | no    | PK   |
+| STRKEY_CONTRACT          | 2 << 3     | C          | no    | Hash |
+| STRKEY_LIQUIDITY_POOL    | 11 << 3    | L          | no    | Hash |
+| STRKEY_CLAIMABLE_BALANCE | 1 << 3     | B          | no    | Hash |
 
 The low 3 bits of the version byte encode an algorithm specifier. Thus, a version byte becomes the bitwise OR of a base
 value above and one of the algorithm specifiers from the two tables below. (These tables will be extended when Stellar
@@ -186,7 +188,40 @@ software to accept the invalid test cases, which could in turn cause security pr
    }
    ```
 
+1. Valid liquidity pool address
+
+   - Strkey `LA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUPJN`
+   - type: `HASH_TYPE_SHA256`
+   - hash:
+
+   ```{.c}
+   {
+       0x3f, 0x0c, 0x34, 0xbf, 0x93, 0xad, 0x0d, 0x99,
+       0x71, 0xd0, 0x4c, 0xcc, 0x90, 0xf7, 0x05, 0x51,
+       0x1c, 0x83, 0x8a, 0xad, 0x97, 0x34, 0xa4, 0xa2,
+       0xfb, 0x0d, 0x7a, 0x03, 0xfc, 0x7f, 0xe8, 0x9a,
+   }
+   ```
+
+1. Valid claimable balance address
+
+   - Strkey `BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TU`
+   - type: `HASH_TYPE_SHA256`
+   - claimable balance type: `v0`
+   - hash:
+
+   ```{.c}
+   {
+       0x3f, 0x0c, 0x34, 0xbf, 0x93, 0xad, 0x0d, 0x99,
+       0x71, 0xd0, 0x4c, 0xcc, 0x90, 0xf7, 0x05, 0x51,
+       0x1c, 0x83, 0x8a, 0xad, 0x97, 0x34, 0xa4, 0xa2,
+       0xfb, 0x0d, 0x7a, 0x03, 0xfc, 0x7f, 0xe8, 0x9a,
+   }
+   ```
+
 ### Invalid test cases
+
+# TODO: Add invalid test cases for liquidity pool and claimable balance.
 
 1. Invalid length (Ed25519 should be 32 bytes, not 5)
 

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -316,6 +316,7 @@ There are many implementations of strkey in Stellar SDKs. As a reference, the fo
 up-to-date with this SEP.
 
 https://github.com/xdrpp/stc
+
 https://github.com/stellar/rs-stellar-strkey
 
 ## Security Concerns

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -69,8 +69,8 @@ The following steps transform a binary key into a strkey:
 
 2.  Append the binary bytes of the key (e.g., 32-bytes for ED25519, 32-bytes for SHA256).
 
-    If we are encoding a claimable balance, the key is 33-bytes: 1-byte value indicating the type of claimable balance,
-    where 0 maps to V0, and a 32-byte SHA256 hash.
+    If we are encoding a claimable balance, the binary bytes of the key is 33-bytes: 1-byte value indicating the type of
+    claimable balance, where 0 maps to V0, and a 32-byte SHA256 hash.
 
 3.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
     first).

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -67,23 +67,23 @@ The following steps transform a binary key into a strkey:
 1.  Start with the appropriate version byte computed by the OR of a key type base value and algorithm selector from the
     tables above.
 
-2.  If we are encoding a claimable balance, append a 1-byte value indicating the type of claimable balance, where 0 maps
-    to V0.
+2.  Append the binary bytes of the key (e.g., 32-bytes for ED25519, 32-bytes for SHA256).
 
-3.  Append the binary bytes of the key (e.g., 32-bytes for ED25519).
+    If we are encoding a claimable balance, the key is 33-bytes: 1-byte value indicating the type of claimable balance,
+    where 0 maps to V0, and a 32-byte SHA256 hash.
 
-4.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
+3.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
     first).
 
-5.  If we are encoding a signed payload, append a 4-byte length in network byte order (most significant byte first) that
+4.  If we are encoding a signed payload, append a 4-byte length in network byte order (most significant byte first) that
     holds the length of the payload, then append the payload, and finally zero padding of 0 to 3 zero bytes such that
     the total number of bytes of the payload plus the zero padding is a multiple of four.
 
-6.  Compute a 16-bit CRC16 checksum of the result of the prior step (using polynomial x<sup>16</sup> + x<sup>12</sup> +
+5.  Compute a 16-bit CRC16 checksum of the result of the prior step (using polynomial x<sup>16</sup> + x<sup>12</sup> +
     x<sup>5</sup> \+ 1). Append the two-byte checksum to the result of the previous step (e.g., producing a 35-byte
     quantity for a non-multiplexed ED25519 public key, or 43 byte quantity for a multiplexed one).
 
-7.  Encode the result of the previous step using
+6.  Encode the result of the previous step using
     [RFC4648 base-32 encoding](https://tools.ietf.org/html/rfc4648#section-6) without padding. For example, a
     multiplexed address yields a 43-byte quantity whose base-32 encoding is 69 bytes with no trailing `=` signs because
     no padding is allowed.

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -69,8 +69,8 @@ The following steps transform a binary key into a strkey:
 
 2.  Append the binary bytes of the key (e.g., 32-bytes for ED25519, 32-bytes for SHA256).
 
-    If we are encoding a claimable balance, the binary bytes of the key is 33-bytes: 1-byte value indicating the type of
-    claimable balance, where 0 maps to V0, and a 32-byte SHA256 hash.
+    If we are encoding a claimable balance, the binary bytes of the key has a length of 33-bytes: 1-byte value
+    indicating the type of claimable balance, where 0x00 maps to V0, and a 32-byte SHA256 hash.
 
 3.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
     first).

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -67,8 +67,8 @@ The following steps transform a binary key into a strkey:
 1.  Start with the appropriate version byte computed by the OR of a key type base value and algorithm selector from the
     tables above.
 
-2.  If we are encoding a claimable balance, append a 1-byte value indicating the
-    type of claimable balance, where 0 maps to V0.
+2.  If we are encoding a claimable balance, append a 1-byte value indicating the type of claimable balance, where 0 maps
+    to V0.
 
 3.  Append the binary bytes of the key (e.g., 32-bytes for ED25519).
 

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -224,8 +224,6 @@ software to accept the invalid test cases, which could in turn cause security pr
 
 ### Invalid test cases
 
-# TODO: Add invalid test cases for liquidity pool and claimable balance.
-
 1. Invalid length (Ed25519 should be 32 bytes, not 5)
 
    - Strkey: `GAAAAAAAACGC6`
@@ -282,6 +280,14 @@ software to accept the invalid test cases, which could in turn cause security pr
    - Strkey:
      `PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6`
 
+1. The unused trailing 2-bits must be zero in the encoding of the last symbol.
+
+   - Strkey: `BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV`
+
+1. Invalid claimable balance type (first byte of binary key is not 0)
+
+   - Strkey: `BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA`
+
 You can paste these invalid strkeys more conveniently into a unit test using the following array:
 
 ```{.c}
@@ -299,6 +305,8 @@ You can paste these invalid strkeys more conveniently into a unit test using the
     "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IAAAAAAAAPM",
     "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4Z2PQ",
     "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAOQCAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DXFH6",
+    "BAAD6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGR4TV",
+    "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA",
 }
 ```
 

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -316,6 +316,7 @@ There are many implementations of strkey in Stellar SDKs. As a reference, the fo
 up-to-date with this SEP.
 
 https://github.com/xdrpp/stc
+https://github.com/stellar/rs-stellar-strkey
 
 ## Security Concerns
 

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -67,20 +67,23 @@ The following steps transform a binary key into a strkey:
 1.  Start with the appropriate version byte computed by the OR of a key type base value and algorithm selector from the
     tables above.
 
-2.  Append the binary bytes of the key (e.g., 32-bytes for ED25519).
+2.  If we are encoding a claimable balance, append a 1-byte value indicating the
+    type of claimable balance, where 0 maps to V0.
 
-3.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
+3.  Append the binary bytes of the key (e.g., 32-bytes for ED25519).
+
+4.  If we are encoding a multiplexed address, append an 8-byte memo ID in network byte order (most significant byte
     first).
 
-4.  If we are encoding a signed payload, append a 4-byte length in network byte order (most significant byte first) that
+5.  If we are encoding a signed payload, append a 4-byte length in network byte order (most significant byte first) that
     holds the length of the payload, then append the payload, and finally zero padding of 0 to 3 zero bytes such that
     the total number of bytes of the payload plus the zero padding is a multiple of four.
 
-5.  Compute a 16-bit CRC16 checksum of the result of the prior step (using polynomial x<sup>16</sup> + x<sup>12</sup> +
+6.  Compute a 16-bit CRC16 checksum of the result of the prior step (using polynomial x<sup>16</sup> + x<sup>12</sup> +
     x<sup>5</sup> \+ 1). Append the two-byte checksum to the result of the previous step (e.g., producing a 35-byte
     quantity for a non-multiplexed ED25519 public key, or 43 byte quantity for a multiplexed one).
 
-6.  Encode the result of the previous step using
+7.  Encode the result of the previous step using
     [RFC4648 base-32 encoding](https://tools.ietf.org/html/rfc4648#section-6) without padding. For example, a
     multiplexed address yields a 43-byte quantity whose base-32 encoding is 69 bytes with no trailing `=` signs because
     no padding is allowed.


### PR DESCRIPTION
### What
Add two new strkey types for liquidity pool and claimable balance, including examples of valid and invalid addresses.

### Why
In support of the upcoming changes to SEP-23 for CAP-67.

### Related

- https://github.com/stellar/rs-stellar-strkey/pull/74

### Todo

- [x] Add invalid test cases.
- [x] Validate with rs-stellar-strkey implementation, tests, and fuzzing. 
- [ ] Get agreement and sign off prior to merge from reviewers involved in CAP-67.