### PR TITLE
SEP-45: Handle `require_auth` in `__check_auth`

### DIFF
--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -89,34 +89,40 @@ The authentication flow is as follows:
 1. The **Client** obtains a signature from the **Client Domain Address** for the authorization entry where
    `credentials.address.address` is the **Client Domain Address** if the **Client** included a client domain in the
    request
-1. The **Client** simulates the transaction with the signed authorization entries and verifies the following to ensure
+1. If the **Client** contract's `__check_auth` implementation requires additional signed authorization entries, the
+   **Client** signs them and includes them in the authorization entry list
+1. The **Client** simulates the transaction with all signed authorization entries and verifies the following to ensure
    the transaction does not have any unintended side effects:
    - The transaction's ledger footprint `read_write` set contains only `contract_data` entries where:
      - The `contract` is the **Client Account** address, and the `key` is `ledger_key_nonce`.
      - The `contract` is the **Home Domain Address**, and the `key` is `ledger_key_nonce`.
      - (Optional) if an authorization entry for the **Client Domain Address** was present in the challenge, the
        `contract` is the **Client Domain Address**, and the `key` is `ledger_key_nonce`.
-1. The **Client** submits the signed authorization entries back to the **Server** using [`token`](#token) endpoint
-1. The **Server** extracts the arguments from the authorization entries returned by the client
-1. The **Server** verifies that the `contract_address` in each authorization entry matches the `WEB_AUTH_CONTRACT_ID`
-   from the **Server**'s `stellar.toml`
-1. The **Server** verifies that the `function_name` in each authorization entry is `web_auth_verify`
-1. The **Server** verifies that the `args` map in each authorization entry match the expected values and are the same
-   across all authorization entries:
-   1. The `account` value matches the **Client Account** address
-   1. The `home_domain` value matches the **Home Domain**
-   1. The `home_domain_address` value matches the **Home Domain Address**
-   1. The `web_auth_domain` value matches the **Server**'s domain
-   1. The `client_domain_address` value matches the **Client Domain Address** if the **Client** included a
-      `client_domain` in the request, otherwise it is not present
-1. (Optional) The **Server** verifies that the `nonce` argument is the same across all authorization entries and is
-   unique
+     - If the **Client** included additional authorization entries, the `contract` is the `credentials.address.address`
+       of the additional authorization entry, and the `key` is `ledger_key_nonce`.
+1. The **Client** submits all signed authorization entries back to the **Server** using [`token`](#token) endpoint
+1. The **Server** verifies there are authorization entries where `contract_address` in each authorization entry matches
+   the `WEB_AUTH_CONTRACT_ID` from the **Server**'s `stellar.toml` and for each matching authorization entry:
+   1. The **Server** verifies that the `function_name` in each authorization entry is `web_auth_verify`
+   1. The **Server** extracts the arguments from the authorization entries returned by the client
+   1. The **Server** verifies that the `args` map in each authorization entry match the expected values and are the same
+      across all authorization entries:
+      - The `account` value matches the **Client Account** address
+      - The `home_domain` value matches the **Home Domain**
+      - The `home_domain_address` value matches the **Home Domain Address**
+      - The `web_auth_domain` value matches the **Server**'s domain
+      - The `client_domain_address` value matches the **Client Domain Address** if the **Client** included a
+        `client_domain` in the request, otherwise it is not present
+      - (Optional) The **Server** verifies that the `nonce` argument is the same across all authorization entries and is
+        unique
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Home Domain
    Address** and contains a valid signature from the **Home Domain Address**
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Client
    Account** address
 1. The **Server** verifies that there is an authorization entry where `credentials.address.address` is the **Client
    Domain Address** if the arguments included a `client_domain_address`
+1. The **Server** does not validate any additional authorization entries that the **Client** may have included in the
+   request
 1. The **Server** constructs a transaction with a single Invoke Host Function operation where the contract address is
    `WEB_AUTH_CONTRACT_ID` and the function is `web_auth_verify` using the previously extracted arguments and the
    authorization entries returned by the client
@@ -247,18 +253,18 @@ by the server):
 To validate the challenge transaction the following steps are performed by the **Server**. If any of the listed steps
 fail, then the authentication request must be rejected — that is, treated by the **Server** as an invalid input.
 
-1. Extract the arguments from the authorization entries returned by the client;
-1. Verify that the `contract_address` in each authorization entry matches the `WEB_AUTH_CONTRACT_ID` from the
-   **Server**'s `stellar.toml`;
-1. Verify that the `function_name` in each authorization entry is `web_auth_verify`;
-1. Verify that the `args` in each authorization entry match the expected values and is the same across all authorization
-   entries:
-   1. The `home_domain` value matches the **Home Domain**;
-   1. The `home_domain_address` value matches the **Home Domain Address**;
-   1. The `web_auth_domain` value matches the **Server**'s domain;
-   1. The `client_domain` is present if `client_domain_address` is present;
-   1. The `client_domain_address` value matches the **Client Domain Address** if `client_domain` is present;
-1. (Optional) Verify that the `nonce` argument is the same across all authorization entries and is valid;
+1. Verify there are authorization entries where `contract_address` in each authorization entry matches the
+   `WEB_AUTH_CONTRACT_ID` from the **Server**'s `stellar.toml` and for each matching authorization entry:
+   1. Verify that the `function_name` in each authorization entry is `web_auth_verify`;
+   1. Extract the arguments from the authorization entries returned by the client;
+   1. Verify that the `args` in each authorization entry match the expected values and is the same across all
+      authorization entries:
+      - The `home_domain` value matches the **Home Domain**;
+      - The `home_domain_address` value matches the **Home Domain Address**;
+      - The `web_auth_domain` value matches the **Server**'s domain;
+      - The `client_domain` is present if `client_domain_address` is present;
+      - The `client_domain_address` value matches the **Client Domain Address** if `client_domain` is present;
+      - (Optional) Verify that the `nonce` argument is the same across all authorization entries and is valid;
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Home Domain Address** and
    contains a valid signature from the **Home Domain Address**;
 1. Verify that there is an authorization entry where `credentials.address.address` is the **Client Account** address


### PR DESCRIPTION
A recording simulation will not generate authorization entries required by a client contract's `__check_auth` implementation if it has nested `require_auth`s. However, the client must provide these entries in the token request for the enforcing simulation to succeed. These entries do not follow the same format as the auth entries generated by the recording simulation and cannot not be verified by the server when receiving a token request. 

An example of such auth entry looks like:

```json
{
  "credentials": {
    "address": {
      "address": "GB36W6FIDEPLAH2XNM3CKJR4QRCKWVIKQANKOGWJN6NC6J3X5SVMUCPR",
      "nonce": 5990244105667177314,
      "signature_expiration_ledger": 1070813,
      "signature": {
        "vec": [
          {
            "map": [
              {
                "key": {
                  "symbol": "public_key"
                },
                "val": {
                  "bytes": "77eb78a8191eb01f576b3625263c8444ab550a801aa71ac96f9a2f2777ecaaca"
                }
              },
              {
                "key": {
                  "symbol": "signature"
                },
                "val": {
                  "bytes": "5a4147e292b3019fceb86833948642865bdb12ec71e0cf24f3238090461f6f73c2896a132b089a3c642b0b46f1500fa28cffdc4831a73e4cde52e557b9ba9c06"
                }
              }
            ]
          }
        ]
      }
    }
  },
  "root_invocation": {
    "function": {
      "contract_fn": {
        "contract_address": "CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX",
        "function_name": "__check_auth",
        "args": [
          {
            "bytes": "ad31a086eeb53572dd5ac8c06f272c3dd86eb556ee765b9ad1c75b7691c1e6e6"
          }
        ]
      }
    },
    "sub_invocations": []
  }
}
```

`GB36W6FIDEPLAH2XNM3CKJR4QRCKWVIKQANKOGWJN6NC6J3X5SVMUCPR` auth is required for a client contract `CAASCQKVVBSLREPEUGPOTQZ4BC2NDBY2MW7B2LGIGFUPIY4Z3XUZRVTX`'s `__check_auth`.

This PR relaxes the authorization entry verification performed by the server so that arbitrary authorization entries can be included in the token request.