### PR TITLE
Removed evicted state from cap 66

### DIFF
--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -114,9 +114,6 @@ mostly finalized in [CAP-0057](cap-0057.md), it is now appropriate to introduce 
 +// Ledger access settings for contracts.
 +struct ConfigSettingContractLedgerCostExtV0
 +{
-+    // Maximum number of in-memory entry read operations per ledger
-+    uint32 ledgerMaxInMemoryReadEntries;
-+
 +    // Maximum number of in-memory ledger entry read operations per transaction
 +    uint32 txMaxInMemoryReadEntries;
  };
@@ -178,10 +175,10 @@ index 7d32481..f966640 100644
  
 +struct SorobanResourcesExtV0
 +{
-+    // Vector of uint8_t indices representing what Soroban
-+    // entries in the footprint are evicted, based on the
++    // Vector of indices representing what Soroban
++    // entries in the footprint are archived, based on the
 +    // order of keys provided in the readWrite footprint.
-+    opaque<> evictedSorobanEntries;
++    uint32 archivedSorobanEntries<>;
 +};
 +
  // The transaction extension for Soroban.
@@ -208,9 +205,8 @@ Read resources are now separated between memory backed and disk backed state as 
 
 - in-memory entries:
   - Live Soroban entries
-  - Archived entries that have not yet been evicted (i.e. still exist in the live BucketList)
 - disk entries:
-  - Archived Soroban entries that have been evicted
+  - Archived Soroban entries
   - Classic entries
 
 In-memory entries are subject to the corresponding in-memory limits, but charge no entry or byte based
@@ -228,18 +224,23 @@ up to `txMaxReadEntries - 2` classic entries today (all classic entries + wasm +
 carefully measured assuming disk access only, so the addition of in-memory state should not negatively affect the network
 in any way should we maintain these values via disk read limits.
 
-TODO:  In-memory read entries must be measured in order to find a reasonable starting point.
+In-memory read limits are not required wrt execution time, as they are very inexpensive. However, the size of TX footprints
+does impact the cost and complexity of assembling transactions sets. For this reason, no ledger wide read limit is necessary,
+and no byte based read limit is necessary. However, a tx entry limit is still necessary to ensure efficient transaction set
+construction.
 
-#### `evictedEntries` Vector
+TODO: Determine initial tx in-memory read limit.
+
+#### `archivedEntries` Vector
 
 For the purposes of block creation, the `LedgerKey` alone is sufficient to distinguish between classic and Soroban data.
-However, a disk read would be required prior to tx application in order to determine if a Soroban entry was live or evicted.
+However, a disk read would be required prior to tx application in order to determine if a Soroban entry was live or archived.
 This is necessary for determining what resources limits a Soroban key counts towards, but
-exposes a significant DOS angle. To prevent this attack, the footprint must statically declare which entries are live vs. evicted.
+exposes a significant DOS angle. To prevent this attack, the footprint must statically declare which entries are live vs. archived.
 
-This is accomplished via the `evictedEntries` vector. If any evicted Soroban entry is present in a TX's footprint,
-it must provide the `evictedEntries` vector containing the index of each evicted key based on the ordering of the
-readWrite footprint. Because restores are a write operation, no evicted key should be in the readOnly footprint. This vector
+This is accomplished via the `archivedEntries` vector. If any archived Soroban entry is present in a TX's footprint,
+it must provide the `archivedEntries` vector containing the index of each archived key based on the ordering of the
+readWrite footprint. Because restores are a write operation, no archived key should be in the readOnly footprint. This vector
 should contain no classic key indexes, as classic keys are always considered disk reads.
 
 #### Changes to `InvokeHostFunctionOp`
@@ -249,51 +250,64 @@ should contain no classic key indexes, as classic keys are always considered dis
 Whenever `InvokeHostFunctionOp` is applied, any archived state is
 automatically restored prior to host function invocation. This restored state is then accessible to the host function.
 
-Restored state is still subject to the same minimum rent and write fees that exist currently.
+Restored state is still subject to the same minimum rent and write fees that exist currently. All entries being restored
+count towards disk read resources and fees. Even if an entry is archived but not yet evicted such that it technically still
+exists in memory, it is still subject to the same limits and fees as disk based entries in order ot provide a simpler unified
+interface for downstream systems.
 
-If an archived Soroban entry has not yet been evicted and still exists in the live BucketList, it is metered and charged based
-on in-memory read limits and fees. If an archived Soroban entry has been evicted, it is metered and charged based
-on on-disk limits and fees. All evicted keys must be declared in the `evictedEntries` vector via `SorobanResourcesExtV0`.
-If no evicted entries are present in the footprint, `SorobanResourcesExtV0` may be omitted.
+All archived keys must be declared in the `archivedEntries` vector via `SorobanResourcesExtV0`.
+If no archived entries are present in the footprint, `SorobanResourcesExtV0` may be omitted.
 
-##### Incorrect Entries in `evictedEntries` Vector
+##### Incorrect Entries in `archivedEntries` Vector
 
-If a key is not marked as evicted, but the entry is actually evicted, then the TX fails. If a Soroban key is marked as evicted when
-it is not, the transaction does not fail. The entry is treated as if it is evicted from a resource and fee perspective.
+If a key is not marked as archived, but the entry is actually archived, then the TX fails. If a Soroban key is marked as archived when
+it is not, the transaction does not fail. The entry is treated as if it is archived from a resource and fee perspective.
 This is appropriate, as on disk reads are more expensive than in-memory. So long as the TX pays the disk based fees,
 there is no issue with actually loading an in-memory entry.
 
-If a classic key is marked as evicted, the TX fails, as the footprint is malformed.
+If a classic key is marked as archived, the TX fails, as the footprint is malformed.
 
 ##### Failure Codes
 
-If an evicted entry is included in the TX's footprint but is not specified via the `evictedEntries` vector, the
+If an archived entry is included in the TX's footprint but is not specified via the `archivedEntries` vector, the
 tx will fail with the `INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED` code. If there are insufficient resources for entry restoration,
 the tx will fail with the `INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED` code.
 
-If a classic entry is marked as evicted, the TX fails with `INVOKE_HOST_FUNCTION_MALFORMED` during apply time.
+If a classic entry is marked as archived, the TX fails with `INVOKE_HOST_FUNCTION_MALFORMED` during apply time.
 
 ##### Meta
 
-Whenever an entry is restored, it will be emitted as a `LedgerEntryChangeType` of type `LEDGER_ENTRY_RESTORE`.
+Whenever an entry is restored, the data/code entry will be emitted as a `LedgerEntryChangeType` of type `LEDGER_ENTRY_RESTORE`.
 This will include the complete LedgerEntry of the restored entry. It does not matter if the entry has been
-evicted or not, the meta produced will be the same.
+evicted or not, the meta produced will be the same. Additionally, the corresponding `TTL` entry will also be emitted
+as a `LedgerEntryChangeType` of type `LEDGER_ENTRY_RESTORE`.
 
 If a restored entry is modified during host function invocation, another `LedgerEntryChangeType` will be
 emitted corresponding to the entry change in addition to the `LEDGER_ENTRY_RESTORE` restore event.
 This is similar to the current meta schema, where the starting value of a LedgerEntry is emitted as
 `LEDGER_ENTRY_STATE` followed by the change. This is similar, except that `LEDGER_ENTRY_STATE` is replaced
-by `LEDGER_ENTRY_RESTORE`.
+by `LEDGER_ENTRY_RESTORE`. This applies to both data/code and `TTL` entries. For example, suppose a data/code entry
+is restored via an `InvokeHostFunctionOp`, then during invocation its `TTL` value is bumped. Meta for the TX will be
+as follows:
 
-#### Deprecation of RestoreFootprintOp(?)
+```
+data/code: LEDGER_ENTRY_RESTORE(restoredValue)
+TTL: LEDGER_ENTRY_RESTORE(minimumTTLfromRestore), LEDGER_ENTRY_UPDATED(bumpedTTLValue)
+```
 
-With the addition of automatic restoration, there is currently no need for `RestoreFootprintOp`. Functionally, the same automatic
-restoration behavior that exists in `InvokeHostFunctionOp` could be replicated in `ExtendFootprintTTLOp` to provide a single
-"admin" op type for managing lifetimes and restoration.
+Similarly, suppose a `CONTRACT_DATA` entry is restored, then deleted during invocation. Meta for the TX will be:
 
-Currently, `ExtendFootprintTTLOp` is rarely called, as most rent management is performed via contract calls. With the addition of
-automatic restoration, I expect that `RestoreFootprintOp` will also be rarely invoked. It may make sense from a maintenance and UX
-perspective to deprecate `RestoreFootprintOp` in favor of a single op type.
+```
+CONTRACT_DATA: LEDGER_ENTRY_RESTORE(restoredValue), LEDGER_ENTRY_REMOVED(dataKey)
+TTL: LEDGER_ENTRY_RESTORE(minimumTTLfromRestore), LEDGER_ENTRY_REMOVED(ttlKey)
+```
+
+If an entry is restored and not modified (either from RestoreFootprintOp or InvokeHostFunctionOp), the meta will be:
+
+```
+CONTRACT_DATA: LEDGER_ENTRY_RESTORE(restoredValue)
+TTL: LEDGER_ENTRY_RESTORE(minimumTTLfromRestore)
+```
 
 #### getledgerentry Endpoint
 
@@ -303,7 +317,7 @@ In order to facilitate state queries for RPC preflight, captive-core will expose
 
 Used to query both live and archived LedgerEntries. While `getledgerentryraw` does simple key-value lookup
 on the live ledger, `getledgerentry` will query a given key in both the live BucketList and Hot Archive BucketList.
-It will also report whether an entry is archived, evicted, or live, and return the entry's current TTL value.
+It will also report whether an entry is archived or live, and return the entry's current TTL value.
 
 A POST request with the following body:
 
@@ -325,7 +339,6 @@ A JSON payload is returned as follows:
      {"e": "Base64-LedgerEntry", "state": "live", /*optional*/ "ttl": uint32},
      {"e": "Base64-LedgerKey", "state": "new"},
      {"e": "Base64-LedgerEntry", "state": "archived"},
-     {"e": "Base64-LedgerEntry", "state": "evicted"}
 ],
 "ledger": ledgerSeq
 }
@@ -339,8 +352,7 @@ is live or archived, `e` contains the corresponding `LedgerEntry`. If a key does
 - `state`: One of the following values:
   - `live`: Entry is live.
   - `new`: Entry does not exist. Either the entry has never existed or is an expired temp entry.
-  - `archived`: Entry is archived, but not yet evicted, counts towards in-memory resources.
-  - `evicted`: Entry is archived and evicted, counts towards disk resources.
+  - `archived`: Entry is archived, counts towards on-disk resources.
 - `ttl`: An optional value, only returned for live Soroban entries. Contains
 a uint32 value for the entry's `liveUntilLedgerSeq`.
 - `ledgerSeq`: The ledger number on which the query was performed.
@@ -364,20 +376,20 @@ While there is a resource limit for the maximum number of in-memory entry reads,
 number of in-memory read bytes. Additionally, there are no read-specific fees for in-memory state.
 
 There does not seem to be a need for limits on in-memory bytes read. The cost associated with loading an
-in-memory entry is searching an in-memory map and making a copy of the LedgerEntry. Given that there is a limit
-on the maximum number of in-memory entries, and given that there is a limit on the maximum size for each entry,
-it seems highly unlikely that an attacker would be able to DOS the network via in-memory entry copies.
+in-memory entry is searching an in-memory map and making a copy of the LedgerEntry. These copies will be
+metered against the `txMemoryLimit` limit. To prevent OOM based DOS, operation apply will exit early if
+loading entries exceeds this limit.
 
-Given that in-memory state lookups are cheap, it also does not seem necessary to have an explicit fee for
-in-memory reads. In-memory reads will already be implicitly charged fees due to instruction and memory costs
-associated with interacting with the entry. An attacker could potentially exploit these implicit fees
+There is very little execution time associated with copying an in-memory entry. Given that the size of the
+copies is bounded by the `txMemoryLimit` and no expensive disk IO is required, it is not necessary to charge
+a fee for in-memory reads. An attacker could potentially exploit this
 by creating TXs with large readOnly footprints that don't actually interact with the loaded state. The
 TX would consume little resources and would be cheap, but would load the maximum amount of in-memory state
-and avoid these implicit fees. Due to the low cost of these loads, it seems unlikely this would negatively
+and. Due to the low computational cost of these in-memory copies, it seems unlikely this would negatively
 affect the network. Even the TX size costs associated with the large footprint may make the attack economically
-nonviable relative to the amount of stress on the network. However, if this were to become an issue,
-this could be solved in implementation. For example, instead of passing copies of state to the VM, const
-pointers to readOnly state could be used.
+nonviable relative to the amount of stress on the network. Additionally, memory allocations are short lived and
+freed immediately following TX application. Only a small number of TXs are executed at any given time such that
+memory is quickly freed such that OOM based attacks are not possible.
 
 ### UX Expectations
 
@@ -390,30 +402,12 @@ in the worst case. This means that from a limits perspective, only Soroban state
 for contract correctness. However, there may be issues with usability or efficiency, discussed in the section below.
 
 While contract developers only need to distinguish between Soroban and classic state for contract correctness, the
-tx itself will still need to properly populate limits and the `evictedEntries` vector based on whether or not
+tx itself will still need to properly populate limits and the `archivedEntries` vector based on whether or not
 entries are archived. Similar to today, these resources and footprints will be generated automatically via RPC.
-Specifically, RPC will correctly generate the footprint, `evictedEntries` vector, in-memory read resources,
+Specifically, RPC will correctly generate the footprint, `archivedEntries` vector, in-memory read resources,
 and disk read resources. Thus most of the complexity introduced by these changes should be abstracted away.
 
 Note that the RPC itself is not required to implement this behavior, but will call captive-core endpoints.
-
-### Host Functions that are too expensive for automatic restore
-
-Suppose an expensive contract is written, such that it uses the maximum in-memory resources and the maximum
-disk resources when no entries are evicted. Should any Soroban entry be evicted, automatic
-restoration would not be possible, as the restoration would exceed resource limits. In this case, it would be
-necessary to manually issue a `RestoreFootprintOp` (or equivalent in the case of deprecation) prior to the
-host function invocation.
-
-Ideally, this should be avoided if possible. The challenge will be communicating this to developers. This may be accomplished
-via documentation. Additionally, RPC could provide a warning to developers when the submitted invocation would
-exceed network limits should a sufficient amount of state restoration be required. This may help developers catch this
-class of performance issue earlier in the development process.
-
-Despite warning and documentation, there will be expensive contracts that are not compatible with automatic restore
-in all cases. For this reason, RPC preflight must be able to distinguish whether automatic restore is possible for a
-given invocation. If it is not, preflight must return the appropriate `restorePreamble` and communicate that an
-explicit restoration is required before function invocation.
 
 ### Expectations for Downstream Systems
 
@@ -421,26 +415,58 @@ RPC must make the following changes:
 
 1. Ingest the new `LEDGER_ENTRY_RESTORE` restore changes. This includes interpreting the new `LedgerEntryChangeType`
 correctly, but also correctly handling the case where an entry is restored and modified in the same ledger.
-2. Distinguish between live and evicted Soroban state during preflight in order to populate the new resource types
-and populate the `evictedEntries` vector.
-3. Notify users if a given preflighted transaction will not be able to be automatically restored due to resource limits,
-and provide a restore preamble for manual restoration in these cases.
-4. Allow user queries for both live and evicted state via the `getledgerentry` endpoint.
+2. Allow user queries for both live and evicted state via the `getledgerentry` endpoint.
+3. Handle transactions that cannot use automatic restore due to resource limits.
 
 Change 1 should be straight forward and is defined in the [InvokeHostFunctionOp Meta](#meta) section.
 
-For change 2, the construction of the footprint, resources, and evicted keys vector will be handled by the simulation
-library. However, RPC will need to input a given LedgerEntry and its eviction state (whether or not it is evicted)
-to the simulation library. RPC can accomplish this by utilizing the captive-core [`getledgerentry` HTTP endpoint](#getledgerentry-endpoint).
-
-Change 3 is largely an interface problem. The simulation library is responsible for detecting whether or not
-automatic restoration will violate current network limits and if a manual restore op is required. It is then
-the responsibility of RPC to forward this information to the user in an actionable way. It may also be useful
-to warn a user if a given transaction could in the future require manual restoration, even if it is not the case
-with the current ledger state.
-
-Change 4 allows wallets to effectively reason about ledger state. RPC integration is minimal, as internally
+Change 2 allows wallets and dapps to effectively reason about ledger state. RPC integration is minimal, as internally
 this endpoint can be implemented by calling the captive-core [`getledgerentry` HTTP endpoint](#getledgerentry-endpoint).
+
+Change 3 is more involved and discussed in the section below.
+
+### Handling Invocations that restore too much state for automatic restore
+
+Suppose an expensive contract is written, such that it uses the maximum in-memory resources and the maximum
+disk resources when no entries are archived. Should any Soroban entry be archived automatic
+restoration would not be possible, as the restoration would exceed resource limits. In this case, it would be
+necessary to manually issue one or more`RestoreFootprintOp` prior to the
+host function invocation.
+
+To facilitate this, RPC must change the structure of `restorePreamble` to allow for multiple `RestoreFootprintOp`s.
+Instead of returning a single set of keys and resource object in `restorePreamble`, it should return a vector of
+{keySet, resourceObject} pairs, where each pair represents a `RestoreFootprintOp`. This vector should be constructed
+as follows:
+
+```python
+restorePreamble = []
+archivedKeys = keysReturnedFromSimulationLibrary
+invokeHostFunctionOp = preflightedOp
+
+# First, append as many archived keys as possible to be auto restored via invokeHostFunctionOp
+while invokeHostFunctionOp.hasSpaceInDiskResources() and not archivedKeys.empty():
+     keyToAutoRestore = archivedKeys.pop()
+
+     # Function will mark the key as archived in the footprint and add
+     # the required diskRead resources to invokeHostFunctionOp
+     markAsArchivedEntry(invokeHostFunctionOp, keyToAutoRestore)
+
+# If we get here, there are more archived keys than can be restored via invokeHostFunctionOp auto restore
+# We need to construct RestoreOps to restore the remaining keys
+if not archivedKeys.empty():
+     restorePreamble.append(RestoreOp())
+     while not archivedKeys.empty():
+          while restorePreamble[-1].hasSpaceInDiskResources() and not archivedKeys.empty():
+               keyToRestore = archivedKeys.pop()
+               restorePreamble[-1].addKey(keyToRestore)
+
+          # If we filled up out first restore op, create a new one
+          if not archivedKeys.empty():
+               restorePreamble.append(RestoreOp())
+```
+
+Ideally, developers should be avoid creating contracts that require these expensive restores if possible.
+The challenge will be communicating this to developers, but may be accomplished via documentation.
 
 ### Concerns regarding Automatic Restoration with Full State Archival
 
@@ -459,7 +485,7 @@ With this proposal, it is vital to ensure that automatic restore does not result
 of developers circumvent preflight. Two specific features of this proposal help ensure developers are incentivized
 to build preflight into their flows now such that they are not broken later by archival proofs. Specifically,
 no in-memory read fees incentivize developers to minimize fees by using preflight to detect the maximum
-number of entries currently live. Additionally, the requirement of `evictedEntries` vectors makes manually
+number of entries currently live. Additionally, the requirement of `archivedEntries` vectors makes manually
 constructing footprints challenging, as the developer would need to be able to distinguish live vs evicted state
 to minimize fees. Given that preflighting will result in lower on-chain fees, and given that resource footprints
 are somewhat challenging to create without captive-core seems to indicate that developers will preflight transactions


### PR DESCRIPTION
Updates CAP 66 as follows:

- Removes "evicted" state from protocol, all archived entries are considered disk reads
- Clarifies meta changes for entries that are restored and modified in the same transaction
- adds detail on changes required for `restorePreamble` for TXs that restore too many entries for auto restore to work
- Discuses DOS attacks and mitigations wrt in memory read limits