### PR TITLE
sorobanLiveStateTargetSizeBytes now measures in-memory live soroban state

### DIFF
--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -203,11 +203,46 @@ entries can be restored from both the Live State and Hot Archive BucketList, bec
 continue to exist in Live State until they are evicted as part of natural BucketList growth. The emitted
 meta does not distinguish between these.
 
+#### `sorobanLiveStateTargetSizeBytes`
+
+`bucketListTargetSizeBytes` has been renamed to `sorobanLiveStateTargetSizeBytes`. Wrt to fees and limits,
+this value will be used in the same way. However, the value of `sorobanLiveStateTargetSizeBytes` is calculated
+differently.
+
+The value of `sorobanLiveStateTargetSizeBytes` is the total size of live Soroban state in the ledger, in bytes.
+Previously, `bucketListTargetSizeBytes` was based on the total size of the BucketList. In addition to no longer
+counting classic state, `sorobanLiveStateTargetSizeBytes` is also now based on the "ledger state" instead of on-disk
+size of entries. The "ledger state" corresponds to live `CONTRACT_DATA` entries, `TTL` entries for both `CONTRACT_DATA`
+and `CONTRACT_CODE`, and instantiated contract code. Archived and deleted state is not included, even if a `BucketEntry`
+for the archived or deleted state exists in the Live BucketList.
+
+`sorobanLiveStateTargetSizeBytes` is the sum of the size of each live `CONTRACT_DATA` entry, `CONTRACT_WASM` entry, and
+corresponding `TTL` entry, where the size of each entry is calculated as follows:
+ - `CONTRACT_DATA`: XDR serialized size of `CONTRACT_DATA` LedgerEntry.
+ - `TTL`: XDR serialized size of `TTL` LedgerEntry.
+ - `CONTRACT_WASM`: The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
+    Note that this is usually much larger than the `CONTRACT_WASM` LedgerEntry size.
+
+#### Changes to `CONTRACT_WASM` Fees and Limits
+
+`contractMaxSizeBytes` will now be based on the size of instantiated contract code, not the `CONTRACT_WASM` LedgerEntry size.
+Specifically, the size of a contract will be defined as the memory cost of the given code based on the module's `ContractCodeCostInputs`,
+as calculated by the cost model.
+
+Similarly, wrt fees and limits, the size of `CONTRACT_WASM` entries will be based on the instantiated module memory cost model size.
+
 #### Default Values for Network Configs
 
 `sorobanLiveStateTargetSizeBytes` (formerly `bucketListTargetSizeBytes`) will need to be changed
 to reflect the new size calculations. Additionally, the "fee curve" may need to be revisted
 now that classic state growth no longer affects Soroban fees.
+
+`contractMaxSizeBytes` will need to be increased to account for the new size calculations.
+
+These changes will be included in the protocol 23 upgrade and will not be subject to a separate
+Soroban settings upgrade.
+
+TODO: Initial values for network configs.
 
 ## Design Rationale
 
@@ -230,7 +265,9 @@ While there are no immediate benefits to the "full" state archival introduced in
 term gains from "partial state archival" introduced in this CAP. Specifically, this CAP will allow for full in-memory Soroban live state
 caching and automatic restoration of Soroban entries via `InvokeHostFunctionOp`, to be detailed in a future CAP.
 
-### Fee Changes
+### Fees and Limits Changes
+
+#### Not counting Archive State
 
 Because ledger state is now split into two BucketLists, the BucketList size component for storage fees must be
 reconsidered. Currently, the total size of the BucketList is used for Soroban related fees. This is frustrating
@@ -241,12 +278,9 @@ state, reduce the size of the BucketList, thus reducing fees. The issue is, clas
 not subject to State Archival, so this back pressure system is not effective. In practice, should BucketList size
 rapidly increase, it is most likely due to classic state, and the only way to lower fees is via network config upgrade.
 
-This CAP changes the BucketList size used in fee calculations to Live Soroban State Size. Specifically, Live Soroban
-State Size is is the total amount of state currently consumed by Soroban entries in the Live BucketList, in bytes.
-This includes TTL entries and shadows.
-
-The Hot Archive size does not impact fees. Long term, it is expected that CAP-0057 will be implemented and the
-Hot Archive will be dropped from validators. Thus long term, from a network health standpoint, the size of
+This CAP changes the BucketList size used in fee calculations to Live Soroban State Size. This means that
+archived state (i.e. the Hot Archive size) does not impact fees. Long term, it is expected that CAP-0057 will
+be implemented and the Hot Archive will be dropped from validators. Thus from a network health standpoint, the size of
 the Hot Archive does not have a significant impact on network sustainability.
 
 Prior to CAP-0057, large Hot Archives do impact network sustainability, specifically with respect to History
@@ -264,15 +298,48 @@ via network config settings. The rate at which state is added to the Live Bucket
 controlled by network config settings. Thus, enough tools are already in place to prevent state based DOS
 attacks without the addition of a Hot Archive based fee.
 
+#### Changes required for `CONTRACT_WASM`
+
+[CAP-0065](cap-0065.md) and [CAP-0066](cap-0066.md) build on this work to cache all live Soroban state in memory,
+including `CONTRACT_DATA`, `TTL`, and instantiated contract code. These caches open potential DOS vectors with the
+way `CONTRACT_CODE` size is metered in protocol 22.
+
+For `CONTRACT_DATA` and `TTL`, we cache all live `LedgerEntry`. This does not present a DOS angle. We meter these
+entry types based on `LedgerEntry` size such that we have a 1 to 1 ratio between the bytes that are metered and
+the bytes that are cached in memory.
+
+For `CONTRACT_CODE`, this is no longer the case. [CAP-0065](cap-0065.md) caches instantiated modules in memory,
+which in the worst case could be up to 40x the size of the `CONTRACT_CODE` LedgerEntry size. This is a significant
+OOM risk, as `sorobanLiveStateTargetSizeBytes` must bound the amount of state validators are required to cache in
+memory. If `CONTRACT_CODE` xdr size is used, an attacker could upload code that once instantiated could bloat the
+cache size to `sorobanLiveStateTargetSizeBytes * 40`, causing an OOM based DOS of the network. To prevent this,
+we use the instantiated module memory cost model size instead of the `CONTRACT_CODE` LedgerEntry size.
+
+The only down side is that uploading, restoring, and rent bumping `CONTRACT_CODE` will be more expensive from both a
+fee and limits standpoint. The fee increase is not a significant concern. However, when uploading/restoring a
+new `CONTRACT_CODE` entry with the new size calculation, writeBytes will be significantly higher than what is actually
+being written to disk, as we charge for the (much larger) in-memory size instead of the actual on-disk size. This means
+that we might need to increase `txMaxWriteBytes` to support uploading larger/more complex contracts despite these write
+sources not actually being utilized.
+
+In the short term, this does not seem to be an issue, as we can set max contract sizes modestly and have significant
+buffer wrt write bytes limits. However, this may become an issue in the future. A future protocol may explore splitting
+limits and fees on write bytes for `CONTRACT_CODE`. We could charge writeBytes fees based on instantiated size to prevent DOS,
+but use the actual on-disk size for `txMaxWriteBytes` and `ledgerMaxWriteBytes` limits to avoid increasing limits artificially
+due to under utilization. However, this does not appear necessary for protocol 23.
+
 ### Expectations for Downstream Systems
 
-Other than small changes in restoration meta and eviction meta, no significant changes will impact
-downstream systems.
+Meta changed outlined in [CAP-0066](cap-0066.md). Otherwise, there will be minimal changes with some XDR fields
+being renamed.
 
 ## Security Concerns
 
 This introduces no novel security concerns. All state is still maintained by validators and written to History
 Archives. Splitting state into separate DBs has no inherit risks.
+
+[CAP-0065](cap-0065.md) and [CAP-0066](cap-0066.md) introduce potential DOS vectors wrt `sorobanLiveStateTargetSizeBytes`
+addressed above in the fees section.
 
 ## Test Cases
 

--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -205,7 +205,7 @@ meta does not distinguish between these.
 
 #### `sorobanLiveStateTargetSizeBytes`
 
-`bucketListTargetSizeBytes` has been renamed to `sorobanLiveStateTargetSizeBytes`. Wrt to fees and limits,
+`bucketListTargetSizeBytes` has been renamed to `sorobanLiveStateTargetSizeBytes`. Wrt to fees,
 this value will be used in the same way. However, the value of `sorobanLiveStateTargetSizeBytes` is calculated
 differently.
 
@@ -216,20 +216,23 @@ size of entries. The "ledger state" corresponds to live `CONTRACT_DATA` entries,
 and `CONTRACT_CODE`, and instantiated contract code. Archived and deleted state is not included, even if a `BucketEntry`
 for the archived or deleted state exists in the Live BucketList.
 
-`sorobanLiveStateTargetSizeBytes` is the sum of the size of each live `CONTRACT_DATA` entry, `CONTRACT_WASM` entry, and
+`sorobanLiveStateTargetSizeBytes` is the sum of the size of each live `CONTRACT_DATA` entry, `CONTRACT_CODE` entry, and
 corresponding `TTL` entry, where the size of each entry is calculated as follows:
  - `CONTRACT_DATA`: XDR serialized size of `CONTRACT_DATA` LedgerEntry.
  - `TTL`: XDR serialized size of `TTL` LedgerEntry.
- - `CONTRACT_WASM`: The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
-    Note that this is usually much larger than the `CONTRACT_WASM` LedgerEntry size.
+ - `CONTRACT_CODE`: The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
+    Note that this is usually much larger than the `CONTRACT_CODE` LedgerEntry XDR size.
 
 #### Changes to `CONTRACT_WASM` Fees and Limits
 
-`contractMaxSizeBytes` will now be based on the size of instantiated contract code, not the `CONTRACT_WASM` LedgerEntry size.
+`contractMaxSizeBytes` will now be based on the size of instantiated contract code, not the `CONTRACT_CODE` LedgerEntry size.
 Specifically, the size of a contract will be defined as the memory cost of the given code based on the module's `ContractCodeCostInputs`,
 as calculated by the cost model.
 
-Similarly, wrt fees and limits, the size of `CONTRACT_WASM` entries will be based on the instantiated module memory cost model size.
+When a `CONTRACT_CODE` entry is extended or restored, the size of the instantiated module will be used as the entry size for both fees
+and limits. For restoration and uploads, the instantiated size will be metered and charged against `writeBytes` instead of the LedgerEntry XDR size.
+For rent fees, the instantiated size will also be used. From a limits and fee perspective, the XDR size of the `CONTRACT_CODE` LedgerEntry is
+now irrelevant.
 
 #### Default Values for Network Configs
 


### PR DESCRIPTION
Changes `sorobanLiveStateTargetSizeBytes` from tracking on-disk Soroban state to tracking in-memory live Soroban state.