### PR TITLE
Updated to dynamic rent fee + constant write fee

### DIFF
--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -108,24 +108,6 @@ case LEDGER_ENTRY_STATE:
 case LEDGER_ENTRY_RESTORE:
     LedgerEntry restored;
 };
-
-// Ledger access settings for contracts.
-struct ConfigSettingContractLedgerCostV0
-{
-    ...
-    // Note: The following fields are the same as they were before,
-    // but have just been renamed
-
-    // The following parameters determine the write fee per 1KB.
-    // Write fee grows linearly until bucket list reaches this size
-    int64 sorobanLiveStateTargetSizeBytes;
-    // Fee per 1KB write when the bucket list is empty
-    int64 writeFee1KBSorobanStateLow;
-    // Fee per 1KB write when the bucket list has reached `sorobanLiveStateTargetSizeBytes`
-    int64 writeFee1KBSorobanStateHigh;
-    // Write fee multiplier for any additional data past the first `sorobanLiveStateSizeBytes`
-    uint32 sorobanStateWriteFeeGrowthFactor;
-};
 ```
 
 ### Semantics
@@ -203,36 +185,6 @@ entries can be restored from both the Live State and Hot Archive BucketList, bec
 continue to exist in Live State until they are evicted as part of natural BucketList growth. The emitted
 meta does not distinguish between these.
 
-#### `sorobanLiveStateTargetSizeBytes`
-
-`bucketListTargetSizeBytes` has been renamed to `sorobanLiveStateTargetSizeBytes`. Wrt to fees,
-this value will be used in the same way. However, the value of `sorobanLiveStateTargetSizeBytes` is calculated
-differently.
-
-The value of `sorobanLiveStateTargetSizeBytes` is the total size of live Soroban state in the ledger, in bytes.
-Previously, `bucketListTargetSizeBytes` was based on the total size of the BucketList. In addition to no longer
-counting classic state, `sorobanLiveStateTargetSizeBytes` is also now based on the "ledger state" instead of on-disk
-size of entries. The "ledger state" corresponds to live `CONTRACT_DATA` entries, `TTL` entries for both `CONTRACT_DATA`
-and `CONTRACT_CODE`, and instantiated contract code. Archived and deleted state is not included, even if a `BucketEntry`
-for the archived or deleted state exists in the Live BucketList.
-
-`sorobanLiveStateTargetSizeBytes` is the sum of the size of each live `CONTRACT_DATA` entry, `CONTRACT_CODE` entry, and
-corresponding `TTL` entry, where the size of each entry is calculated as follows:
- - `CONTRACT_DATA`: XDR serialized size of `CONTRACT_DATA` LedgerEntry.
- - `TTL`: XDR serialized size of `TTL` LedgerEntry.
- - `CONTRACT_CODE`: The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
-    Note that this is usually much larger than the `CONTRACT_CODE` LedgerEntry XDR size.
-
-#### Changes to `CONTRACT_WASM` Fees and Limits
-
-`contractMaxSizeBytes` will now be based on the size of instantiated contract code, not the `CONTRACT_CODE` LedgerEntry size.
-Specifically, the size of a contract will be defined as the memory cost of the given code based on the module's `ContractCodeCostInputs`,
-as calculated by the cost model.
-
-When a `CONTRACT_CODE` entry is extended or restored, the size of the instantiated module will be used as the entry size for both fees
-and limits. For restoration and uploads, the instantiated size will be metered and charged against `writeBytes` instead of the LedgerEntry XDR size.
-For rent fees, the instantiated size will also be used. From a limits and fee perspective, the XDR size of the `CONTRACT_CODE` LedgerEntry is
-now irrelevant.
 
 #### Default Values for Network Configs
 

--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -101,14 +101,14 @@ mostly finalized in [CAP-0057](cap-0057.md), it is now appropriate to introduce 
 -    int64 writeFee1KBBucketListHigh;
 -    // Write fee multiplier for any additional data past the first `bucketListTargetSizeBytes`
 -    uint32 bucketListWriteFeeGrowthFactor;
-+    // Write fee grows linearly until soroban state reaches this size
++    // Rent fee grows linearly until soroban state reaches this size
 +    int64 sorobanStateTargetSizeBytes;
-+    // Fee per 1KB write when the soroban state is empty
-+    int64 writeFee1KBSorobanStateLow;
-+    // Fee per 1KB write when the soroban state has reached `sorobanStateTargetSizeBytes`
-+    int64 writeFee1KBSorobanStateHigh;
-+    // Write fee multiplier for any additional data past the first `sorobanStateTargetSizeBytes`
-+    uint32 sorobanStateWriteFeeGrowthFactor;
++    // Fee per 1KB rent when the soroban state is empty
++    int64 rentFee1KBSorobanStateSizeLow;
++    // Fee per 1KB rent when the soroban state has reached `sorobanStateTargetSizeBytes`
++    int64 rentFee1KBSorobanStateSizeHigh;
++    // Rent fee multiplier for any additional data past the first `sorobanStateTargetSizeBytes`
++    uint32 sorobanStateRentFeeGrowthFactor;
 +};
 +
 +// Ledger access settings for contracts.
@@ -116,8 +116,8 @@ mostly finalized in [CAP-0057](cap-0057.md), it is now appropriate to introduce 
 +{
 +    // Maximum number of in-memory ledger entry read operations per transaction
 +    uint32 txMaxInMemoryReadEntries;
-+    // Fee per 1 KB  write of 'classic' entries
-+    uint32 feeClassicWrite1KB;
++    // Fee per 1 KB write
++    uint32 feeWrite1KB;
  };
  
  // Historical data (pushed to core archives) settings for contracts.
@@ -215,22 +215,107 @@ In-memory entries are subject to the corresponding in-memory limits, but charge 
 read fees. On disk entries are subject to the corresponding limits and also charge entry and byte based
 read fees.
 
+#### `sorobanLiveStateTargetSizeBytes`
+
+`bucketListTargetSizeBytes` has been renamed to `sorobanLiveStateTargetSizeBytes`. Instead of tracking the current
+amount of disk being used by the network, this value has changed semantically to track the amount of in-memory
+(i.e. live soroban) state.
+
+The value of `sorobanLiveStateTargetSizeBytes` is the total size of live Soroban state in the ledger, in bytes.
+Previously, `bucketListTargetSizeBytes` was based on the total size of the BucketList. In addition to no longer
+counting classic state, `sorobanLiveStateTargetSizeBytes` is now based on the "live soroban state" instead of on-disk
+size of entries. The "live soroban state" corresponds to live `CONTRACT_DATA` entries, `TTL` entries for both `CONTRACT_DATA`
+and `CONTRACT_CODE`, and instantiated contract code. Archived and deleted state is not included, even if a `BucketEntry`
+for the archived or deleted state exists in the Live BucketList.
+
+`sorobanLiveStateTargetSizeBytes` is the sum of the size of each live `CONTRACT_DATA` entry, `CONTRACT_CODE` entry, and
+corresponding `TTL` entry, where the size of each entry is calculated as follows:
+ - `CONTRACT_DATA`: XDR serialized size of `CONTRACT_DATA` LedgerEntry.
+ - `TTL`: XDR serialized size of `TTL` LedgerEntry.
+ - `CONTRACT_CODE`: The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
+    Note that this is usually much larger than the `CONTRACT_CODE` LedgerEntry XDR size.
+
 #### Write fee computation changes
 
-The write fee for the Soroban ledger entries is still computed using the logic defined by [CAP-46-07](cap-0046-07.md#ledger-data). However, instead of using the size of the whole bucket list, only the size of the Soroban state will be used. The name changes in the configuration XDR reflect this semantic change. The write fee will still be used to compute the total fee for writing the Soroban entries, as well as the rent payments.
+Previously, a dynamic write fee was used in order to limit the amount of disk space being used by the network. With
+State Archival, the size of disk usage is no longer as significant of a concern. However, the size of
+in-memory state must be bounded to prevent OOM DOS attacks. To accomplish this, we maintain a dynamic rent fee to
+limit the amount of in-memory state on the ledger at a given time.
 
-Since the write fee is based on the Soroban state now, it does not make sense to charge the same fee for writing the classic entries. Moreover, protocol currently doesn't provide any way to increase the size of the classic state, as only the balance-changing operations are currently supported. This is why
-the flat per-KB write fee is introduced for the classic state: `feeClassicWrite1KB`.
+Since `sorobanLiveStateTargetSizeBytes` tracks in-memory state instead of on-disk state, it no longer makes sense
+to charge dynamic write fees based off of `sorobanLiveStateTargetSizeBytes`, but we still need to charge a fee for
+the cost of the write operation itself. To accomplish this, we introduce a constant per-KB write fee.
 
-Since classic entries accessible to Soroban (account and trustline entries) have relatively stable and predictable size, there is no need to provide a separate value for the write bytes for classic writes. Instead, the following computations are performed to compute the total non-refundable write KB fee:
+Soroban and classic state are both charged the flat per-KB write fee. The transaction write fee is computed as follows:
 
-- Define `CLASSIC_ENTRY_SIZE = 128` constant
-- Define `classic_write_count` as the number of classic entries in the `readWrite` footprint of the transaction
-- `classic_write_size = CLASSIC_ENTRY_SIZE * classic_write_count`
-- `soroban_write_size = tx.sorobanData.resources.writeBytes - classic_write_size` (if this value is negative, transaction is not valid) 
-- `write_fee = ceil(classic_write_size * feeClassicWrite1KB / 1024) + ceil(soroban_write_size * feeSoroban)`
+```
+write_fee = ceil(write_bytes * feeWrite1KB / 1024)
+```
 
-Since the fee is now based on `CLASSIC_ENTRY_SIZE`, this has to be reflected in the limit enforcement logic as well. Specifically, when computing the total size of the entries written by the transaction, the size of modified classic entries is assumed to be `CLASSIC_ENTRY_SIZE` instead of their actual XDR size.
+#### Rent fee computation changes
+
+Intuitively, the rent fee now represents the cost of reserving memory in the ledger state, so it should be dynamic wrt
+`sorobanLiveStateTargetSizeBytes`. The `Rent_fee` and `rent_fee_per_entry_change` calculations from
+[CAP-46-07](cap-0046-07.md#rent-fee) remain unchanged, with `rent_fee_for_size_and_ledgers` now being computed
+as follows:
+
+Renting S bytes of ledger space for the period of L ledgers:
+
+```
+rent_fee_for_size_and_ledgers(is_persistent, S, L) = round_up(
+    S * L * rent_fee_per_1kb(BucketListSize) /
+        if (is_persistent, persistentRentRateDenominator, tempRentRateDenominator)
+)
+```
+
+The `rent_fee_per_1kb` function is defined as follows:
+
+```
+MINIMUM_RENT_FEE_PER_1KB = 1
+
+// this is the fee rate slope
+// feeRate1KB = (rentFee1KBSorobanStateSizeHigh - rentFee1KBSorobanStateSizeLow)/sorobanStateTargetSizeBytes
+
+// in all cases, rate is clamped as to not fall under MINIMUM_RENT_FEE_PER_1KB in case
+// rentFee1KBSorobanStateSizeLow or rentFee1KBSorobanStateSizeHigh are too low
+
+// if s < sorobanStateTargetSizeBytes,
+//   grow by feeRate1KB until we reach rentFee1KBSorobanStateSizeHigh
+rent_fee_per_1kb(s) = max(MINIMUM_RENT_FEE_PER_1KB,
+    (rentFee1KBSorobanStateSizeHigh - rentFee1KBSorobanStateSizeLow)*s/sorobanStateTargetSizeBytes)
+
+// else (s >= sorobanStateTargetSizeBytes),
+//   grow by sorobanStateRentFeeGrowthFactor*feeRate1KB from rentFee1KBSorobanStateSizeHigh
+rent_fee_per_1kb(s) = max(MINIMUM_RENT_FEE_PER_1KB,
+    rentFee1KBSorobanStateSizeHigh +
+    sorobanStateRentFeeGrowthFactor*(rentFee1KBSorobanStateSizeHigh - rentFee1KBSorobanStateSizeLow)*
+        (s-sorobanStateTargetSizeBytes)/sorobanStateTargetSizeBytes)
+```
+
+Note this is the same from the `write_fee_per_1kb` calculation in [CAP-46-07](cap-0046-07.md#ledger-data). The only difference is that
+`rent_fee_for_size_and_ledgers` does not apply a discount to `rent_fee_per_1kb` (other than the contract data type discount),
+which was the case for `write_fee_per_1kb`.
+
+#### `CONTRACT_CODE` size calculation for limits and fees
+
+`CONTRACT_CODE` entries have two "sizes" that are relevant to fees and limits:
+ - "Disk Size": The size of the `CONTRACT_CODE` LedgerEntry XDR.
+ - "In-memory Size": The memory cost of the given code based on the module's `ContractCodeCostInputs`, as calculated by the cost model.
+
+Disk size is consistent between protocol upgrades, as the `CONTRACT_CODE` bytes themselves are immutable. However, the
+in-memory size is dependent on the cost model. For this reason, limits can not be based on in-memory size. If in-memory size
+was used for limits, a contract could be "bricked" by any upgrade that changes the cost model such that the in-memory size
+increases.
+
+For this reason, `contractMaxSizeBytes` will continue to be based on disk size. For `CONTRACT_CODE`
+upload and restoration, `writeBytes` will be metered against the disk size.
+
+While limits cannot be exceeded via cost model changes, fees can increase without risk of breaking contracts. For this reason,
+and in order protect against malicious contract uploads in an OOM attack, rent fees will be based on the in-memory size. This
+fits the new paradigm of rent fees reserving a portion of ledger memory.
+
+While instantiated contract code is significantly larger than it's on disk size, this is not true for cached contract data.
+For this reason, rent fees for `CONTRACT_DATA` will continue to be based on the serialized XDR disk size.
 
 #### Initial Network Config Settings
 
@@ -243,13 +328,13 @@ in any way should we maintain these values via disk read limits.
 In-memory read limits are not required wrt execution time, as they are very inexpensive. For this reason, no ledger wide read limit is necessary,
 and no byte based read limit is necessary for them. However, the size of TX footprints
 does impact the cost and complexity of assembling transactions sets and potentially maintaining the mempool, as with implementation [CAP-63](./CAP-63) Core will need to verify the presence of the conflicts in transaction footprints. Thus a tx entry limit is introduced to ensure efficient transaction set
-construction. 
+construction.
 
 Note, that there is also a 'soft' limit on the maximum number of reads per transaction that is caused by the transaction size limit. But coupling the limits in this fashion is risky - for example, network might need to increase the minimal transaction size in order to accommodate larger contracts, but the simultaneous increase in in-memory entry count might not be desired.
 
 When the protocol is upgraded to version 23 the initial values of the new configuration settings will be set to the following values:
 - `txMaxInMemoryReadEntries` will be set to the current value of `txMaxDiskReadEntries` (renamed from `txMaxReadLedgerEntries`) in order to prevent breakages of any existing contracts
-- `feeClassicWrite1KB` will be set to `10000` stroops, which roughly matches the current Soroban write fee per 1 KB
+- `feeWrite1KB` will be set to `10000` stroops, which roughly matches the current Soroban write fee per 1 KB
 
 #### `archivedEntries` Vector
 
@@ -390,7 +475,7 @@ still the archived entry's full `LedgerEntry` as well as the proper state.
 
 ## Design Rationale
 
-### Reasoning behind in-memory limits and no fees
+### Reasoning behind in-memory limits and no read fees
 
 While there is a resource limit for the maximum number of in-memory entry reads, there is no limit on the
 number of in-memory read bytes. Additionally, there are no read-specific fees for in-memory state.
@@ -410,6 +495,30 @@ affect the network. Even the TX size costs associated with the large footprint m
 nonviable relative to the amount of stress on the network. Additionally, memory allocations are short lived and
 freed immediately following TX application. Only a small number of TXs are executed at any given time such that
 memory is quickly freed such that OOM based attacks are not possible.
+
+### Changes required for `CONTRACT_CODE`
+
+This CAP combined with [CAP-0065](cap-0065.md) cache all live Soroban state in memory,
+including `CONTRACT_DATA`, `TTL`, and instantiated contract code. These caches open potential DOS vectors with the
+way `CONTRACT_CODE` size is metered currently.
+
+For `CONTRACT_DATA` and `TTL`, we cache all live `LedgerEntries`. This does not present a DOS angle. We meter these
+entry types based on serialized `LedgerEntry` XDR size such that we have a 1 to 1 ratio between the bytes that are metered and
+the bytes that are cached in memory.
+
+For `CONTRACT_CODE`, this is no longer the case. [CAP-0065](cap-0065.md) caches instantiated modules in memory,
+which in the worst case could be up to 40x the size of the `CONTRACT_CODE` LedgerEntry size. This is a significant
+OOM risk, as `sorobanLiveStateTargetSizeBytes` must bound the amount of state validators are required to cache in
+memory. If `CONTRACT_CODE` XDR size is used, an attacker could upload code that once instantiated could bloat the
+cache size to `sorobanLiveStateTargetSizeBytes * 40`, causing an OOM based DOS of the network. To prevent this,
+we use the instantiated module memory cost model size instead of the `CONTRACT_CODE` LedgerEntry size for rent fees.
+While fees become slightly higher, this is reasonable given that the contract modules consume more network resources
+(memory).
+
+### Requirement for Module Cache and Cost Model Consistency
+
+Using the instantiated module size for rent fees requires that the Module Cache be up to date with the current
+cost model. This means that each upgrade to the cost model must trigger a rebuild of the Module Cache.
 
 ### UX Expectations
 


### PR DESCRIPTION
This updates gives write fees a constant per kb rate. Rent fees have been changed to depend on the current amount of live, in-memory soroban state. Rent is charged based on the in-memory size of the given entry, not the on-disk size. For `CONTRACT_DATA` this is irrelevant, since on-disk and in-memory size is the same. For `CONTRACT_CODE`, the instantiated module size is used, as reported by the cost model.