### PR TITLE
Add SEP for ledger metadata storage

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -97,6 +97,7 @@ All SEPs have individuals fulfilling the following roles:
 | [SEP-0051](sep-0051.md) | XDR-JSON                                                       | Leigh McCulloch                               | Draft                |
 | [SEP-0052](sep-0052.md) | Key Sharing Method for Stellar Keys                            | Pamphile Roy, Jun Luo                         | Draft                |
 | [SEP-0053](sep-0053.md) | Sign and Verify Messages                                       | Jun Luo, Pamphile Roy, OrbitLens, Piyal Basu  | Draft                |
+| [SEP-0054](sep-0054.md) | Ledger Metadata Storage                                        | Tamir Sen                                     | Draft                |
 
 ### Abandoned Proposals
 

--- a/ecosystem/sep-0054.md
+++ b/ecosystem/sep-0054.md
@@ -1,12 +1,14 @@
 ## Preamble
 
 ```
-SEP: To Be Assigned
+SEP: 0054
 Title: Ledger Metadata Storage
 Author: Tamir Sen <@tamirms>
 Status: Draft
 Created: 2025-03-11
+Updated: 2025-03-11
 Version: 0.2.0
+Discussion: https://github.com/orgs/stellar/discussions/1678
 ```
 
 ## Simple Summary

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -77,13 +77,13 @@ Keys follow a hierarchical directory structure. The root directory is `/ledgers`
 partitions. Each partition contains a fixed number of batches:
 
 ```
-/ledgers/<partition>/<batch>.xdr
+/ledgers/<partition>/<batch>.xdr.zst
 ```
 
 If the partition size is 1, the partition is omitted, resulting in:
 
 ```
-/ledgers/<batch>.xdr
+/ledgers/<batch>.xdr.zst
 ```
 
 #### Partition Format:
@@ -95,14 +95,18 @@ fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partiti
 #### Batch Format:
 
 ```go
- fmt.Sprintf("%08X--%d-%d.xdr", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
+ fmt.Sprintf("%08X--%d-%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
 ```
 
 If the batch size is 1, the format simplifies to:
 
 ```go
- fmt.Sprintf("%08X--%d.xdr", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence)
+ fmt.Sprintf("%08X--%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence)
 ```
+
+Note the `.zst` suffix is the filename extension defined in the [Zstandard]([https://facebook.github.io/zstd/)
+[RFC](https://datatracker.ietf.org/doc/html/rfc8478). If this SEP is extended to support another compression algorithm
+then the standard filename extension for the given compression algorithm will be used as a suffix in the batch name.
 
 ---
 
@@ -135,18 +139,18 @@ following properties:
 Below is an example list of keys for ledger batches based on the configuration above:
 
 ```
-/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr
-/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr
-/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr
+/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr.zst
+/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr.zst
+/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr.zst
 ```
 
-[![](https://mermaid.ink/img/pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8)
+[![](https://mermaid.ink/img/pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g)
 
 **Note:** The genesis ledger starts at sequence number 2, so the oldest batch must have a `batchStartLedgerSequence`
 of 2.

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -11,32 +11,38 @@ Version: 0.1.0
 
 ## Simple Summary
 
-A standard for how [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) objects should be stored so that ledgers can be easily and efficiently ingested by downstream systems.
+A standard for how [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545)
+objects should be stored so that ledgers can be easily and efficiently ingested by downstream systems.
 
 ## Dependencies
+
 None.
 
 ## Motivation
 
-[galexie](https://github.com/stellar/go/tree/master/services/galexie) is a service which publishes [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) XDR objects to a GCS (Google Cloud Storage) bucket. However, the data format and layout of the XDR objects are not formally documented. This SEP aims to provide a comprehensive specification for storing LedgerCloseMeta objects, enabling third-party developers to build compatible data stores and clients for retrieving ledger metadata.
+[galexie](https://github.com/stellar/go/tree/master/services/galexie) is a service which publishes
+[`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) XDR objects to a GCS
+(Google Cloud Storage) bucket. However, the data format and layout of the XDR objects are not formally documented. This
+SEP aims to provide a comprehensive specification for storing LedgerCloseMeta objects, enabling third-party developers
+to build compatible data stores and clients for retrieving ledger metadata.
 
 ## Specification
 
+The data store is a key-value store where:
 
-The data store is a key-value store where:  
-- **Keys** are strings following a specific hierarchical format.  
-- **Values** are binary blobs representing compressed `LedgerCloseMetaBatch` XDR values.  
+- **Keys** are strings following a specific hierarchical format.
+- **Values** are binary blobs representing compressed `LedgerCloseMetaBatch` XDR values.
 
-The key-value store must support:  
-- Efficient point lookups for arbitrary keys.  
-- Listing keys in lexicographic order, optionally filtered by a prefix.  
+The key-value store must support:
+
+- Efficient point lookups for arbitrary keys.
+- Listing keys in lexicographic order, optionally filtered by a prefix.
 
 Examples of compatible key-value stores include Google Cloud Storage (GCS) and Amazon S3.
 
 ---
 
 ### Value Format
-
 
 Each value in the key-value store is the compressed binary encoding of the following XDR structure:
 
@@ -59,14 +65,12 @@ struct LedgerCloseMetaBatch
 
 - All batches in a data store instance contain the same number of ledgers.
 
-
 ---
 
 ### Key Format
 
-
-Keys follow a hierarchical directory structure. The root directory is `/ledgers``, and subdirectories represent partitions. Each partition contains a fixed number of batches:
-
+Keys follow a hierarchical directory structure. The root directory is `/ledgers``, and subdirectories represent
+partitions. Each partition contains a fixed number of batches:
 
 ```
 /ledgers/<partition>/<batch>.xdr
@@ -74,17 +78,15 @@ Keys follow a hierarchical directory structure. The root directory is `/ledgers`
 
 If the partition size is 1, the partition is omitted, resulting in:
 
-
 ```
 /ledgers/<batch>.xdr
 ```
 
 #### Partition Format:
 
-
- ```go
- fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
- ```
+```go
+fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
+```
 
 #### Batch Format:
 
@@ -102,10 +104,12 @@ If the batch size is 1, the format simplifies to:
 
 ### Configuration File
 
-The data store includes a configuration JSON object stored under the key `/config.json``. This file contains the following properties:
+The data store includes a configuration JSON object stored under the key `/config.json``. This file contains the
+following properties:
 
 - `networkPassphrase` - (string) the passphrase for the Stellar network associated with the ledgers.
-- `compression` - (string) the compression algorithm used to compress ledger objects (currently only [`zstd`]([https://facebook.github.io/zstd/) is supported).
+- `compression` - (string) the compression algorithm used to compress ledger objects (currently only
+  [`zstd`]([https://facebook.github.io/zstd/) is supported).
 - `ledgersPerBatch` - (integer) the number of ledgers bundled into each `LedgerCloseMetaBatch`.
 - `batchesPerPartition` - (integer) the number of batches in a partition.
 
@@ -113,10 +117,10 @@ The data store includes a configuration JSON object stored under the key `/confi
 
 ```json
 {
-    "networkPassphrase": "Public Global Stellar Network ; September 2015",
-    "compression": "zstd",
-    "ledgersPerBatch": 2,
-    "batchesPerPartition": 8
+  "networkPassphrase": "Public Global Stellar Network ; September 2015",
+  "compression": "zstd",
+  "ledgersPerBatch": 2,
+  "batchesPerPartition": 8
 }
 ```
 
@@ -124,9 +128,7 @@ The data store includes a configuration JSON object stored under the key `/confi
 
 ### Example Key Structure
 
-
 Below is an example list of keys for ledger batches based on the configuration above:
-
 
 ```
 /ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr
@@ -140,24 +142,32 @@ Below is an example list of keys for ledger batches based on the configuration a
 /ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr
 ```
 
-
 [![](https://mermaid.ink/img/pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8)
 
-**Note:** The genesis ledger starts at sequence number 2, so the oldest batch must have a `batchStartLedgerSequence` of 2.
-
+**Note:** The genesis ledger starts at sequence number 2, so the oldest batch must have a `batchStartLedgerSequence`
+of 2.
 
 ## Design Rationale
 
 ### Key Encoding (Reversed Ledger Sequence)
-- **Lexicographic Order**: Many key-value stores (e.g., GCS, S3) optimize for listing keys in lexicographic order. By encoding the most recent ledgers first, clients can efficiently retrieve the latest data without scanning the entire dataset.
-- **Reversed Sequence**: Using `math.MaxUint32 - startLedger` ensures that newer ledgers (with higher sequence numbers) appear before older ones when sorted lexicographically. This avoids the need for additional metadata or indexes to determine the latest ledger.
 
-### Compression Algorithm  
-- `zstd` was chosen after evaluating `zstd`, `lz4`, and `gzip`. It provides the best balance between compression ratio and decompression speed.  
+- **Lexicographic Order**: Many key-value stores (e.g., GCS, S3) optimize for listing keys in lexicographic order. By
+  encoding the most recent ledgers first, clients can efficiently retrieve the latest data without scanning the entire
+  dataset.
+- **Reversed Sequence**: Using `math.MaxUint32 - startLedger` ensures that newer ledgers (with higher sequence numbers)
+  appear before older ones when sorted lexicographically. This avoids the need for additional metadata or indexes to
+  determine the latest ledger.
+
+### Compression Algorithm
+
+- `zstd` was chosen after evaluating `zstd`, `lz4`, and `gzip`. It provides the best balance between compression ratio
+  and decompression speed.
 
 ## Security Concerns
 
-Verifying the validity of the ledgers contained within the data store is outside the scope of this SEP. In otherwords, this SEP does not provide any mechanism for validating that the ledgers obtained from a data store have not been altered. 
+Verifying the validity of the ledgers contained within the data store is outside the scope of this SEP. In otherwords,
+this SEP does not provide any mechanism for validating that the ledgers obtained from a data store have not been
+altered.
 
 ## Changelog
 

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -1,0 +1,164 @@
+## Preamble
+
+```
+SEP: To Be Assigned
+Title: Ledger Metadata Storage
+Author: Tamir Sen <@tamirms>
+Status: Draft
+Created: 2025-03-11
+Version: 0.1.0
+```
+
+## Simple Summary
+
+A standard for how [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) objects should be stored so that ledgers can be easily and efficiently ingested by downstream systems.
+
+## Dependencies
+None.
+
+## Motivation
+
+[galexie](https://github.com/stellar/go/tree/master/services/galexie) is a service which publishes [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) XDR objects to a GCS (Google Cloud Storage) bucket. However, the data format and layout of the XDR objects are not formally documented. This SEP aims to provide a comprehensive specification for storing LedgerCloseMeta objects, enabling third-party developers to build compatible data stores and clients for retrieving ledger metadata.
+
+## Specification
+
+
+The data store is a key-value store where:  
+- **Keys** are strings following a specific hierarchical format.  
+- **Values** are binary blobs representing compressed `LedgerCloseMetaBatch` XDR values.  
+
+The key-value store must support:  
+- Efficient point lookups for arbitrary keys.  
+- Listing keys in lexicographic order, optionally filtered by a prefix.  
+
+Examples of compatible key-value stores include Google Cloud Storage (GCS) and Amazon S3.
+
+---
+
+### Value Format
+
+
+Each value in the key-value store is the compressed binary encoding of the following XDR structure:
+
+```c++
+// Batch of ledgers along with their transaction metadata
+struct LedgerCloseMetaBatch
+{
+    // starting ledger sequence number in the batch
+    uint32 startSequence;
+
+    // ending ledger sequence number in the batch
+    uint32 endSequence;
+
+    // Ledger close meta for each ledger within the batch
+    LedgerCloseMeta ledgerCloseMetas<>;
+};
+```
+
+- A LedgerCloseMetaBatch represents a contiguous range of one or more consecutive ledgers.
+
+- All batches in a data store instance contain the same number of ledgers.
+
+
+---
+
+### Key Format
+
+
+Keys follow a hierarchical directory structure. The root directory is `/ledgers``, and subdirectories represent partitions. Each partition contains a fixed number of batches:
+
+
+```
+/ledgers/<partition>/<batch>.xdr
+```
+
+If the partition size is 1, the partition is omitted, resulting in:
+
+
+```
+/ledgers/<batch>.xdr
+```
+
+#### Partition Format:
+
+
+ ```go
+ fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
+ ```
+
+#### Batch Format:
+
+```go
+ fmt.Sprintf("%08X--%d-%d.xdr", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
+```
+
+If the batch size is 1, the format simplifies to:
+
+```go
+ fmt.Sprintf("%08X--%d.xdr", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence)
+```
+
+---
+
+### Configuration File
+
+The data store includes a configuration JSON object stored under the key `/config.json``. This file contains the following properties:
+
+- `networkPassphrase` - (string) the passphrase for the Stellar network associated with the ledgers.
+- `compression` - (string) the compression algorithm used to compress ledger objects (currently only [`zstd`]([https://facebook.github.io/zstd/) is supported).
+- `ledgersPerBatch` - (integer) the number of ledgers bundled into each `LedgerCloseMetaBatch`.
+- `batchesPerPartition` - (integer) the number of batches in a partition.
+
+#### Example Configuration:
+
+```json
+{
+    "networkPassphrase": "Public Global Stellar Network ; September 2015",
+    "compression": "zstd",
+    "ledgersPerBatch": 2,
+    "batchesPerPartition": 8
+}
+```
+
+---
+
+### Example Key Structure
+
+
+Below is an example list of keys for ledger batches based on the configuration above:
+
+
+```
+/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr
+/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr
+/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr
+```
+
+
+[![](https://mermaid.ink/img/pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpl0U2LgzAQBuC_InPurJva1uphYa3rYb8_emr1EJpUC2okVdil9L_vrBpwSQ4h4X3IDJkLHJSQEEKueVM42zitHVr3e7eUIpf67GYO4p0T7ZN-PSSIbIUec7NR9vFmjBOKb5EtTTrsUW8ezRMxPbFGFtx8C51NxdP_IsyfiGHf9O7ZVGPkFlRu4gbxYoRHYo7Ms8SrEUsS1DKzxJsRPuIaAyt_N3mAuELfyj9MHiEu0O7x0-T0H3McOoQZVFJX_CRoJJc_nUJbyEqmENJRyCPvyjaFtL4S5V2rvn7qA4St7uQMtOryAsIjL8906xrBWxmfOI22MqTh9U6pakTXX0nQih8)
+
+**Note:** The genesis ledger starts at sequence number 2, so the oldest batch must have a `batchStartLedgerSequence` of 2.
+
+
+## Design Rationale
+
+### Key Encoding (Reversed Ledger Sequence)
+- **Lexicographic Order**: Many key-value stores (e.g., GCS, S3) optimize for listing keys in lexicographic order. By encoding the most recent ledgers first, clients can efficiently retrieve the latest data without scanning the entire dataset.
+- **Reversed Sequence**: Using `math.MaxUint32 - startLedger` ensures that newer ledgers (with higher sequence numbers) appear before older ones when sorted lexicographically. This avoids the need for additional metadata or indexes to determine the latest ledger.
+
+### Compression Algorithm  
+- `zstd` was chosen after evaluating `zstd`, `lz4`, and `gzip`. It provides the best balance between compression ratio and decompression speed.  
+
+## Security Concerns
+
+Verifying the validity of the ledgers contained within the data store is outside the scope of this SEP. In otherwords, this SEP does not provide any mechanism for validating that the ledgers obtained from a data store have not been altered. 
+
+## Changelog
+
+- `v0.1.0`: Initial draft

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -73,7 +73,9 @@ struct LedgerCloseMetaBatch
 
 ### Key Format
 
-Keys follow a hierarchical directory structure, effectively acting as file paths within the data store. All the ledgers are stored under a configurable `/<ledgers-path>`. Within the `/<ledgers-path>` directory there are subdirectories which represent partitions. Each partition contains a fixed number of batches:
+Keys follow a hierarchical directory structure, effectively acting as file paths within the data store. All the ledgers
+are stored under a configurable `/<ledgers-path>`. Within the `/<ledgers-path>` directory there are subdirectories which
+represent partitions. Each partition contains a fixed number of batches:
 
 ```
 /<ledgers-path>/<partition>/<batch>.xdr.zst
@@ -91,7 +93,7 @@ If the partition size is 1, the partition is omitted, resulting in:
 fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
 ```
 
-Example for `partitionStartLedgerSequence=0` and  `partitionEndLedgerSequence=15`: `FFFFFFFF--0-15`
+Example for `partitionStartLedgerSequence=0` and `partitionEndLedgerSequence=15`: `FFFFFFFF--0-15`
 
 #### Batch Format:
 
@@ -99,8 +101,7 @@ Example for `partitionStartLedgerSequence=0` and  `partitionEndLedgerSequence=15
  fmt.Sprintf("%08X--%d-%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
 ```
 
-Example for `batchStartLedgerSequence=2` and  `batchEndLedgerSequence=3`: `FFFFFFFD--2-3.xdr.zst`
-
+Example for `batchStartLedgerSequence=2` and `batchEndLedgerSequence=3`: `FFFFFFFD--2-3.xdr.zst`
 
 If the batch size is 1, the format simplifies to:
 
@@ -109,7 +110,6 @@ If the batch size is 1, the format simplifies to:
 ```
 
 Example for `batchStartLedgerSequence=2`: `FFFFFFFD--2.xdr.zst`
-
 
 Note the `.zst` suffix is the filename extension defined in the [Zstandard]([https://facebook.github.io/zstd/)
 [RFC](https://datatracker.ietf.org/doc/html/rfc8478). If this SEP is extended to support another compression algorithm
@@ -145,7 +145,8 @@ following properties:
 
 ### Example Key Structure
 
-Below is an example list of keys (with `/<config-path>` set to  `/stellar/pubnet/config.json`) for ledger batches based on the above example configuration:
+Below is an example list of keys (with `/<config-path>` set to `/stellar/pubnet/config.json`) for ledger batches based
+on the above example configuration:
 
 ```
 /stellar/pubnet/config.json

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -12,7 +12,7 @@ Version: 0.1.0
 ## Simple Summary
 
 A standard for how [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545)
-objects should be stored so that ledgers can be easily and efficiently ingested by downstream systems.
+objects can be stored so that ledgers can be easily and efficiently ingested by downstream systems.
 
 ## Dependencies
 
@@ -44,7 +44,8 @@ Examples of compatible key-value stores include Google Cloud Storage (GCS) and A
 
 ### Value Format
 
-Each value in the key-value store is the compressed binary encoding of the following XDR structure:
+Each value in the key-value store is the [Zstandard]([https://facebook.github.io/zstd/) compressed binary encoding of
+the following XDR structure:
 
 ```c++
 // Batch of ledgers along with their transaction metadata
@@ -64,6 +65,9 @@ struct LedgerCloseMetaBatch
 - A LedgerCloseMetaBatch represents a contiguous range of one or more consecutive ledgers.
 
 - All batches in a data store instance contain the same number of ledgers.
+
+- Currently only [Zstandard]([https://facebook.github.io/zstd/) compression is supported but it is possible to extend
+  the SEP in the future to allow other compression algorithms.
 
 ---
 

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -69,7 +69,7 @@ struct LedgerCloseMetaBatch
 
 ### Key Format
 
-Keys follow a hierarchical directory structure. The root directory is `/ledgers``, and subdirectories represent
+Keys follow a hierarchical directory structure. The root directory is `/ledgers`, and subdirectories represent
 partitions. Each partition contains a fixed number of batches:
 
 ```

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -11,8 +11,10 @@ Version: 0.2.0
 
 ## Simple Summary
 
-A standard for how [`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545)
-objects can be stored so that ledgers can be easily and efficiently ingested by downstream systems.
+A standard for how
+[`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545)
+objects can be stored so that ledgers can be easily and efficiently ingested by
+downstream systems.
 
 ## Dependencies
 
@@ -20,31 +22,37 @@ None.
 
 ## Motivation
 
-[galexie](https://github.com/stellar/go/tree/master/services/galexie) is a service which publishes
-[`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545) XDR objects to a GCS
-(Google Cloud Storage) bucket. However, the data format and layout of the XDR objects are not formally documented. This
-SEP aims to provide a comprehensive specification for storing LedgerCloseMeta objects, enabling third-party developers
-to build compatible data stores and clients for retrieving ledger metadata.
+[galexie](https://github.com/stellar/go/tree/master/services/galexie) is a
+service which publishes
+[`LedgerCloseMeta`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539-L545)
+XDR objects to a GCS (Google Cloud Storage) bucket. However, the data format
+and layout of the XDR objects are not formally documented. This SEP aims to
+provide a comprehensive specification for storing LedgerCloseMeta objects,
+enabling third-party developers to build compatible data stores and clients for
+retrieving ledger metadata.
 
 ## Specification
 
 The data store is a key-value store where:
 
 - **Keys** are strings following a specific hierarchical format.
-- **Values** are binary blobs representing compressed `LedgerCloseMetaBatch` XDR values.
+- **Values** are binary blobs representing compressed `LedgerCloseMetaBatch`
+  XDR values.
 
 The key-value store must support:
 
 - Efficient random access lookups on arbitrary keys.
 - Listing keys in lexicographic order, optionally filtered by a prefix.
 
-Examples of compatible key-value stores include Google Cloud Storage (GCS) and Amazon S3.
+Examples of compatible key-value stores include Google Cloud Storage (GCS) and
+Amazon S3.
 
 ---
 
 ### Value Format
 
-Each value in the key-value store is the [Zstandard]([https://facebook.github.io/zstd/) compressed binary encoding of
+Each value in the key-value store is the
+[Zstandard]([https://facebook.github.io/zstd/) compressed binary encoding of
 the following XDR structure:
 
 ```c++
@@ -62,20 +70,24 @@ struct LedgerCloseMetaBatch
 };
 ```
 
-- A LedgerCloseMetaBatch represents a contiguous range of one or more consecutive ledgers.
+- A LedgerCloseMetaBatch represents a contiguous range of one or more
+  consecutive ledgers.
 
 - All batches in a data store instance contain the same number of ledgers.
 
-- Currently only [Zstandard]([https://facebook.github.io/zstd/) compression is supported but it is possible to extend
-  the SEP in the future to allow other compression algorithms.
+- Currently only [Zstandard]([https://facebook.github.io/zstd/) compression is
+  supported but it is possible to extend the SEP in the future to allow other
+  compression algorithms.
 
 ---
 
 ### Key Format
 
-Keys follow a hierarchical directory structure, effectively acting as file paths within the data store. All the ledgers
-are stored under a configurable `/<ledgers-path>`. Within the `/<ledgers-path>` directory there are subdirectories which
-represent partitions. Each partition contains a fixed number of batches:
+Keys follow a hierarchical directory structure, effectively acting as file
+paths within the data store. All the ledgers are stored under a configurable
+`/<ledgers-path>`. Within the `/<ledgers-path>` directory there are
+subdirectories which represent partitions. Each partition contains a fixed
+number of batches:
 
 ```
 /<ledgers-path>/<partition>/<batch>.xdr.zst
@@ -93,7 +105,8 @@ If the partition size is 1, the partition is omitted, resulting in:
 fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
 ```
 
-Example for `partitionStartLedgerSequence=0` and `partitionEndLedgerSequence=15`: `FFFFFFFF--0-15`
+Example for `partitionStartLedgerSequence=0` and
+`partitionEndLedgerSequence=15`: `FFFFFFFF--0-15`
 
 #### Batch Format:
 
@@ -101,7 +114,8 @@ Example for `partitionStartLedgerSequence=0` and `partitionEndLedgerSequence=15`
  fmt.Sprintf("%08X--%d-%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
 ```
 
-Example for `batchStartLedgerSequence=2` and `batchEndLedgerSequence=3`: `FFFFFFFD--2-3.xdr.zst`
+Example for `batchStartLedgerSequence=2` and `batchEndLedgerSequence=3`:
+`FFFFFFFD--2-3.xdr.zst`
 
 If the batch size is 1, the format simplifies to:
 
@@ -111,22 +125,28 @@ If the batch size is 1, the format simplifies to:
 
 Example for `batchStartLedgerSequence=2`: `FFFFFFFD--2.xdr.zst`
 
-Note the `.zst` suffix is the filename extension defined in the [Zstandard]([https://facebook.github.io/zstd/)
-[RFC](https://datatracker.ietf.org/doc/html/rfc8478). If this SEP is extended to support another compression algorithm
-then the standard filename extension for the given compression algorithm will be used as a suffix in the batch name.
+Note the `.zst` suffix is the filename extension defined in the
+[Zstandard]([https://facebook.github.io/zstd/)
+[RFC](https://datatracker.ietf.org/doc/html/rfc8478). If this SEP is extended
+to support another compression algorithm then the standard filename extension
+for the given compression algorithm will be used as a suffix in the batch name.
 
 ---
 
 ### Configuration File
 
-The data store includes a configuration JSON object stored under the key `/<config-path>`. This file contains the
-following properties:
+The data store includes a configuration JSON object stored under the key
+`/<config-path>`. This file contains the following properties:
 
-- `networkPassphrase` - (string) the passphrase for the Stellar network associated with the ledgers.
-- `ledgersPath` - (string) the `/<ledgers-path>` directory which contains all the partitions and batches.
-- `compression` - (string) the compression algorithm used to compress ledger objects (currently only
-  [`zstd`]([https://facebook.github.io/zstd/) is supported).
-- `ledgersPerBatch` - (integer) the number of ledgers bundled into each `LedgerCloseMetaBatch`.
+- `networkPassphrase` - (string) the passphrase for the Stellar network
+  associated with the ledgers.
+- `ledgersPath` - (string) the `/<ledgers-path>` directory which contains all
+  the partitions and batches.
+- `compression` - (string) the compression algorithm used to compress ledger
+  objects (currently only [`zstd`]([https://facebook.github.io/zstd/) is
+  supported).
+- `ledgersPerBatch` - (integer) the number of ledgers bundled into each
+  `LedgerCloseMetaBatch`.
 - `batchesPerPartition` - (integer) the number of batches in a partition.
 
 #### Example Configuration:
@@ -145,8 +165,9 @@ following properties:
 
 ### Example Key Structure
 
-Below is an example list of keys (with `/<config-path>` set to `/stellar/pubnet/config.json`) for ledger batches based
-on the above example configuration:
+Below is an example list of keys (with `/<config-path>` set to
+`/stellar/pubnet/config.json`) for ledger batches based on the above example
+configuration:
 
 ```
 /stellar/pubnet/config.json
@@ -163,30 +184,33 @@ on the above example configuration:
 
 [![](https://mermaid.ink/img/pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g)
 
-**Note:** The genesis ledger starts at sequence number 2, so the oldest batch must have a `batchStartLedgerSequence`
-of 2.
+**Note:** The genesis ledger starts at sequence number 2, so the oldest batch
+must have a `batchStartLedgerSequence` of 2.
 
 ## Design Rationale
 
 ### Key Encoding (Reversed Ledger Sequence)
 
-- **Lexicographic Order**: Many key-value stores (e.g., GCS, S3) optimize for listing keys in lexicographic order. By
-  encoding the most recent ledgers first, clients can efficiently retrieve the latest data without scanning the entire
-  dataset.
-- **Reversed Sequence**: Using `math.MaxUint32 - startLedger` ensures that newer ledgers (with higher sequence numbers)
-  appear before older ones when sorted lexicographically. This avoids the need for additional metadata or indexes to
-  determine the latest ledger.
+- **Lexicographic Order**: Many key-value stores (e.g., GCS, S3) optimize for
+  listing keys in lexicographic order. By encoding the most recent ledgers
+  first, clients can efficiently retrieve the latest data without scanning the
+  entire dataset.
+- **Reversed Sequence**: Using `math.MaxUint32 - startLedger` ensures that
+  newer ledgers (with higher sequence numbers) appear before older ones when
+  sorted lexicographically. This avoids the need for additional metadata or
+  indexes to determine the latest ledger.
 
 ### Compression Algorithm
 
-- `zstd` was chosen after evaluating `zstd`, `lz4`, and `gzip`. It provides the best balance between compression ratio
-  and decompression speed.
+- `zstd` was chosen after evaluating `zstd`, `lz4`, and `gzip`. It provides the
+  best balance between compression ratio and decompression speed.
 
 ## Security Concerns
 
-Verifying the validity of the ledgers contained within the data store is outside the scope of this SEP. In otherwords,
-this SEP does not provide any mechanism for validating that the ledgers obtained from a data store have not been
-altered.
+Verifying the validity of the ledgers contained within the data store is
+outside the scope of this SEP. In otherwords, this SEP does not provide any
+mechanism for validating that the ledgers obtained from a data store have not
+been altered.
 
 ## Changelog
 

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -35,7 +35,7 @@ The data store is a key-value store where:
 
 The key-value store must support:
 
-- Efficient point lookups for arbitrary keys.
+- Efficient random access lookups on arbitrary keys.
 - Listing keys in lexicographic order, optionally filtered by a prefix.
 
 Examples of compatible key-value stores include Google Cloud Storage (GCS) and Amazon S3.

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -6,7 +6,7 @@ Title: Ledger Metadata Storage
 Author: Tamir Sen <@tamirms>
 Status: Draft
 Created: 2025-03-11
-Version: 0.1.0
+Version: 0.2.0
 ```
 
 ## Simple Summary
@@ -73,17 +73,16 @@ struct LedgerCloseMetaBatch
 
 ### Key Format
 
-Keys follow a hierarchical directory structure. The root directory is `/ledgers`, and subdirectories represent
-partitions. Each partition contains a fixed number of batches:
+Keys follow a hierarchical directory structure, effectively acting as file paths within the data store. All the ledgers are stored under a configurable `/<ledgers-path>`. Within the `/<ledgers-path>` directory there are subdirectories which represent partitions. Each partition contains a fixed number of batches:
 
 ```
-/ledgers/<partition>/<batch>.xdr.zst
+/<ledgers-path>/<partition>/<batch>.xdr.zst
 ```
 
 If the partition size is 1, the partition is omitted, resulting in:
 
 ```
-/ledgers/<batch>.xdr.zst
+/<ledgers-path>/<batch>.xdr.zst
 ```
 
 #### Partition Format:
@@ -92,17 +91,25 @@ If the partition size is 1, the partition is omitted, resulting in:
 fmt.Sprintf("%08X--%d-%d/", math.MaxUint32-partitionStartLedgerSequence, partitionStartLedgerSequence, partitionEndLedgerSequence)
 ```
 
+Example for `partitionStartLedgerSequence=0` and  `partitionEndLedgerSequence=15`: `FFFFFFFF--0-15`
+
 #### Batch Format:
 
 ```go
  fmt.Sprintf("%08X--%d-%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence, batchEndLedgerSequence)
 ```
 
+Example for `batchStartLedgerSequence=2` and  `batchEndLedgerSequence=3`: `FFFFFFFD--2-3.xdr.zst`
+
+
 If the batch size is 1, the format simplifies to:
 
 ```go
  fmt.Sprintf("%08X--%d.xdr.zst", math.MaxUint32-batchStartLedgerSequence, batchStartLedgerSequence)
 ```
+
+Example for `batchStartLedgerSequence=2`: `FFFFFFFD--2.xdr.zst`
+
 
 Note the `.zst` suffix is the filename extension defined in the [Zstandard]([https://facebook.github.io/zstd/)
 [RFC](https://datatracker.ietf.org/doc/html/rfc8478). If this SEP is extended to support another compression algorithm
@@ -112,10 +119,11 @@ then the standard filename extension for the given compression algorithm will be
 
 ### Configuration File
 
-The data store includes a configuration JSON object stored under the key `/config.json`. This file contains the
+The data store includes a configuration JSON object stored under the key `/<config-path>`. This file contains the
 following properties:
 
 - `networkPassphrase` - (string) the passphrase for the Stellar network associated with the ledgers.
+- `ledgersPath` - (string) the `/<ledgers-path>` directory which contains all the partitions and batches.
 - `compression` - (string) the compression algorithm used to compress ledger objects (currently only
   [`zstd`]([https://facebook.github.io/zstd/) is supported).
 - `ledgersPerBatch` - (integer) the number of ledgers bundled into each `LedgerCloseMetaBatch`.
@@ -126,6 +134,7 @@ following properties:
 ```json
 {
   "networkPassphrase": "Public Global Stellar Network ; September 2015",
+  "ledgersPath": "/stellar/pubnet/ledgers",
   "compression": "zstd",
   "ledgersPerBatch": 2,
   "batchesPerPartition": 8
@@ -136,18 +145,19 @@ following properties:
 
 ### Example Key Structure
 
-Below is an example list of keys for ledger batches based on the configuration above:
+Below is an example list of keys (with `/<config-path>` set to  `/stellar/pubnet/config.json`) for ledger batches based on the above example configuration:
 
 ```
-/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr.zst
-/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr.zst
-/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr.zst
+/stellar/pubnet/config.json
+/stellar/pubnet/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr.zst
+/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr.zst
 ```
 
 [![](https://mermaid.ink/img/pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g)
@@ -180,3 +190,4 @@ altered.
 ## Changelog
 
 - `v0.1.0`: Initial draft
+- `v0.2.0`: Make ledgers path and config path configurable

--- a/ecosystem/sep-datastore.md
+++ b/ecosystem/sep-datastore.md
@@ -104,7 +104,7 @@ If the batch size is 1, the format simplifies to:
 
 ### Configuration File
 
-The data store includes a configuration JSON object stored under the key `/config.json``. This file contains the
+The data store includes a configuration JSON object stored under the key `/config.json`. This file contains the
 following properties:
 
 - `networkPassphrase` - (string) the passphrase for the Stellar network associated with the ledgers.


### PR DESCRIPTION
Adds a SEP to document how galexie stores ledger metadata. By formally specifying the data format we can enable third-party developers to build compatible data stores and clients for retrieving ledger metadata.

See also https://github.com/stellar/go/issues/5577 for motivation