### PR TITLE
Minor updates/clarifications for CAP-67

### DIFF
--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -54,9 +54,9 @@ index 5113005..a7c3c7f 100644
      SC_ADDRESS_TYPE_ACCOUNT = 0,
 -    SC_ADDRESS_TYPE_CONTRACT = 1
 +    SC_ADDRESS_TYPE_CONTRACT = 1,
-+    SC_ADDRESS_TYPE_CLAIMABLE_BALANCE = 2,
-+    SC_ADDRESS_TYPE_LIQUIDITY_POOL = 3,
-+    SC_ADDRESS_TYPE_MUXED_ACCOUNT = 4
++    SC_ADDRESS_TYPE_MUXED_ACCOUNT = 2,
++    SC_ADDRESS_TYPE_CLAIMABLE_BALANCE = 3,
++    SC_ADDRESS_TYPE_LIQUIDITY_POOL = 4
  };
  
  union SCAddress switch (SCAddressType type)
@@ -64,12 +64,12 @@ index 5113005..a7c3c7f 100644
      AccountID accountId;
  case SC_ADDRESS_TYPE_CONTRACT:
      Hash contractId;
++case SC_ADDRESS_TYPE_MUXED_ACCOUNT:
++    MuxedAccount muxedAccount;     
 +case SC_ADDRESS_TYPE_CLAIMABLE_BALANCE:
 +    ClaimableBalanceID claimableBalanceId;
 +case SC_ADDRESS_TYPE_LIQUIDITY_POOL:
 +    PoolID liquidityPoolId;
-+case SC_ADDRESS_TYPE_MUXED_ACCOUNT:
-+    MuxedAccount muxedAccount;
  };
  
  %struct SCVal;
@@ -150,40 +150,59 @@ contract: asset, topics: ["clawback", from:Address, sep0011_asset:String], data:
 
 At the moment, if the issuer is the sender in a Stellar Asset Contract `transfer`, the asset will be minted. If the issuer is the recipient, the asset will be burned. The event emitted in both scenarios, however, is the `transfer` event. This CAP changes that behavior to instead emit the `mint`/`burn` event.
 
-### Update the `transfer` function to take in a `MuxedAccount` for `from` and `to`
+### Multiplexing support
 
-This change will allow the `transfer` event to emit muxed information for exchange support. 
+Multiplexing (muxing) is a technique used by the Stellar users to represent custodial accounts, i.e. accounts that are represented by a single on-chain entity, but may have an arbitrary number of off-chain, 'virtual' balances. Stellar protocol currently provides two ways for supporting the account 'multiplexing' ('muxing'): using the transaction memo to identify the payment destination, and the `MuxedAccount` type that can identify the source or destination of most of the Stellar operations.
 
-### Emit a map as the `data` field in the `transfer` event if muxed information is being emitted.
+This CAP ensures that muxing information is represented in the events, and also extends the multiplexing functionality to Soroban operations.
+
+#### Update the SAC `transfer` function to take in a `MuxedAccount` for `from` and `to`
+
+The `transfer` function of the Stellar Asset contract will be updated to accept the `MuxedAccounts` via `SC_ADDRESS_TYPE_MUXED_ACCOUNT` addresses.
+
+#### Prohibit the transaction memo and muxed source accounts from being set on Soroban transactions
+In order to avoid confusion between the multiplexing support mechanism via `transfer` contract function, and the existing multiplexing mechanisms the following changes are made:
+
+- Any transaction with an `InvokeHostFunctionOp` operation that has `memo` set to a value other than `MEMO_NONE` will be rejected as invalid.
+- Any transaction with an `InvokeHostFunctionOp` operation that has a muxed source account (i.e. operation source account when set, transaction source account otherwise) will be rejected as invalid.
+
+#### Emit a map as the `data` field in the `transfer` event if muxed information is being emitted.
 
 The `data` field is currently an integer that represents the `amount`. If no muxed information is being emitted, this will not change. If we're emitting muxed information, then the `data` field on the `transfer` event will be an `SCVal` of type `SCV_MAP`. In
 that case, the key for each map entry will be an `SCSymbol` with the name of the field in `data` (eg. "amount"), and the value will be represented by the types specified by the events below.
 
-Here are the relevant scenarios and what the resulting events should look like - 
+The general `transfer` event format that involves muxed accounts is `topics: ["transfer", from:<non-muxed ScAddress>, to:<non-muxed ScAddress>] data: { amount: i128, from_muxed_id:u64, to_muxed_id:u64|bytes|string }`, where at least one of `from_muxed_id` and `to_muxed_id` is present. The muxed accounts are always represented as a pair of (`non-muxed ScAddress`, `muxed_id`) , i.e the pair of (`from`, `from_muxed_id`) identifies the muxed transfer source and the pair of (`to`, `to_muxed_id`) identifies the muxed transfer destination. Non-muxed accounts are represented as a singular `from`/`to` value in the event topics and the respective `from_muxed_id`/`to_muxed_id` key won't be present in the `data` map.
 
-1. For Soroban transfers -
-   1. If either or both `from` and `to` are of type `KEY_TYPE_MUXED_ED25519`, then the respective `u64` IDs will be pulled out and emitted in the data field - `topics: ["transfer", from:G, to:G] data: { amount: i128, from_muxed_id:u64, to_muxed_id:u64 }`. Note that `from` and `to` are the ed25519 addresses, not the muxed address.
-2. For any of the `transfer` events that can be emitted by non-soroban operations -
-   1. The memo in a non-Soroban transaction can be one of `MEMO_NONE`, `MEMO_TEXT`, `MEMO_ID`, `MEMO_HASH`, or `MEMO_RETURN`. This memo will be forwarded for the destination, so `to_muxed_id` in those scenarios can be of type `SCV_U64`, `SCV_STRING`, or `SCV_BYTES` with a size of 32. Both `MEMO_HASH` and `MEMO_RETURN` use  `BytesN<32>` so the types are indistinguishable in the event.
-   2. If the sender of the `transfer` is muxed, then `from_muxed_id` will be emitted with the `MEMO_ID` on that muxed account.
-   3. If the destination of the `transfer` is muxed, then `to_muxed_id` will be emitted with the `MEMO_ID` on the muxed account. If the destination is not muxed, but the transaction memo is set, then `to_muxed_id` will be emitted with the memo on the transaction. If the destination is muxed and the transaction memo is set, we use the destination's muxed information.
-3. For both scenarios, note that the map will only contain a `from_muxed_id` and/or `to_muxed_id` if there is muxed information for the addresses, so the data field can have one, two, or three elements.
+The mapping between the input muxed addresses and the emitted events is generically defined as follows:
 
-### Prohibit the transaction memo from being set on Soroban transactions as well as soroban transactions with `SOROBAN_CREDENTIALS_ADDRESS` and a muxed source account
-Any transaction with an `InvokeHostFunctionOp` operation that has `memo` set to a value other than `MEMO_NONE` will be rejected as invalid. In addition to that, any transaction with an `InvokeHostFunctionOp` operation that is using `SOROBAN_CREDENTIALS_ADDRESS` in its `auth` payload with a muxed source account will be rejected as well.
+1. `MuxedAccount` (or `ScAddress` that wraps `MuxedAccount`, i.e `SC_ADDRESS_TYPE_MUXED_ACCOUNT`) with `KEY_TYPE_MUXED_ED25519` variant set will be represented as a pair of `ScVal::SCV_ADDRESS` with `ScAddress` type `SC_ADDRESS_TYPE_ACCOUNT` and the same `ed25519` key as in the `MuxedAccount`, and `ScVal::SCV_U64` `muxed_id` with the same value as the `id` field of the `MuxedAccount`.
+2. If transaction memo is not `MEMO_NONE`, and the classic operation in the transaction has the transfer destination that is non-muxed classic account (i.e. is representable by `SC_ADDRESS_TYPE_ACCOUNT` address), then the transfer event destination will be represented as a pair of `ScVal::SCV_ADDRESS` with `to` `ScAddress` type `SC_ADDRESS_TYPE_ACCOUNT` and the same `ed25519` key as in the destination account, and an `to_muxed_id` `ScVal` containing the transaction memo. The memo is mapped to `ScVal` in the following fashion:
+  - `MEMO_ID` is represented by `SCV_U64`
+  - `MEMO_TEXT` is represented by `SCV_STRING`
+  - `MEMO_HASH` and `MEMO_RETURN` are represented as `SCV_BYTES`, i.e. these memo types are indistinguishable in the event
 
-### New Events
-This section will go over the semantics of how the additional `transfer` events are emitted for each operation, as well as the `fee` event emitted for the fee paid by the source account. These events will be emitted through the `events<>` field in the new `OperationMetaV2`. Soroban events will be moved to `OperationMetaV2`. The hash of the current soroban events will still exist under `INVOKE_HOST_FUNCTION_SUCCESS` as it does today. It's also important to note that nothing is being removed from meta, and in fact, the emission of the events mentioned in this section will be configurable through a flag.
+Note, that the memo mapping rules above imply that in case if the destination of the transfer is not a classic account (i.e. a claimable balance, or liquidity pool), or a muxed account itself, then the transaction memo will not be represented in the unified events at all.
 
-Note that the `contract` field for these events corresponds to the Stellar Asset Contract address for the respective asset. The Stellar Asset Contract instance is not required to be deployed for the asset. The events will be published using the reserved contract address regardless of deployment status.
+Here is how the rules above generally apply to the generated unified events (the event-specific sections also contain more detailed information where necessary):
 
-#### Fees paid by source account
+- For `transfer` events coming directly from Soroban (i.e. from Stellar Asset contract) we will represent the input `KEY_TYPE_MUXED_ED25519` muxed account addresses according to the rule 1
+- For the `transfer` events emitted due to non-Soroban value movement we make best-effort mapping based on the input `MuxedAccount`s and the transaction memo:
+  - If the transfer source is a `MuxedAccount` with `KEY_TYPE_MUXED_ED25519`, then `from_muxed_id` will be emitted according to rule 1
+  - If the transfer destination is a `MuxedAccount` with `KEY_TYPE_MUXED_ED25519`, then `to_muxed_id` will be emitted according to rule 1
+  - If the transfer destination is a non-muxed classic account (i.e. `MuxedAccount` with `KEY_TYPE_ED25519` variant set), then emit `to_muxed_id` according to rule 2
 
-For each transaction whose source account pays fees for the execution of a transaction, emit an event in the following format:
+### New Events for Representing Fees
+
+For each transaction whose source account pays fees for the execution of a transaction, emit an event in the following format in the `contractEvents` field of the `TransactionMetaV4`:
 ```
 contract: native asset, topics: ["fee", from:Address], data: [amount:i128]
 ```
-Where from is the account paying the fee, either the fee bump fee account or the tx source account. This event should take the refund into account for Soroban transactions, so the amount on the event would be `initial fee charged - refund`.
+Where `from` is the account paying the fee, either the fee bump fee account or the tx source account. This event should take the refund into account for Soroban transactions, so the amount on the event would be `initial fee charged - refund`.
+
+### New Events for Operations
+This section will go over the semantics of how the additional `transfer`/`mint`/`burn`/`clawback` events are emitted for each operation. These events will be emitted through the `events<>` field in the new `OperationMetaV2`. Soroban events will be moved to `OperationMetaV2`. The hash of the current soroban events will still exist under `INVOKE_HOST_FUNCTION_SUCCESS` as it does today. It's also important to note that nothing is being removed from meta, and in fact, the emission of the events (as well as the new meta version) mentioned in this section will be configurable through a flag.
+
+Note that the `contract` field for these events corresponds to the Stellar Asset Contract address for the respective asset. The Stellar Asset Contract instance is not required to be deployed for the asset. The events will be published using the reserved contract address regardless of deployment status.
 
 #### Payment
 Emit one of the following events -
@@ -203,7 +222,7 @@ When sending to an issuer:
 contract: asset, topics: ["burn", from:Address, sep0011_asset:String], data: amount:i128
 ```
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event.
 
 
 #### Path Payment Strict Send / Path Payment Strict Receive
@@ -231,7 +250,7 @@ The trades within a path payment are conceptually between the source account and
 
 Note that if the path payment has an empty path and `sendAsset == destAsset`, then the operation is effectively a regular [payment](#payment), so emit an event following the specifications of the payment section.
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event. More specifically, if the source account is muxed and appears as `from` or `to` in an event, the respective `from_muxed_id` or `to_muxed_id` will be set. For the final event to the destination, if it is a `transfer`, `to_muxed_account` will be set if the `destination` is muxed, and if not, then it'll be set if the tx memo is set.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event. More specifically, if the source account is muxed and appears as `from` or `to` in an event, the respective `from_muxed_id` or `to_muxed_id` will be set. For the final event to the destination, if it is a `transfer`, `to_muxed_account` will be set if the `destination` is muxed, and if not, then it'll be set if the tx memo is set.
 
 #### Create Account
 Emit the following event:
@@ -243,7 +262,7 @@ contract: native asset, topics: ["transfer", from:Address, to:Address, sep0011_a
 * `to` is the account being credited (created).
 * `amount` is the starting native balance.
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map. The `destination` on a `CreateAccountOp` can't be muxed, so `to_muxed_id`, will only be added to the data map if the transaction memo is set.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map. The `destination` on a `CreateAccountOp` can't be muxed, so `to_muxed_id`, will only be added to the data map if the transaction memo is set.
 
 #### Merge Account
 Emit the following event:
@@ -255,7 +274,7 @@ contract: native asset, topics: ["transfer", from:Address, to:Address, sep0011_a
 * `to` is the account being credited (merged into).
 * `amount` is the merged native balance.
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map. 
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map. 
 
 #### Create Claimable Balance
 Emit the following event:
@@ -272,7 +291,7 @@ If an asset is a movement from the issuer of the asset, instead emit for the mov
 contract: asset, topics: ["mint", to:Address, sep0011_asset:String], data: amount:i128
 ```
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` can be added to the `data` map on the `transfer` event. The `to` address will be a claimable balance id, so it does not make sense to add the transaction memo into the event. Therefore, `to_muxed_id` will not be emitted in this case.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` can be added to the `data` map on the `transfer` event. The `to` address will be a claimable balance id, so it does not make sense to add the transaction memo into the event. Therefore, `to_muxed_id` will not be emitted in this case.
 
 #### Claim Claimable Balance
 Emit the following event:
@@ -288,7 +307,7 @@ If the claim is a movement to the issuer of the asset, instead emit for the move
 contract: asset, topics: ["burn", from:Address, sep0011_asset:String], data: amount:i128
 ```
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event.  The `destination` on a claimable balances `claimant` cannot be muxed, so `to_muxed_id` will only be added to the data map if the transaction memo is set.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event.  The `destination` on a claimable balances `claimant` cannot be muxed, so `to_muxed_id` will only be added to the data map if the transaction memo is set.
 
 #### Liquidity Pool Deposit
 Emit the following events:
@@ -306,7 +325,7 @@ If an asset is a movement from the issuer of the asset, instead emit for the mov
 contract: asset, topics: ["mint", to:Address, sep0011_asset:String], data: amount:i128
 ```
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` can be added to the `data` map on the `transfer` event. The `to` address will be a liquidity pool id, so it does not make sense to add the transaction memo into the event. Therefore, `to_muxed_id` will not be emitted in this case.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `from_muxed_id` can be added to the `data` map on the `transfer` event. The `to` address will be a liquidity pool id, so it does not make sense to add the transaction memo into the event. Therefore, `to_muxed_id` will not be emitted in this case.
 
 #### Liquidity Pool Withdraw
 Emit the following events:
@@ -325,7 +344,7 @@ If an asset is issued by the withdrawer, instead emit for the movement of the is
 contract: asset, topics: ["burn", from:Address, sep0011_asset:String], data: amount:i128
 ```
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `to_muxed_id` can be added to the `data` map on the `transfer` event. The `from` address will be a liquidity pool id, so it does not make sense to add the transaction memo into the event. Therefore, `from_muxed_id` will not be emitted in this case.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), `to_muxed_id` can be added to the `data` map on the `transfer` event. The `from` address will be a liquidity pool id, so it does not make sense to add the transaction memo into the event. Therefore, `from_muxed_id` will not be emitted in this case.
 
 #### Manage Buy Offer / Manage Sell Offer / Create Passive Sell Offer
 Emit two events per offer traded against. Each pair of events represents both sides of a trade. This does mean zero events can be emitted if the resulting offer is not marketable - 
@@ -348,7 +367,7 @@ contract: asset, topics: ["burn", from:Address, sep0011_asset:String], data: amo
 * `from` is the account being debited (seller).
 * `to` is the account being credited (buyer).
 
-As specified in the [section to update the transfer events data field](#Emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event. More specifically, if the source account is muxed and appears as `from` or `to` in an event, the respective `from_muxed_id` or `to_muxed_id` will be set.
+As specified in the [section to update the transfer events data field](#emit-a-map-as-the-data-field-in-the-transfer-event-if-muxed-information-is-being-emitted), both `from_muxed_id` and `to_muxed_id` can be added to the `data` map on the `transfer` event. More specifically, if the source account is muxed and appears as `from` or `to` in an event, the respective `from_muxed_id` or `to_muxed_id` will be set.
 
 #### Clawback / Clawback Claimable Balance
 Emit the following event:


### PR DESCRIPTION
- [functional] State that muxed source accounts are unconditionally prohibited for Soroban. The currently specified rule is in fact incorrect, and in general leaving the muxed source account support for Soroban seems like a footgun.
- [non-functional] Move the fields in ScAddress XDR around a bit to group the 'soroban-representable' types together
- [non-functional] Extend multiplexing section a bit for some context/more detailed definitions.
- [non-functional] Simplify/clarify the rules for emitting the events with muxed sources/destinations, also close some gaps (like it wasn't clearly specified that CB/LP addresses won't ever have memo attached)
- [non-functional] Clarify that fee events are emitted at tx level (and not operation level)