### PR TITLE
Update CAP-67 XDR to include a separate muxed account struct.

### DIFF
--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -42,13 +42,13 @@ The changes specified by this CAP -
 
 ### XDR Changes
 
-This patch of XDR changes is based on the XDR files in commit `734bcccdbb6d1f7e794793ad3b8be51f3ba76f92` of stellar-xdr.
+This patch of XDR changes is based on the XDR files in commit `fa0338f4a25a95320d2143c8f08d200f0a360a4b` of stellar-xdr.
 ```diff mddiffcheck.ignore=true
 diff --git a/Stellar-contract.x b/Stellar-contract.x
-index 5113005..a7c3c7f 100644
+index 5113005..71738cb 100644
 --- a/Stellar-contract.x
 +++ b/Stellar-contract.x
-@@ -179,7 +179,10 @@ case CONTRACT_EXECUTABLE_STELLAR_ASSET:
+@@ -179,7 +179,16 @@ case CONTRACT_EXECUTABLE_STELLAR_ASSET:
  enum SCAddressType
  {
      SC_ADDRESS_TYPE_ACCOUNT = 0,
@@ -57,15 +57,21 @@ index 5113005..a7c3c7f 100644
 +    SC_ADDRESS_TYPE_MUXED_ACCOUNT = 2,
 +    SC_ADDRESS_TYPE_CLAIMABLE_BALANCE = 3,
 +    SC_ADDRESS_TYPE_LIQUIDITY_POOL = 4
++};
++
++struct MuxedEd25519Account
++{
++    uint64 id;
++    uint256 ed25519;
  };
  
  union SCAddress switch (SCAddressType type)
-@@ -188,6 +191,12 @@ case SC_ADDRESS_TYPE_ACCOUNT:
+@@ -188,6 +197,12 @@ case SC_ADDRESS_TYPE_ACCOUNT:
      AccountID accountId;
  case SC_ADDRESS_TYPE_CONTRACT:
      Hash contractId;
 +case SC_ADDRESS_TYPE_MUXED_ACCOUNT:
-+    MuxedAccount muxedAccount;     
++    MuxedEd25519Account muxedAccount;
 +case SC_ADDRESS_TYPE_CLAIMABLE_BALANCE:
 +    ClaimableBalanceID claimableBalanceId;
 +case SC_ADDRESS_TYPE_LIQUIDITY_POOL:
@@ -74,17 +80,15 @@ index 5113005..a7c3c7f 100644
  
  %struct SCVal;
 diff --git a/Stellar-ledger.x b/Stellar-ledger.x
-index 6ab63fb..f86e17a 100644
+index 0fc03e2..963acc4 100644
 --- a/Stellar-ledger.x
 +++ b/Stellar-ledger.x
-@@ -446,7 +446,44 @@ struct TransactionMetaV3
+@@ -434,6 +434,41 @@ struct TransactionMetaV3
                                           // Soroban transactions).
  };
  
 +struct OperationMetaV2
 +{
-+    // We can use this to add more fields, or because it
-+    // is first, to change OperationMetaV2 into a union.
 +    ExtensionPoint ext;
 +
 +    LedgerEntryChanges changes;
@@ -106,22 +110,22 @@ index 6ab63fb..f86e17a 100644
 +
 +    LedgerEntryChanges txChangesBefore;  // tx level changes before operations
 +                                         // are applied if any
-+    OperationMetaV2 operations<>;          // meta for each operation
++    OperationMetaV2 operations<>;        // meta for each operation
 +    LedgerEntryChanges txChangesAfter;   // tx level changes after operations are
 +                                         // applied if any
 +    SorobanTransactionMetaV2* sorobanMeta; // Soroban-specific meta (only for
 +                                           // Soroban transactions).
 +
-+    ContractEvent events<>;
-+    DiagnosticEvent txDiagnosticEvents<>; // Used for diagnostic information not tied
-+                                          // to an operation.
++    ContractEvent events<>; // Used for transaction-level events (like fee payment)
++    DiagnosticEvent txDiagnosticEvents<>; // Used for transaction-level diagnostic
++                                          //  information
 +};
++
 +
  // This is in Stellar-ledger.x to due to a circular dependency 
  struct InvokeHostFunctionSuccessPreImage
  {
-     SCVal returnValue;
-@@ -465,6 +502,8 @@ case 2:
+@@ -453,6 +488,8 @@ case 2:
      TransactionMetaV2 v2;
  case 3:
      TransactionMetaV3 v3;


### PR DESCRIPTION
The previous version used the `MuxedAccount` union that has non-muxed variant. That created unnecessary ambiguity in ScAddress.