### PR TITLE
Fix the status on CAPs 62-69 and the protocol version

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -95,14 +95,14 @@
 | [CAP-0057](cap-0057.md) | State Archival Persistent Entry Eviction | Garand Tyson | Draft |
 | [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Accepted |
 | [CAP-0061](cap-0061.md) | Smart Contract Standardized Asset (Stellar Asset Contract) Extension: Memo | Tomer Weller | Draft |
-| [CAP-0062](cap-0062.md) | Soroban Live State Prioritization | Garand Tyson | Draft |
-| [CAP-0063](cap-0063.md) | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | Draft |
-| [CAP-0064](cap-0064.md) | Memo Authorization for Soroban | Dmytro Kozhevin | Draft |
-| [CAP-0065](cap-0065.md) | Reusable Module Cache | Graydon Hoare | Draft |
-| [CAP-0066](cap-0066.md) | Soroban In-memory Read Resource | Garand Tyson | Draft |
-| [CAP-0067](cap-0067.md) | Unified Asset Events | Siddharth Suresh | Draft |
-| [CAP-0068](cap-0068.md) | Host function for getting  executable for `Address` | Dmytro Kozhevin | Draft |
-| [CAP-0069](cap-0069.md) | String/Bytes conversion host functions | Dmytro Kozhevin | Draft |
+| [CAP-0062](cap-0062.md) | Soroban Live State Prioritization | Garand Tyson | Awaiting Decision |
+| [CAP-0063](cap-0063.md) | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | Awaiting Decision |
+| [CAP-0064](cap-0064.md) | Memo Authorization for Soroban | Dmytro Kozhevin | Rejected |
+| [CAP-0065](cap-0065.md) | Reusable Module Cache | Graydon Hoare | Awaiting Decision |
+| [CAP-0066](cap-0066.md) | Soroban In-memory Read Resource | Garand Tyson | Awaiting Decision |
+| [CAP-0067](cap-0067.md) | Unified Asset Events | Siddharth Suresh | Awaiting Decision |
+| [CAP-0068](cap-0068.md) | Host function for getting  executable for `Address` | Dmytro Kozhevin | Awaiting Decision |
+| [CAP-0069](cap-0069.md) | String/Bytes conversion host functions | Dmytro Kozhevin | Awaiting Decision |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0046-06.md
+++ b/core/cap-0046-06.md
@@ -387,6 +387,11 @@ uses it will error. For the `Contract` scenario, the contract will create a
 `clawback` flag to mimic classic trustlines and allow for the same issuer
 controls.
 
+#### `set_authorized`
+If the `set_authorized` function is called with `authorize == true` on an `Account`, it will set the accounts trustline's flag to `AUTHORIZED_FLAG` and unset `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` if the trustline currently does not have `AUTHORIZED_FLAG` set.
+
+If the `set_authorized` function is called with `authorize == false` on an `Account`, it will set the accounts trustline's flag to `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` and unset `AUTHORIZED_FLAG` if the trustline currently has `AUTHORIZED_FLAG` set. We set `AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG` instead of clearing the flags to avoid pulling all offers and pool shares that involve this trustline.
+
 #### Authorized flag
 Contract balances will be authorized by default unless the issuer account has
 `AUTH_REQUIRED_FLAG` set.

--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -8,7 +8,7 @@ Working Group:
 Status: Draft
 Created: 2024-12-02
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1575
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>
     Consulted: Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Draft
+Status: Awaiting Decision
 Created: 2024-12-02
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1575
 Protocol version: TBD

--- a/core/cap-0063.md
+++ b/core/cap-0063.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2024-12-18
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1602
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0063.md
+++ b/core/cap-0063.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: dmkozh@stellar.org
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted: Siddharth Suresh <@sisuresh>, Nicolas Barry <@MonsieurNicolas>, Graydon Hoare <@graydon>
-Status: Draft
+Status: Awaiting Decision
 Created: 2024-12-18
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1602
 Protocol version: TBD

--- a/core/cap-0064.md
+++ b/core/cap-0064.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: dmkozh@stellar.org
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted: Leigh McCulloch <@leighmcculloch>, Siddharth Suresh <@sisuresh>
-Status: Draft
+Status: Rejected
 Created: 2025-01-09
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1610
 Protocol version: TBD

--- a/core/cap-0064.md
+++ b/core/cap-0064.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2025-01-09
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1610
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0065.md
+++ b/core/cap-0065.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1615
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0065.md
+++ b/core/cap-0065.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Garand Tyson <@SirTyson>, Siddharth Suresh <@sisuresh>, Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Draft
+Status: Awaiting Decision
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1615
 Protocol version: TBD

--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>
     Consulted: Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Draft
+Status: Awaiting Decision
 Created: 2024-12-09
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1585
 Protocol version: TBD

--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -8,7 +8,7 @@ Working Group:
 Status: Draft
 Created: 2024-12-09
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1585
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -15,7 +15,7 @@ Protocol version: 23
 
 ## Simple Summary
 
-Emit `transfer`, `mint`, `burn`, `clawback`, and `fee` events in Classic in the same format as what we see in Soroban so that the movement of assets can be tracked using a single stream of data. In addition to emitting events in Classic, update the events emitted in the Stellar Asset Contract to be semantically correct and compatible with SEP-41.
+Emit `transfer`, `mint`, `burn`, `clawback`, `fee`, and `set_authorized` events in Classic in the same format as what we see in Soroban so that the movement of assets and trustline updates can be tracked using a single stream of data. In addition to emitting events in Classic, update the events emitted in the Stellar Asset Contract to be semantically correct and compatible with SEP-41.
 
 ## Motivation
 
@@ -138,7 +138,7 @@ index 0fc03e2..963acc4 100644
 
 ## Semantics
 
-### Remove the admin from the SAC `mint` and `clawback` events
+### Remove the admin from the SAC `mint`, `clawback`, and `set_authorized` events
 
 The `mint` event will look like:
 ```
@@ -148,6 +148,11 @@ contract: asset, topics: ["mint", to:Address, sep0011_asset:String], data: amoun
 The `clawback` event will look like:
 ```
 contract: asset, topics: ["clawback", from:Address, sep0011_asset:String], data: amount:i128
+```
+
+The `set_authorized` event will look like:
+```
+contract: asset, topics: ["set_authorized", id:Address, sep0011_asset:String], data: authorize:bool
 ```
 
 ### Emit the semantically correct event for a Stellar Asset Contract `transfer` when the issuer is involved 
@@ -204,7 +209,7 @@ contract: native asset, topics: ["fee", from:Address], data: [amount:i128]
 Where `from` is the account paying the fee, either the fee bump fee account or the tx source account. This event should take the refund into account for Soroban transactions, so the amount on the event would be `initial fee charged - refund`.
 
 ### New Events for Operations
-This section will go over the semantics of how the additional `transfer`/`mint`/`burn`/`clawback` events are emitted for each operation. These events will be emitted through the `events<>` field in the new `OperationMetaV2`. Soroban events will be moved to `OperationMetaV2`. The hash of the current soroban events will still exist under `INVOKE_HOST_FUNCTION_SUCCESS` as it does today. It's also important to note that nothing is being removed from meta, and in fact, the emission of the events (as well as the new meta version) mentioned in this section will be configurable through a flag.
+This section will go over the semantics of how the additional `transfer`/`mint`/`burn`/`clawback`, `set_authorized` events are emitted for each operation. These events will be emitted through the `events<>` field in the new `OperationMetaV2`. Soroban events will be moved to `OperationMetaV2`. The hash of the current soroban events will still exist under `INVOKE_HOST_FUNCTION_SUCCESS` as it does today. It's also important to note that nothing is being removed from meta, and in fact, the emission of the events (as well as the new meta version) mentioned in this section will be configurable through a flag.
 
 Note that the `contract` field for these events corresponds to the Stellar Asset Contract address for the respective asset. The Stellar Asset Contract instance is not required to be deployed for the asset. The events will be published using the reserved contract address regardless of deployment status.
 
@@ -385,6 +390,15 @@ contract: asset, topics: ["clawback", from:Address, sep0011_asset:String], data:
 
 
 #### Allow Trust / Set Trustline Flags
+If a trustline has the `AUTHORIZED_FLAG` added or removed, as a result of one of these operations, then a `set_authorized` event should be emitted.
+
+```
+contract: asset, topics: ["set_authorized", id:Address, sep0011_asset:String], data: authorize:bool
+```
+
+* `id` is the account that the trustline belongs to.
+* `authorize` is a bool that determines if the trustline is now authorized to send and receive payments for this asset.
+
 If either operation is used to revoke authorization from a trustline that deposited into a liquidity pool then claimable balances can be created for the withdrawn assets (See [CAP-0038](cap-0038.md#SetTrustLineFlagsOp-and-AllowTrustOp) for more info). If any claimable balances are created due to this scenario, emit the following event for each claimable balance:
 
 ```

--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Siddharth Suresh <@sisuresh>
     Authors: Siddharth Suresh <@sisuresh>, Leigh McCulloch <@leighmcculloch>
     Consulted: Dmytro Kozhevin <@dmkozh>, Jake Urban <jake@stellar.org>, Simon Chow <simon.chow@stellar.org>
-Status: Draft
+Status: Awaiting Decision
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1553
 Protocol version: TBD

--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1553
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0068.md
+++ b/core/cap-0068.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1626
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0068.md
+++ b/core/cap-0068.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: Draft
+Status: Awaiting Decision
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1626
 Protocol version: TBD

--- a/core/cap-0069.md
+++ b/core/cap-0069.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: Draft
+Status: Awaiting Decision
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1633
 Protocol version: TBD

--- a/core/cap-0069.md
+++ b/core/cap-0069.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Draft
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1633
-Protocol version: 23
+Protocol version: TBD
 ```
 
 ## Simple Summary


### PR DESCRIPTION
### What
Flip `Protocol Version` of draft CAPs to TBD and move the statuses to Awaiting Decision. 
Once CAP is accepted and implemented we would set the Protocol Version that they would be available in.