### PR TITLE
CAP-0067 - Remove op level diagnostic event vector

### DIFF
--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -94,7 +94,6 @@ index 0fc03e2..963acc4 100644
 +    LedgerEntryChanges changes;
 +
 +    ContractEvent events<>;
-+    DiagnosticEvent diagnosticEvents<>;
 +}
 +
 +struct SorobanTransactionMetaV2
@@ -117,8 +116,7 @@ index 0fc03e2..963acc4 100644
 +                                           // Soroban transactions).
 +
 +    ContractEvent events<>; // Used for transaction-level events (like fee payment)
-+    DiagnosticEvent txDiagnosticEvents<>; // Used for transaction-level diagnostic
-+                                          //  information
++    DiagnosticEvent diagnosticEvents<>; // Used for all diagnostic information
 +};
 +
 +

--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -464,6 +464,10 @@ Soroban authorization payloads with `SOROBAN_CREDENTIALS_ADDRESS` do not sign th
 
 The `transfer` event can emit muxed information for both `from` and `to`, where the transaction memo will be forwarded to `to_muxed_id` for classic if the destination is not muxed, but the CAP has specified that if the destination is muxed and the transaction memo is set for classic events, then we set `to_muxed_id` using an order of precedence. We use the destinations muxed information over the transaction memo. The alternative was to also emit a transaction level `tx_memo` event, but we determined that this was not necessary as setting both a muxed destination account and a tx memo is an edge case without a relevant use case. If a consumer wants the tx memo as well, they can just look for it in the transaction.
 
+### No diagnostics in OperationMetaV2
+
+We currently clear all `OperationMeta` when a transaction fails, but with the way `OperationMetaV2` is setup in the CAP, we wouldn't be able to do that if there was a diagnostics vector inside `OperationMetaV2` is used. We would have to keep around each `OperationMetaV2` object, and clear the non diagnostic internals. Instead of making this change that downstream consumers may not expect, using the transaction level diagnostics vector for all diagnostics is sufficient. Classic operations won't emit any diagnostics in V23, and if we want them to in the future, we can just modify the diagnostic events to contain the operation id if that information is needed.
+
 ## Protocol Upgrade Transition
 On the protocol upgrade, the SAC will start emitting the `mint` and `clawback` events without the `admin` topic. Also, the `transfer` event will not be emitted for `transfers` involving the issuer. Instead, the appropriate `mint`/`burn` will be emitted.
 


### PR DESCRIPTION
We currently clear all `OperationMeta` when a transaction fails, @jayz22 mentioned that with the way the xdr is setup in the CAP, we wouldn't be able to do that if the diagnostics vector inside `OperationMetaV2` is used. We then realized that we don't gain much from having diagnostics in `OperationMetaV2` instead of just using the vector in `TransactionMetaV4`. Classic operations won't emit any diagnostics in v23, and if we want them to in the future, we can just modify the diagnostic events to contain the operation id.