### PR TITLE
SEP-48: Add Contract Interface Specification to table

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -76,6 +76,7 @@
 | [SEP-0045](sep-0045.md) | Stellar Web Authentication for Contract Accounts               | Philip Liu, Marcelo Salloum, Leigh McCulloch  | Standard      | Draft                |
 | [SEP-0046](sep-0046.md) | Contract Meta                                                  | Leigh McCulloch                               | Standard      | Draft                |
 | [SEP-0047](sep-0047.md) | Standard Interface Discovery                                   | Leigh McCulloch                               | Standard      | Draft                |
+| [SEP-0048](sep-0048.md) | Contract Interface Specification                               | Leigh McCulloch                               | Standard      | Draft                |
 
 ### Rejected and Deprecated Proposals
 


### PR DESCRIPTION
### What
Add SEP-0048 Contract Interface Specification to the ecosystem README table.

### Why
The new SEP-0048 draft proposal needs to be listed with other SEPs for discoverability.