### PR TITLE
SEP-47: Rename to Contract Interface Discovery

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -87,7 +87,7 @@
 | [SEP-0041](sep-0041.md) | Soroban Token Interface                                        | Jonathan Jove, Siddharth Suresh               | Standard      | Draft                |
 | [SEP-0045](sep-0045.md) | Stellar Web Authentication for Contract Accounts               | Philip Liu, Marcelo Salloum, Leigh McCulloch  | Standard      | Draft                |
 | [SEP-0046](sep-0046.md) | Contract Meta                                                  | Leigh McCulloch                               | Standard      | Draft                |
-| [SEP-0047](sep-0047.md) | Standard Interface Discovery                                   | Leigh McCulloch                               | Standard      | Draft                |
+| [SEP-0047](sep-0047.md) | Contract Interface Discovery                                   | Leigh McCulloch                               | Standard      | Draft                |
 | [SEP-0048](sep-0048.md) | Contract Interface Specification                               | Leigh McCulloch                               | Standard      | Draft                |
 | [SEP-0049](sep-0049.md) | Upgradeable Contracts                                          | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Standard      | Draft                |
 | [SEP-0050](sep-0050.md) | Non-Fungible Tokens                                            | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Standard      | Draft                |

--- a/ecosystem/sep-0047.md
+++ b/ecosystem/sep-0047.md
@@ -2,7 +2,7 @@
 
 ```
 SEP: 0047
-Title: Standard Interface Discovery
+Title: Contract Interface Discovery
 Author: Leigh McCulloch
 Track: Standard
 Status: Draft


### PR DESCRIPTION
### What
Rename SEP-47 from Standard Interface Discovery to Contract Interface Discovery.

### Why
To make the title more clear and obvious to the scopeand context of the interface discovery. The use of the term Standard at the front is generic and provides no scope. Because of Stellar's context of classic and contracts the contract prefix is helpful in setting the scope and intent.