### PR TITLE
SEP-46/48: Change status to Active

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -65,6 +65,8 @@
 | [SEP-0029](sep-0029.md) | Account Memo Requirements                                              | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières      | Standard | Active                                                            |
 | [SEP-0031](sep-0031.md) | Cross-Border Payments API                                              | SDF                                                           | Standard | Active                                                            |
 | [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts                                        | Lobstr.co, Gleb Pitsevich                                     | Standard | Active                                                            |
+| [SEP-0046](sep-0046.md) | Contract Meta                                                          | Leigh McCulloch                                               | Standard | Active                                                            |
+| [SEP-0048](sep-0048.md) | Contract Interface Specification                                       | Leigh McCulloch                                               | Standard | Active                                                            |
 
 ### Draft Proposals
 
@@ -86,9 +88,7 @@
 | [SEP-0040](sep-0040.md) | Oracle Consumer Interface                                      | Alex Mootz, OrbitLens, Markus Paulson-Luna    | Standard      | Draft                |
 | [SEP-0041](sep-0041.md) | Soroban Token Interface                                        | Jonathan Jove, Siddharth Suresh               | Standard      | Draft                |
 | [SEP-0045](sep-0045.md) | Stellar Web Authentication for Contract Accounts               | Philip Liu, Marcelo Salloum, Leigh McCulloch  | Standard      | Draft                |
-| [SEP-0046](sep-0046.md) | Contract Meta                                                  | Leigh McCulloch                               | Standard      | Draft                |
 | [SEP-0047](sep-0047.md) | Standard Interface Discovery                                   | Leigh McCulloch                               | Standard      | Draft                |
-| [SEP-0048](sep-0048.md) | Contract Interface Specification                               | Leigh McCulloch                               | Standard      | Draft                |
 | [SEP-0049](sep-0049.md) | Upgradeable Contracts                                          | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Standard      | Draft                |
 | [SEP-0050](sep-0050.md) | Non-Fungible Tokens                                            | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Standard      | Draft                |
 

--- a/ecosystem/sep-0046.md
+++ b/ecosystem/sep-0046.md
@@ -5,10 +5,10 @@ SEP: 0046
 Title: Contract Meta
 Author: Leigh McCulloch
 Track: Standard
-Status: Draft
+Status: Active
 Created: 2025-02-13
-Updated: 2025-02-13
-Version: 0.1.0
+Updated: 2025-04-16
+Version: 1.0.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1656
 ```
 
@@ -74,7 +74,7 @@ case SC_META_V0:
 };
 ```
 
-Ref: https://github.com/stellar/stellar-xdr/blob/curr/Stellar-contract-meta.x
+Ref: <https://github.com/stellar/stellar-xdr/blob/curr/Stellar-contract-meta.x>
 
 ## Example Usage
 
@@ -97,7 +97,7 @@ Contract meta can be inserted via the [`stellar contract build`] at build time
 using the `--meta` option.
 
 ```
-$ stellar contract build --meta key1=val2 --meta key2=val2
+stellar contract build --meta key1=val2 --meta key2=val2
 ```
 
 [`stellar contract build`]:
@@ -173,5 +173,6 @@ any SEP that defines meta keys.
 
 ## Changelog
 
+- `v1.0.0`: Status changed to Active.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
   soroban-sdk and stellar-cli.

--- a/ecosystem/sep-0048.md
+++ b/ecosystem/sep-0048.md
@@ -5,9 +5,9 @@ SEP: 0048
 Title: Contract Interface Specification
 Author: Leigh McCulloch
 Track: Standard
-Status: Draft
+Status: Active
 Created: 2025-03-26
-Updated: 2025-03-26
+Updated: 2025-04-16
 Version: 0.1.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1693
 ```
@@ -297,7 +297,7 @@ case SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
 };
 ```
 
-Ref: https://github.com/stellar/stellar-xdr/blob/curr/Stellar-contract-spec.x
+Ref: <https://github.com/stellar/stellar-xdr/blob/curr/Stellar-contract-spec.x>
 
 ### XDR Common Fields
 
@@ -1416,6 +1416,7 @@ do not exist. Or a contract may omit spec entries for functions that do exist.
 
 ## Changelog
 
+- `v1.0.0`: Status changed to Active.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
   [`soroban-sdk`].
 


### PR DESCRIPTION
### What
Change the status of SEP-46 and SEP-48 to Active.

### Why
Both SEPs describe existing standards that are well adopted.