### PR TITLE
[ANCHOR-1031] Fix signature count when a manage data operation with  is present.

### DIFF
--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -37,17 +37,17 @@ It involves the following components:
   GET and POST operations discussed in this document. The server's domain may
   be the **Home Domain**, a sub-domain of the **Home Domain**, or a different
   domain.
-    - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
+  - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
 - A **Client Account**: the account being authenticated.
-    - A Stellar account (`G...`) or a muxed account (`M...`).
-    - If a Stellar account (`G...`), may be accompanied by a memo to scope the
-      authentication to a user or sub-account of the account.
+  - A Stellar account (`G...`) or a muxed account (`M...`).
+  - If a Stellar account (`G...`), may be accompanied by a memo to scope the
+    authentication to a user or sub-account of the account.
 - A **Client**: the software used by the holder of the **Client Account** being
   authenticated by the **Server**.
 - A **Client Domain** (optional): a domain hosting a
   [SEP-1 stellar.toml](sep-0001.md) containing a `SIGNING_KEY` used for
   [Verifying the Client Domain](#verifying-the-client-domain)
-    - The `SIGNING_KEY` from this domain is the **Client Domain Account**
+  - The `SIGNING_KEY` from this domain is the **Client Domain Account**
 
 The discovery flow is as follows:
 
@@ -72,20 +72,20 @@ The authentication flow is as follows:
    Account** obtained through discovery flow.
 1. The **Client** verifies that the transaction's first operation is a Manage
    Data operation that has its:
-    1. Source account set to the **Client Account**
-    1. Key set to `<home domain> auth` where the home domain is the **Home
-       Domain**.
-    1. Value set to a nonce value.
+   1. Source account set to the **Client Account**
+   1. Key set to `<home domain> auth` where the home domain is the **Home
+      Domain**.
+   1. Value set to a nonce value.
 1. The **Client** verifies that if the transaction has a Manage Data operation
    with key `web_auth_domain` that it has:
-    1. Source account set to the **Server Account**.
-    1. Value set to the **Server**'s domain that the client requested the
-       challenge from.
+   1. Source account set to the **Server Account**.
+   1. Value set to the **Server**'s domain that the client requested the
+      challenge from.
 1. The **Client** verifies that if the transaction has other operations they
    are Manage Data operations and that their source account is set to:
-    1. The **Client Domain Account** if the Manage Data operation key is set to
-       `client_domain`
-    1. Otherwise, the **Server Account**.
+   1. The **Client Domain Account** if the Manage Data operation key is set to
+      `client_domain`
+   1. Otherwise, the **Server Account**.
 1. If the client included a client domain in the request, and the transaction
    has a Manage Data operation with key `client_domain`, the **Client** obtains
    a signature from the **Client Domain Account** and adds it to the challenge
@@ -281,35 +281,35 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object
 with these fields:
 
 - `transaction`: an XDR-encoded Stellar transaction with the following:
-    - source account set to the **Server Account**
-    - invalid sequence number (set to 0) so the transaction cannot be run on the
-      Stellar network
-    - time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of
-      15 minutes to give the **Client** time to sign transaction)
-    - memo: the `memo` value passed by the **Client** if specified, omitted
-      otherwise
-    - operations:
-        - `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
-            - The source account is the **Client Account**
-            - The value of key is the **Home Domain**, followed by `auth`. It can be
-              at most 64 characters.
-            - The value must be 64 bytes long. It contains a 48 byte
-              cryptographic-quality random string encoded using base64 (for a total
-              of 64 bytes after encoding).
-        - subsequent operations, order unimportant:
-            - `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
-                - The source account is the **Server Account**
-                - The value is the **Server**'s domain. It can be at most 64
-                  characters.
-            - (optional)
-              `manage_data(source: client domain account, key: 'client_domain', value: client_domain)`
-                - The source account is the **Client Domain Account**
-                - Add this operation if the server supports
-                  [Verifying the Client Domain](#verifying-the-client-domain) and the
-                  client provided a `client_domain` parameter in the request.
-            - zero or more `manage_data(source: server account, ...)` reserved for
-              future use
-    - signature by the **Server Account**
+  - source account set to the **Server Account**
+  - invalid sequence number (set to 0) so the transaction cannot be run on the
+    Stellar network
+  - time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of
+    15 minutes to give the **Client** time to sign transaction)
+  - memo: the `memo` value passed by the **Client** if specified, omitted
+    otherwise
+  - operations:
+    - `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
+      - The source account is the **Client Account**
+      - The value of key is the **Home Domain**, followed by `auth`. It can be
+        at most 64 characters.
+      - The value must be 64 bytes long. It contains a 48 byte
+        cryptographic-quality random string encoded using base64 (for a total
+        of 64 bytes after encoding).
+    - subsequent operations, order unimportant:
+      - `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
+        - The source account is the **Server Account**
+        - The value is the **Server**'s domain. It can be at most 64
+          characters.
+      - (optional)
+        `manage_data(source: client domain account, key: 'client_domain', value: client_domain)`
+        - The source account is the **Client Domain Account**
+        - Add this operation if the server supports
+          [Verifying the Client Domain](#verifying-the-client-domain) and the
+          client provided a `client_domain` parameter in the request.
+      - zero or more `manage_data(source: server account, ...)` reserved for
+        future use
+  - signature by the **Server Account**
 - `network_passphrase`: (optional but recommended) Stellar network passphrase
   used by the **Server**. This allows a **Client** to verify that it's using
   the correct passphrase when signing and is useful for identifying when a
@@ -391,25 +391,25 @@ must be rejected — that is, treated by the **Server** as an invalid input.
   the minimum and maximum bounds;
 - verify that transaction contains at least one operation;
 - verify that transaction's first operation:
-    - is a Manage Data operation
-    - has a non-null source account
+  - is a Manage Data operation
+  - has a non-null source account
 - verify that transaction envelope has a correct signature by the **Server
   Account**
 - if the first operation's source account exists:
-    - verify that the remaining signature count is one or more;
-    - verify that remaining signatures on the transaction are signers of the
-      **Client Account**
-    - verify that remaining signatures are correct;
-    - verify that remaining signatures provide weight that meets the required
-      threshold(s), if any;
+  - verify that the remaining signature count is one or more;
+  - verify that remaining signatures on the transaction are signers of the
+    **Client Account**
+  - verify that remaining signatures are correct;
+  - verify that remaining signatures provide weight that meets the required
+    threshold(s), if any;
 - if the first operation's source account does not exist:
-    - verify that remaining signature count is one;
-    - verify that remaining signature is correct for the master key of the
-      **Client Account**
+  - verify that remaining signature count is one;
+  - verify that remaining signature is correct for the master key of the
+    **Client Account**
 - if the transaction contains a Manage Data operation with the key
   `client_domain`:
-    - verify that the transaction was signed by the source account of the Manage
-      Data operation
+  - verify that the transaction was signed by the source account of the Manage
+    Data operation
 - verify that transaction containing additional Manage Data operations have
   their source account set to the **Server Account**;
 - verify that transaction sequenceNumber is equal to zero;
@@ -429,13 +429,13 @@ containing the following claims:
 - `sub` (the principal that is the subject of the JWT,
   [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2))
   — there are several possible formats:
-    - If the **Client Account** is a muxed account (`M...`), the `sub` value
-      should be the muxed account (`M...`).
-    - If the **Client Account** is a stellar account (`G...`):
-        - And, a memo was attached to the challenge transaction, the `sub` should
-          be the stellar account appended with the memo, separated by a colon
-          (`G...:17509749319012223907`).
-        - Otherwise, the `sub` value should be Stellar account (`G...`).
+  - If the **Client Account** is a muxed account (`M...`), the `sub` value
+    should be the muxed account (`M...`).
+  - If the **Client Account** is a stellar account (`G...`):
+    - And, a memo was attached to the challenge transaction, the `sub` should
+      be the stellar account appended with the memo, separated by a colon
+      (`G...:17509749319012223907`).
+    - Otherwise, the `sub` value should be Stellar account (`G...`).
 - `iat` (the time at which the JWT was issued
   [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6))
   — current timestamp (`1530644093`)
@@ -454,7 +454,7 @@ The **Server** should not provide more than one JWT for a specific challenge
 transaction.
 
 [Uniform Resource Identifier (URI)]:
-https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+  https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 [RFC7519]: https://tools.ietf.org/html/rfc7519
 
 #### Request
@@ -550,7 +550,7 @@ capability to choose the destination of payments on the network which require a
 medium threshold.
 
 [SEP-24]:
-https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
+  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
 
 ### Verifying Complete Authority
 

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -7,7 +7,7 @@ Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh Mc
 Status: Active
 Created: 2018-07-31
 Updated: 2024-03-20
-Version: 3.4.0
+Version: 3.4.1
 ```
 
 ## Simple Summary
@@ -104,7 +104,8 @@ The authentication flow is as follows:
 1. The **Server** verifies the weight provided by the signers of the **Client
    Account** meets the required threshold(s), if any
 1. If the **Client Account** does not exist (optional):
-1. The **Server** verifies the signature count is two
+1. The **Server** verifies the signature count is three if a Manage Data operation with
+   key `client_domain` is present. Otherwise, the signature count must be two.
 1. The **Server** verifies that one signature is correct for the master key of
    the **Client Account**
 1. The **Server** verified that the other signature is from the **Server
@@ -676,7 +677,8 @@ JWTs: [IETF JWT BCP].
 
 ## Changelog
 
-- `v3.4.0`: Add Authorization header for `GET <WEB_AUTH_ENDPOINT>`
+- `v3.4.1`: Fix signature count when a manage data operation with `client_domain` is present.
+- `v3.4.0`: Add Authorization header for `GET <WEB_AUTH_ENDPOINT>`.
   ([#1470](https://github.com/stellar/stellar-protocol/pull/1470))
 - `v3.3.2`: Fixed formatting of markdown section headers.
   ([1175](https://github.com/stellar/stellar-protocol/pull/1175))

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -37,17 +37,17 @@ It involves the following components:
   GET and POST operations discussed in this document. The server's domain may
   be the **Home Domain**, a sub-domain of the **Home Domain**, or a different
   domain.
-  - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
+    - The `SIGNING_KEY` from the **Home Domain** is the **Server Account**.
 - A **Client Account**: the account being authenticated.
-  - A Stellar account (`G...`) or a muxed account (`M...`).
-  - If a Stellar account (`G...`), may be accompanied by a memo to scope the
-    authentication to a user or sub-account of the account.
+    - A Stellar account (`G...`) or a muxed account (`M...`).
+    - If a Stellar account (`G...`), may be accompanied by a memo to scope the
+      authentication to a user or sub-account of the account.
 - A **Client**: the software used by the holder of the **Client Account** being
   authenticated by the **Server**.
 - A **Client Domain** (optional): a domain hosting a
   [SEP-1 stellar.toml](sep-0001.md) containing a `SIGNING_KEY` used for
   [Verifying the Client Domain](#verifying-the-client-domain)
-  - The `SIGNING_KEY` from this domain is the **Client Domain Account**
+    - The `SIGNING_KEY` from this domain is the **Client Domain Account**
 
 The discovery flow is as follows:
 
@@ -72,20 +72,20 @@ The authentication flow is as follows:
    Account** obtained through discovery flow.
 1. The **Client** verifies that the transaction's first operation is a Manage
    Data operation that has its:
-   1. Source account set to the **Client Account**
-   1. Key set to `<home domain> auth` where the home domain is the **Home
-      Domain**.
-   1. Value set to a nonce value.
+    1. Source account set to the **Client Account**
+    1. Key set to `<home domain> auth` where the home domain is the **Home
+       Domain**.
+    1. Value set to a nonce value.
 1. The **Client** verifies that if the transaction has a Manage Data operation
    with key `web_auth_domain` that it has:
-   1. Source account set to the **Server Account**.
-   1. Value set to the **Server**'s domain that the client requested the
-      challenge from.
+    1. Source account set to the **Server Account**.
+    1. Value set to the **Server**'s domain that the client requested the
+       challenge from.
 1. The **Client** verifies that if the transaction has other operations they
    are Manage Data operations and that their source account is set to:
-   1. The **Client Domain Account** if the Manage Data operation key is set to
-      `client_domain`
-   1. Otherwise, the **Server Account**.
+    1. The **Client Domain Account** if the Manage Data operation key is set to
+       `client_domain`
+    1. Otherwise, the **Server Account**.
 1. If the client included a client domain in the request, and the transaction
    has a Manage Data operation with key `client_domain`, the **Client** obtains
    a signature from the **Client Domain Account** and adds it to the challenge
@@ -104,8 +104,9 @@ The authentication flow is as follows:
 1. The **Server** verifies the weight provided by the signers of the **Client
    Account** meets the required threshold(s), if any
 1. If the **Client Account** does not exist (optional):
-1. The **Server** verifies the signature count is three if a Manage Data operation with
-   key `client_domain` is present. Otherwise, the signature count must be two.
+1. The **Server** verifies the signature count is three if a Manage Data
+   operation with key `client_domain` is present. Otherwise, the signature
+   count must be two.
 1. The **Server** verifies that one signature is correct for the master key of
    the **Client Account**
 1. The **Server** verified that the other signature is from the **Server
@@ -280,35 +281,35 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object
 with these fields:
 
 - `transaction`: an XDR-encoded Stellar transaction with the following:
-  - source account set to the **Server Account**
-  - invalid sequence number (set to 0) so the transaction cannot be run on the
-    Stellar network
-  - time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of
-    15 minutes to give the **Client** time to sign transaction)
-  - memo: the `memo` value passed by the **Client** if specified, omitted
-    otherwise
-  - operations:
-    - `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
-      - The source account is the **Client Account**
-      - The value of key is the **Home Domain**, followed by `auth`. It can be
-        at most 64 characters.
-      - The value must be 64 bytes long. It contains a 48 byte
-        cryptographic-quality random string encoded using base64 (for a total
-        of 64 bytes after encoding).
-    - subsequent operations, order unimportant:
-      - `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
-        - The source account is the **Server Account**
-        - The value is the **Server**'s domain. It can be at most 64
-          characters.
-      - (optional)
-        `manage_data(source: client domain account, key: 'client_domain', value: client_domain)`
-        - The source account is the **Client Domain Account**
-        - Add this operation if the server supports
-          [Verifying the Client Domain](#verifying-the-client-domain) and the
-          client provided a `client_domain` parameter in the request.
-      - zero or more `manage_data(source: server account, ...)` reserved for
-        future use
-  - signature by the **Server Account**
+    - source account set to the **Server Account**
+    - invalid sequence number (set to 0) so the transaction cannot be run on the
+      Stellar network
+    - time bounds: `{min: now(), max: now() + 900 }` (we recommend expiration of
+      15 minutes to give the **Client** time to sign transaction)
+    - memo: the `memo` value passed by the **Client** if specified, omitted
+      otherwise
+    - operations:
+        - `manage_data(source: client account, key: '<home domain> auth', value: random_nonce())`
+            - The source account is the **Client Account**
+            - The value of key is the **Home Domain**, followed by `auth`. It can be
+              at most 64 characters.
+            - The value must be 64 bytes long. It contains a 48 byte
+              cryptographic-quality random string encoded using base64 (for a total
+              of 64 bytes after encoding).
+        - subsequent operations, order unimportant:
+            - `manage_data(source: server account, key: 'web_auth_domain', value: web_auth_domain)`
+                - The source account is the **Server Account**
+                - The value is the **Server**'s domain. It can be at most 64
+                  characters.
+            - (optional)
+              `manage_data(source: client domain account, key: 'client_domain', value: client_domain)`
+                - The source account is the **Client Domain Account**
+                - Add this operation if the server supports
+                  [Verifying the Client Domain](#verifying-the-client-domain) and the
+                  client provided a `client_domain` parameter in the request.
+            - zero or more `manage_data(source: server account, ...)` reserved for
+              future use
+    - signature by the **Server Account**
 - `network_passphrase`: (optional but recommended) Stellar network passphrase
   used by the **Server**. This allows a **Client** to verify that it's using
   the correct passphrase when signing and is useful for identifying when a
@@ -390,25 +391,25 @@ must be rejected — that is, treated by the **Server** as an invalid input.
   the minimum and maximum bounds;
 - verify that transaction contains at least one operation;
 - verify that transaction's first operation:
-  - is a Manage Data operation
-  - has a non-null source account
+    - is a Manage Data operation
+    - has a non-null source account
 - verify that transaction envelope has a correct signature by the **Server
   Account**
 - if the first operation's source account exists:
-  - verify that the remaining signature count is one or more;
-  - verify that remaining signatures on the transaction are signers of the
-    **Client Account**
-  - verify that remaining signatures are correct;
-  - verify that remaining signatures provide weight that meets the required
-    threshold(s), if any;
+    - verify that the remaining signature count is one or more;
+    - verify that remaining signatures on the transaction are signers of the
+      **Client Account**
+    - verify that remaining signatures are correct;
+    - verify that remaining signatures provide weight that meets the required
+      threshold(s), if any;
 - if the first operation's source account does not exist:
-  - verify that remaining signature count is one;
-  - verify that remaining signature is correct for the master key of the
-    **Client Account**
+    - verify that remaining signature count is one;
+    - verify that remaining signature is correct for the master key of the
+      **Client Account**
 - if the transaction contains a Manage Data operation with the key
   `client_domain`:
-  - verify that the transaction was signed by the source account of the Manage
-    Data operation
+    - verify that the transaction was signed by the source account of the Manage
+      Data operation
 - verify that transaction containing additional Manage Data operations have
   their source account set to the **Server Account**;
 - verify that transaction sequenceNumber is equal to zero;
@@ -428,13 +429,13 @@ containing the following claims:
 - `sub` (the principal that is the subject of the JWT,
   [RFC7519, Section 4.1.2](https://tools.ietf.org/html/rfc7519#section-4.1.2))
   — there are several possible formats:
-  - If the **Client Account** is a muxed account (`M...`), the `sub` value
-    should be the muxed account (`M...`).
-  - If the **Client Account** is a stellar account (`G...`):
-    - And, a memo was attached to the challenge transaction, the `sub` should
-      be the stellar account appended with the memo, separated by a colon
-      (`G...:17509749319012223907`).
-    - Otherwise, the `sub` value should be Stellar account (`G...`).
+    - If the **Client Account** is a muxed account (`M...`), the `sub` value
+      should be the muxed account (`M...`).
+    - If the **Client Account** is a stellar account (`G...`):
+        - And, a memo was attached to the challenge transaction, the `sub` should
+          be the stellar account appended with the memo, separated by a colon
+          (`G...:17509749319012223907`).
+        - Otherwise, the `sub` value should be Stellar account (`G...`).
 - `iat` (the time at which the JWT was issued
   [RFC7519, Section 4.1.6](https://tools.ietf.org/html/rfc7519#section-4.1.6))
   — current timestamp (`1530644093`)
@@ -453,7 +454,7 @@ The **Server** should not provide more than one JWT for a specific challenge
 transaction.
 
 [Uniform Resource Identifier (URI)]:
-  https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 [RFC7519]: https://tools.ietf.org/html/rfc7519
 
 #### Request
@@ -549,7 +550,7 @@ capability to choose the destination of payments on the network which require a
 medium threshold.
 
 [SEP-24]:
-  https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
+https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
 
 ### Verifying Complete Authority
 
@@ -677,7 +678,8 @@ JWTs: [IETF JWT BCP].
 
 ## Changelog
 
-- `v3.4.1`: Fix signature count when a manage data operation with `client_domain` is present.
+- `v3.4.1`: Fix signature count when a manage data operation with
+  `client_domain` is present.
 - `v3.4.0`: Add Authorization header for `GET <WEB_AUTH_ENDPOINT>`.
   ([#1470](https://github.com/stellar/stellar-protocol/pull/1470))
 - `v3.3.2`: Fixed formatting of markdown section headers.


### PR DESCRIPTION
In Step 9 of the verification flow, the signature count can be three if the transaction has a Manage Data operation with key client_domain. 

This is a bug.