### PR TITLE
Update mddiffcheck workflow for multiple repos

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -14,6 +14,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
-    - run: go install github.com/stellar/mddiffcheck@v1.1.0
-    - run: mddiffcheck -repo https://github.com/stellar/stellar-core core/*.md
+        go-version: ^1.24
+    - run: go install github.com/stellar/mddiffcheck@v1.2.0
+    - run: >
+        mddiffcheck
+        -repo
+        'https://github.com/stellar/stellar-core https://github.com/stellar/stellar-xdr'
+        core/*.md


### PR DESCRIPTION
### What
Update the GitHub Action workflow for mddiffcheck to use v1.2.0 which has built-in support for multiple repos.

### Why
Mdiffcheck v1.2.0 has built in support for multiple repos, only checking repos out once. The workflow was updated temporarily to run once for every doc, instead of once for the whole repo, but running once for every doc means checking out the stellar-core repo 70+ times.