### PR TITLE
Loosen mddiffcheck version to v1 instead of v1.2.0

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ^1.24
-    - run: go install github.com/stellar/mddiffcheck@v1.2.0
+    - run: go install github.com/stellar/mddiffcheck@v1
     - run: >
         mddiffcheck
         -repo


### PR DESCRIPTION
### What
Update the mddiffcheck workflow to use v1 instead of pinning to specific patch v1.2.0.

### Why
Using a major version allows automatic updates to minor and patch versions, reducing maintenance while ensuring compatibility.

I wanted to update to v1.2.1, but we really don't need to pin versions for this tool.