### PR TITLE
Tighter limits on CAP 70 values

### DIFF
--- a/core/cap-0070.md
+++ b/core/cap-0070.md
@@ -97,23 +97,23 @@ these ranges, but must still be tested and validated.
 - **ledgerTargetCloseTimeMilliseconds**
     - Target ledger close time in milliseconds. Validators will use this value to set the nextLedgerTrigger timer.
     - Initial value: 5000
-    - Range: [2000, 5000]
+    - Range: [4000, 5000]
 - **nominationTimeoutInitialMilliseconds**
     - Initial timeout for SCP nomination phase in milliseconds.
     - Initial value: 1000
-    - Range: [500, 3000]
+    - Range: [750, 2500]
 - **nominationTimeoutIncrementMilliseconds**
     - Incremental timeout increase per additional nomination round in milliseconds.
     - Initial value: 1000
-    - Range: [0, 2000]
+    - Range: [500, 2000]
 - **ballotTimeoutInitialMilliseconds**
     - Initial timeout for SCP ballot phase in milliseconds
     - Initial value: 1000
-    - Range: [500, 3000]
+    - Range: [750, 2500]
 - **ballotTimeoutIncrementMilliseconds**
     - Incremental timeout increase per additional ballot round in milliseconds
     - Initial value: 1000
-    - Range: [0, 2000]
+    - Range: [500, 2000]
 For some ballot/nomination round `i`, the timeout for that round is calculated as:
 
 ```
@@ -142,6 +142,19 @@ nomination timeouts can increase network latency on average, they can also cause
 
 Given these complexities, it is vital that timeout adjustments be incrementally tested and validated through simulation to identify safe and optimal settings.
 Only small, gradual changes should be proposed.
+
+### Config Setting Limits
+
+Unlike Soroban TX limit values, SCP timing values are nuanced and complicated to test. Additionally, a
+bad value could cause significant harm to the network, such as a network wide halt, out of sync downstream systems, etc.
+To prevent a bad value being introduced by mistake or by an uninformed proposal, SCP timing values will be limited to
+a tight range at the implementation level. As the Stellar Network becomes more efficient, these ranges can be changed
+on protocol boundaries, i.e. for protocol 23 `ledgerTargetCloseTimeMilliseconds` can only be reduced to 4000, but a
+future protocol may lower this limit further. It is important for these limits to change on protocol boundaries.
+Should a limit be reduced in a minor point release, it is possible for an SCP timing upgrade to occur for older nodes
+on the network that are not capable of keeping up with these new timings. Note that these limits are untested sanity
+checks and may still cause harm to the network. However, these bounds appear tight enough to not cause substantial
+network failure.
 
 ## Test Cases
 


### PR DESCRIPTION
As discussed in the protocol meeting, this change tightens implementation defined SCP timing limits. It also adds a section discussing the reasoning behind these tighter bounds and explains that while the limits are implementation defined (i.e. not written as a network config entry), they should only be changed on protocol boundaries.