### PR TITLE
SEP-51: Encode 128/256bit integer types as strings

### DIFF
--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -7,8 +7,8 @@ Author: Leigh McCulloch
 Track: Standard
 Status: Draft
 Created: 2025-04-16
-Updated: 2025-04-16
-Version: 1.0.0
+Updated: 2025-05-07
+Version: 1.1.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1702
 ```
 
@@ -814,6 +814,17 @@ JSON:
 "ABC\\0\\0"
 ```
 
+#### Integer Types
+
+The following Stellar XDR types should render as a JSON string containing a
+base10 rendering of the integer parts represented as an integer of the
+specified bit size.
+
+- `UInt128Parts`
+- `Int128Parts`
+- `UInt256Parts`
+- `Int256Parts`
+
 ### JSON Schema
 
 All JSON objects should allow, but not require, the presence of a `$schema`
@@ -1024,6 +1035,7 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
+- `v1.1.0`: Add string encoding of 128/256bit integer types.
 - `v1.0.0`: Initial SEP matching existing Protocol v22 XDR-JSON.
 
 [SEP-23 Strkey]: sep-0023.md


### PR DESCRIPTION
### What
Encode 128/256bit integer types as strings.

### Why
See https://github.com/stellar/stellar-protocol/discussions/1702#discussioncomment-12964633