### PR TITLE
SEP-51: Encode 64bit int (Hyper) and 128/256bit types as strings

### DIFF
--- a/.github/workflows/mddiffcheck.yml
+++ b/.github/workflows/mddiffcheck.yml
@@ -14,14 +14,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
-    - run: go install github.com/stellar/mddiffcheck@v1.1.0
-    - run: |
-          failed=0
-          for f in core/*.md; do
-            mddiffcheck -repo https://github.com/stellar/stellar-core "$f" || \
-            mddiffcheck -repo https://github.com/stellar/stellar-xdr "$f" || {
-              failed=1
-            }
-          done
-          exit $failed
+        go-version: ^1.24
+    - run: go install github.com/stellar/mddiffcheck@v1.2.0
+    - run: >
+        mddiffcheck
+        -repo
+        'https://github.com/stellar/stellar-core https://github.com/stellar/stellar-xdr'
+        core/*.md

--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -922,8 +922,9 @@ JSON:
 ### Number Representation for 64-bit Integers
 
 JSON has no bit-size limit on numbers. However, JavaScript cannot precisely
-represent numbers greater than 53-bits due to its use of IEEE 754. XDR-JSON uses
-the string type for 64-bit integers to ensure XDR-JSON documents are accessible via native JSON parsers in JavaScript runtimes.
+represent numbers greater than 53-bits due to its use of IEEE 754. XDR-JSON
+uses the string type for 64-bit integers to ensure XDR-JSON documents are
+accessible via native JSON parsers in JavaScript runtimes.
 
 ### Hexadecimal Encoding for Binary Data
 
@@ -1004,7 +1005,8 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
-- `v2.0.0`: Change Hyper and Unsigned Hyper types to map to JSON strings instead of JSON numbers.
+- `v2.0.0`: Change Hyper and Unsigned Hyper types to map to JSON strings
+  instead of JSON numbers.
 - `v1.0.0`: Initial SEP matching existing Protocol v22 XDR-JSON.
 
 [SEP-23 Strkey]: sep-0023.md

--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -107,7 +107,7 @@ JSON:
 #### Hyper Integer (64-bit)
 
 The XDR 64-bit signed integer data type ([RFC 4506 Section 4.5]) maps to JSON
-numbers.
+strings, with the number base10 encoded as a simple integer.
 
 For example:
 
@@ -132,18 +132,13 @@ f/////////8=
 JSON:
 
 ```json
-9223372036854775807
+"9223372036854775807"
 ```
-
-_Note: JavaScript runtime implementations of JSON do not support numbers that
-require more than 53-bits. JavaScript applications should use a JSON decoder
-supporting 64-bit numbers in JSON numbrs. JSON decoders in other languages do
-not typically have this constraint and support numbers up to 64-bits._
 
 #### Unsigned Hyper Integer (64-bit)
 
 The XDR 64-bit unsigned integer data type ([RFC 4506 Section 4.5]) maps to JSON
-numbers.
+strings, with the number base10 encoded as a simple integer.
 
 For example:
 
@@ -168,13 +163,8 @@ XDR Binary Base64 Encoded:
 JSON:
 
 ```json
-18446744073709551615
+"18446744073709551615"
 ```
-
-_Note: JavaScript runtime implementations of JSON do not support numbers that
-require more than 53-bits. JavaScript applications should use a JSON decoder
-supporting 64-bit numbers in JSON numbrs. JSON decoders in other languages do
-not typically have this constraint and support numbers up to 64-bits._
 
 #### Boolean
 
@@ -932,10 +922,8 @@ JSON:
 ### Number Representation for 64-bit Integers
 
 JSON has no bit-size limit on numbers. However, JavaScript cannot precisely
-represent numbers greater than 53-bits due to its use of IEEE 754 that output
-64-bit numbers in JSON to ensure no precision is lost. XDR-JSON does not use
-the string type for 64-bit integers to JSON numbers because non-native JSON
-decoders in JavaScript support 64-bit numbers and most other languages do also.
+represent numbers greater than 53-bits due to its use of IEEE 754. XDR-JSON uses
+the string type for 64-bit integers to ensure XDR-JSON documents are accessible via native JSON parsers in JavaScript runtimes.
 
 ### Hexadecimal Encoding for Binary Data
 
@@ -988,14 +976,6 @@ interfaces. Other uses requiring more stability can use embedding the `$schema`
 as a way to signal schema version and fallback to past versions of the
 implementation for passing them appropriately.
 
-### Precision Loss with 64-bit Numbers
-
-XDR-JSON uses the JSON number type for 64-bit integers. JSON has no bit-size
-limit. However, JavaScript cannot precisely represent numbers greater than
-53-bits due to its use of IEEE 754 that output 64-bit numbers in JSON to ensure
-no precision is lost. JavaScript applications must use a non-native JSON
-decoder to accurately decode 64-bit numbers otherwise precision may be lost.
-
 ## Breaking Changes
 
 Two types of breaking changes can occur in relation to XDR-JSON:
@@ -1024,6 +1004,7 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
+- `v2.0.0`: Change Hyper and Unsigned Hyper types to map to JSON strings instead of JSON numbers.
 - `v1.0.0`: Initial SEP matching existing Protocol v22 XDR-JSON.
 
 [SEP-23 Strkey]: sep-0023.md

--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -135,6 +135,9 @@ JSON:
 "9223372036854775807"
 ```
 
+_Note: To maintain compatibility with XDR-JSON v1, implementations where
+possible should support deserializing JSON numbers for Hyper._
+
 #### Unsigned Hyper Integer (64-bit)
 
 The XDR 64-bit unsigned integer data type ([RFC 4506 Section 4.5]) maps to JSON
@@ -165,6 +168,9 @@ JSON:
 ```json
 "18446744073709551615"
 ```
+
+_Note: To maintain compatibility with XDR-JSON v1, implementations where
+possible should support deserializing JSON numbers for Unsigned Hyper._
 
 #### Boolean
 

--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -7,8 +7,8 @@ Author: Leigh McCulloch
 Track: Standard
 Status: Draft
 Created: 2025-04-16
-Updated: 2025-05-07
-Version: 1.1.0
+Updated: 2025-05-13
+Version: 2.0.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1702
 ```
 
@@ -1022,8 +1022,9 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
-- `v2.0.0`: Change 64bit integer (Hyper and Unsigned Hyper) to map to JSON strings
-  instead of JSON numbers. Add string encoding of 128/256bit integer types.
+- `v2.0.0`: Change 64bit integer (Hyper and Unsigned Hyper) to map to JSON
+  strings instead of JSON numbers. Add string encoding of 128/256bit integer
+  types. Matches Protocol v23 XDR-JSON.
 - `v1.0.0`: Initial SEP matching existing Protocol v22 XDR-JSON.
 
 [SEP-23 Strkey]: sep-0023.md


### PR DESCRIPTION
### What
Change 64-bit signed and unsigned integers (Hyper) as well as the `ScVal` 128/256-bit types to use JSON string representations instead of JSON number or JSON maps.

### Why
JavaScript cannot precisely represent numbers larger than 53 bits due to IEEE 754 limitations. String representation ensures compatibility with native JavaScript JSON parsers.

See https://github.com/stellar/stellar-protocol/discussions/1702#discussioncomment-12964633 for more discussion.