### PR TITLE
Remove SEP Team Members List

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -258,19 +258,6 @@ require version updates:
 - Updating broken links.
 - Updating links to implementations.
 
-## SEP Team Members
-
-- Justin Rice <@rice2000> (SDF)
-- Tomer Weller <@tomerweller> (SDF)
-- Nikhil Saraf<@nikhilsaraf> (SDF)
-- Leigh McCulloch <@leighmcculloch> (SDF)
-- Jake Urban <@JakeUrban> (SDF)
-- Alex Cordeiro <@accordeiro> (SDF)
-- Marcelo Salloum <@marcelosalloum> (SDF)
-- Orbit Lens <@orbitlens>
-- David Mazières <@stanford-scs> (SDF)
-- Jed McCaleb <@jedmccaleb> (SDF)
-
 [ietf]: https://ietf.org/
 [semantic versioning]: https://semver.org/
 [SEP Versioning]: #sep-versioning

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -258,19 +258,6 @@ require version updates:
 - Updating broken links.
 - Updating links to implementations.
 
-## SEP Team Members
-
-- Justin Rice <@rice2000> (SDF)
-- Tomer Weller <@tomerweller> (SDF)
-- Nikhil Saraf<@nikhilsaraf> (SDF)
-- Leigh McCulloch <@leighmcculloch> (SDF)
-- Jake Urban <@JakeUrban> (SDF)
-- Alex Cordeiro <@accordeiro> (SDF)
-- Marcelo Salloum <@marcelosalloum> (SDF)
-- Orbit Lens <@orbitlens>
-- David Mazières <@stanford-scs> (SDF)
-- Jed McCaleb <@jedmccaleb> (SDF)
-
 [GitHub discussion forum]:
   https://github.com/orgs/stellar/discussions/categories/stellar-ecosystem-proposals
 [Stellar Dev Discord]: https://discord.gg/stellardev


### PR DESCRIPTION
### What

Remove SEP Team Members list.

### Why

The review, approval, and merge workflow process needs some work as @orbitlens highlights in #1728, but irrespective of that this list doesn't seem to serve a purpose as it's consistently out of date, as evidence by it containing the names of folks who are not actively engaged in discussions on new SEPs.

Unlike CAPs, that have a formal list of folks who review and approve the acceptance of CAPs, SEPs don't have a formal list of accepters and have a "lightweight process for approval," as noted by the ecosystem README. SEPs can be proposed and merged on a loose set of requirements as noted in the README.

cc @rice2000 @tomerweller @JakeUrban @accordeiro @marcelosalloum @orbitlens 