### PR TITLE
CAP-66: Minor update semantics for `txMaxInMemoryReadEntries`.

### DIFF
--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -114,8 +114,8 @@ mostly finalized in [CAP-0057](cap-0057.md), it is now appropriate to introduce 
 +// Ledger access settings for contracts.
 +struct ConfigSettingContractLedgerCostExtV0
 +{
-+    // Maximum number of in-memory ledger entry read operations per transaction
-+    uint32 txMaxInMemoryReadEntries;
++    // Maximum number ledger entry read operations per transaction
++    uint32 txMaxFootprintEntries;
 +    // Fee per 1 KB write
 +    uint32 feeWrite1KB;
  };
@@ -319,21 +319,21 @@ For this reason, rent fees for `CONTRACT_DATA` will continue to be based on the 
 
 #### Initial Network Config Settings
 
-Initially, all disk read limits should match exactly the limits and fees of reads today. Limits must not
+Initially, all disk read limits should match exactly the limits of reads today. Limits must not
 decrease from current values in order to prevent bricking existing contracts. In the worst case, a contract can read
-up to `txMaxReadEntries - 1` classic entries today (all classic entries + SAC instance). Current limits have been
+up to `txMaxReadLedgerEntries - 1` classic entries today (all classic entries + SAC instance). Current limits have been
 carefully measured assuming disk access only, so the addition of in-memory state should not negatively affect the network
 in any way should we maintain these values via disk read limits.
 
-In-memory read limits are not required wrt execution time, as they are very inexpensive. For this reason, no ledger wide read limit is necessary,
-and no byte based read limit is necessary for them. However, the size of TX footprints
-does impact the cost and complexity of assembling transactions sets and potentially maintaining the mempool, as with implementation [CAP-63](./CAP-63) Core will need to verify the presence of the conflicts in transaction footprints. Thus a tx entry limit is introduced to ensure efficient transaction set
+The new config setting `txMaxFootprintEntries` sets the limit on the total number of entries in the transaction footprint, i.e. the number of entries in both read-only and read-write footprints. The footprint size limits are not required wrt transaction execution time, as in-memory reads are very inexpensive and disk reads and writes are limited by the separate settings. For this reason, no respective ledger wide read limit is necessary,
+and no byte based read limit is necessary for in-memory reads. However, the size of transaction footprints
+does impact the cost and complexity of assembling transactions sets and potentially maintaining the mempool, as with implementation [CAP-63](./CAP-63) Core will need to verify the presence of the conflicts in transaction footprints. Thus a tx footprint entry limit is introduced to ensure efficient transaction set
 construction.
 
-Note, that there is also a 'soft' limit on the maximum number of reads per transaction that is caused by the transaction size limit. But coupling the limits in this fashion is risky - for example, network might need to increase the minimal transaction size in order to accommodate larger contracts, but the simultaneous increase in in-memory entry count might not be desired.
+Note, that there is also a 'soft' limit on the maximum size of footprint per transaction that is caused by the transaction size limit. But coupling the limits in this fashion is risky - for example, network might need to increase the minimal transaction size in order to accommodate larger contracts, but the simultaneous increase in footprint entry count might not be desired.
 
 When the protocol is upgraded to version 23 the initial values of the new configuration settings will be set to the following values:
-- `txMaxInMemoryReadEntries` will be set to the current value of `txMaxDiskReadEntries` (renamed from `txMaxReadLedgerEntries`) in order to prevent breakages of any existing contracts
+- `txMaxFootprintEntries` will be set to the current value of `txMaxDiskReadEntries` (renamed from `txMaxReadLedgerEntries`) in order to prevent breakages of any existing contracts
 - `feeWrite1KB` will be set to `3'500` stroops, which is roughly 2x of the current Soroban read fee per 1 KB. Note, that this fee is decoupled from the rent write fee now.
 
 #### Rent-related network settings update


### PR DESCRIPTION
In-memory read limit was just a proxy for what we really want: a limit on the maximum overall footprint length. With this change this limit is named and specified explicitly.