### PR TITLE
Update Protocol 23 CAPs to FCP: Accepted status

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -74,6 +74,14 @@
 | [CAP-0056](cap-0056.md) | 21 | Soroban intra-transaction module caching | Graydon Hoare | Final |
 | [CAP-0058](cap-0058.md) | 22 | Constructors for Soroban Contracts | Dmytro Kozhevin | Final |
 | [CAP-0059](cap-0059.md) | 22 | Host functions for BLS12-381 | Jay Geng | Final |
+| [CAP-0062](cap-0062.md) | Soroban Live State Prioritization | Garand Tyson | FCP: Accepted |
+| [CAP-0063](cap-0063.md) | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0065](cap-0065.md) | Reusable Module Cache | Graydon Hoare | FCP: Accepted |
+| [CAP-0066](cap-0066.md) | Soroban In-memory Read Resource | Garand Tyson | FCP: Accepted |
+| [CAP-0067](cap-0067.md) | Unified Asset Events | Siddharth Suresh | FCP: Accepted |
+| [CAP-0068](cap-0068.md) | Host function for getting executable for `Address` | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0069](cap-0069.md) | String/Bytes conversion host functions | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0070](cap-0070.md) | Configurable SCP Timing Parameters | Garand Tyson | FCP: Accepted |
 
 ### Draft Proposals
 | Number | Title | Author | Status |
@@ -95,15 +103,6 @@
 | [CAP-0057](cap-0057.md) | State Archival Persistent Entry Eviction | Garand Tyson | Draft |
 | [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Accepted |
 | [CAP-0061](cap-0061.md) | Smart Contract Standardized Asset (Stellar Asset Contract) Extension: Memo | Tomer Weller | Draft |
-| [CAP-0062](cap-0062.md) | Soroban Live State Prioritization | Garand Tyson | Awaiting Decision |
-| [CAP-0063](cap-0063.md) | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | Awaiting Decision |
-| [CAP-0064](cap-0064.md) | Memo Authorization for Soroban | Dmytro Kozhevin | Rejected |
-| [CAP-0065](cap-0065.md) | Reusable Module Cache | Graydon Hoare | Awaiting Decision |
-| [CAP-0066](cap-0066.md) | Soroban In-memory Read Resource | Garand Tyson | Awaiting Decision |
-| [CAP-0067](cap-0067.md) | Unified Asset Events | Siddharth Suresh | Awaiting Decision |
-| [CAP-0068](cap-0068.md) | Host function for getting  executable for `Address` | Dmytro Kozhevin | Awaiting Decision |
-| [CAP-0069](cap-0069.md) | String/Bytes conversion host functions | Dmytro Kozhevin | Awaiting Decision |
-| [CAP-0070](cap-0070.md) | Configurable SCP Timing Parameters | Garand Tyson | Awaiting Decision |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/README.md
+++ b/core/README.md
@@ -74,14 +74,14 @@
 | [CAP-0056](cap-0056.md) | 21 | Soroban intra-transaction module caching | Graydon Hoare | Final |
 | [CAP-0058](cap-0058.md) | 22 | Constructors for Soroban Contracts | Dmytro Kozhevin | Final |
 | [CAP-0059](cap-0059.md) | 22 | Host functions for BLS12-381 | Jay Geng | Final |
-| [CAP-0062](cap-0062.md) | Soroban Live State Prioritization | Garand Tyson | FCP: Accepted |
-| [CAP-0063](cap-0063.md) | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | FCP: Accepted |
-| [CAP-0065](cap-0065.md) | Reusable Module Cache | Graydon Hoare | FCP: Accepted |
-| [CAP-0066](cap-0066.md) | Soroban In-memory Read Resource | Garand Tyson | FCP: Accepted |
-| [CAP-0067](cap-0067.md) | Unified Asset Events | Siddharth Suresh | FCP: Accepted |
-| [CAP-0068](cap-0068.md) | Host function for getting executable for `Address` | Dmytro Kozhevin | FCP: Accepted |
-| [CAP-0069](cap-0069.md) | String/Bytes conversion host functions | Dmytro Kozhevin | FCP: Accepted |
-| [CAP-0070](cap-0070.md) | Configurable SCP Timing Parameters | Garand Tyson | FCP: Accepted |
+| [CAP-0062](cap-0062.md) | 23 | Soroban Live State Prioritization | Garand Tyson | FCP: Accepted |
+| [CAP-0063](cap-0063.md) | 23 | Parallelism-friendly Transaction Scheduling | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0065](cap-0065.md) | 23 | Reusable Module Cache | Graydon Hoare | FCP: Accepted |
+| [CAP-0066](cap-0066.md) | 23 | Soroban In-memory Read Resource | Garand Tyson | FCP: Accepted |
+| [CAP-0067](cap-0067.md) | 23 | Unified Asset Events | Siddharth Suresh | FCP: Accepted |
+| [CAP-0068](cap-0068.md) | 23 | Host function for getting executable for `Address` | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0069](cap-0069.md) | 23 | String/Bytes conversion host functions | Dmytro Kozhevin | FCP: Accepted |
+| [CAP-0070](cap-0070.md) | 23 | Configurable SCP Timing Parameters | Garand Tyson | FCP: Accepted |
 
 ### Draft Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0062.md
+++ b/core/cap-0062.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>
     Consulted: Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2024-12-02
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1575
 Protocol version: TBD

--- a/core/cap-0063.md
+++ b/core/cap-0063.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: dmkozh@stellar.org
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted: Siddharth Suresh <@sisuresh>, Nicolas Barry <@MonsieurNicolas>, Graydon Hoare <@graydon>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2024-12-18
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1602
 Protocol version: TBD

--- a/core/cap-0065.md
+++ b/core/cap-0065.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Graydon Hoare <@graydon>
     Authors: Graydon Hoare <@graydon>
     Consulted: Garand Tyson <@SirTyson>, Siddharth Suresh <@sisuresh>, Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1615
 Protocol version: TBD

--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>
     Consulted: Dmytro Kozhevin <@dmkozh>, Nicolas Barry <@MonsieurNicolas>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2024-12-09
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1585
 Protocol version: TBD

--- a/core/cap-0067.md
+++ b/core/cap-0067.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Siddharth Suresh <@sisuresh>
     Authors: Siddharth Suresh <@sisuresh>, Leigh McCulloch <@leighmcculloch>
     Consulted: Dmytro Kozhevin <@dmkozh>, Jake Urban <jake@stellar.org>, Simon Chow <simon.chow@stellar.org>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2025-01-13
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1553
 Protocol version: TBD

--- a/core/cap-0068.md
+++ b/core/cap-0068.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1626
 Protocol version: TBD

--- a/core/cap-0069.md
+++ b/core/cap-0069.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>
     Consulted:
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2025-01-17
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1633
 Protocol version: TBD

--- a/core/cap-0070.md
+++ b/core/cap-0070.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Garand Tyson <@SirTyson>
     Authors: Garand Tyson <@SirTyson>
     Consulted: Nicolas Barry <@MonsieurNicolas>
-Status: Awaiting Decision
+Status: FCP: Accepted
 Created: 2025-04-28
 Discussion: https://github.com/orgs/stellar/discussions/1719
 Protocol version: TBD


### PR DESCRIPTION
Now that we have Core CAP Team's approval in stellar-dev mailing list, updating the CAPs for Protocol 23 to `FCP: Accepted status`.