### PR TITLE
Add metadata key registry to SEP-46

### DIFF
--- a/ecosystem/sep-0046.md
+++ b/ecosystem/sep-0046.md
@@ -154,14 +154,16 @@ through the next type. As such no length prefix or counter are required.
 
 ## Commonly used keys
 
-| Key name     | Description                                        | Required by SEP         |
-| ------------ | -------------------------------------------------- | ----------------------- |
-| `name`       | The name of the contract                           | N/A                     |
-| `authors`    | The author(s) of the contract, often with an email | N/A                     |
-| `homepage`   | The relevant domain to relate to this contract     | N/A                     |
-| `repository` | The source repository URL for the contract         | N/A                     |
-| `binver`     | The version of the WASM bytecode of the contract   | [SEP-49](./sep-0049.md) |
-| `sep`        | Indicates which SEPs contract claims to implement  | [SEP-47](./sep-0047.md) |
+| Key name     | Description                                             | Required by SEP         | Used by tool  |
+| ------------ | ------------------------------------------------------- | ----------------------- | ------------- |
+| `rsver`      | Version of rust used to compile WASM                    | N/A                     | [stellar-cli] |
+| `rssdkver`   | Soroban SDK dependency version used when compiling WASM | N/A                     | [stellar-cli] |
+| `name`       | The name of the contract                                | N/A                     | N/A           |
+| `authors`    | The author(s) of the contract, often with an email      | N/A                     | N/A           |
+| `homepage`   | The relevant domain to relate to this contract          | N/A                     | N/A           |
+| `repository` | The source repository URL for the contract              | N/A                     | N/A           |
+| `binver`     | The version of the WASM bytecode of the contract        | [SEP-49](./sep-0049.md) | N/A           |
+| `sep`        | Indicates which SEPs contract claims to implement       | [SEP-47](./sep-0047.md) | N/A           |
 
 ### Note
 
@@ -186,3 +188,5 @@ any SEP that defines meta keys.
 - `v1.0.0`: Status changed to Active.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
 - `v0.2.0`: Add registry draft of commonly used keys
+
+[stellar-cli]: https://github.com/stellar/stellar-cli

--- a/ecosystem/sep-0046.md
+++ b/ecosystem/sep-0046.md
@@ -112,14 +112,6 @@ communicate metadata. There can exist many deployments of an uploaded contract
 and this proposal only defines a location for metadata that relates to the
 uploaded contract, not the individual deployments.
 
-### No Registry
-
-This proposal does not define any registry of meta keys. SEPs that have a use
-for defining meta keys should do so as part of their own SEPs. SDKs may also
-have a use for defining meta keys. Not all users of a meta key need open a SEP,
-but for some where interoperability is helpful may benefit from doing so. Some
-attempt should be made to avoid the reuse of keys across different use cases.
-
 ## Design Rationale
 
 ### Custom Sections
@@ -160,12 +152,30 @@ type is either fixed size, contains a length field to specify the size, or is
 prefixed with discriminants that deterministically branch on selecting the size
 through the next type. As such no length prefix or counter are required.
 
+## Commonly used keys
+
+| Key name     | Description                                        | Required by SEP         |
+| ------------ | -------------------------------------------------- | ----------------------- |
+| `name`       | The name of the contract                           | N/A                     |
+| `authors`    | The author(s) of the contract, often with an email | N/A                     |
+| `homepage`   | The relevant domain to relate to this contract     | N/A                     |
+| `repository` | The source repository URL for the contract         | N/A                     |
+| `binver`     | The version of the WASM bytecode of the contract   | [SEP-49](./sep-0049.md) |
+| `sep`        | Indicates which SEPs contract claims to implement  | [SEP-47](./sep-0047.md) |
+
+### Note
+
+This proposal list keys commonly used by other SEPs or across known tooling. It
+does not limit user to use any mentioned key in the way it is intended by the
+mentioned SEP. Not all users of a meta key need open a SEP, but for some cases
+where interoperability is helpful may benefit from doing so.
+
 ## Security Concerns
 
 Contracts may choose to place some information into contract meta that makes
 some claim, such as a claim that the contract implements a particular SEP, or a
 claim that the contract was built from a particular repository. Contract meta
-carriers no guarantees as to the validity or trustworthyness of the claims.
+carriers no guarantees as to the validity or trustworthiness of the claims.
 Applications using the meta should do so with care and define ways to verify
 claims before taking any action based on them. Specification for how to perform
 any such verification is out-of-scope of this proposal and should be defined in
@@ -175,4 +185,4 @@ any SEP that defines meta keys.
 
 - `v1.0.0`: Status changed to Active.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
-  soroban-sdk and stellar-cli.
+- `v0.2.0`: Add registry draft of commonly used keys

--- a/ecosystem/sep-0049.md
+++ b/ecosystem/sep-0049.md
@@ -12,6 +12,10 @@ Version: 0.2.0
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1670
 ```
 
+## Dependencies
+
+- [SEP-46]
+
 ## Summary
 
 Community guidelines and recommendations for safely upgrading the WASM bytecode
@@ -221,3 +225,6 @@ warnings or requiring explicit confirmations for potential breaking changes.
 
 - `0.1.0`: Initial draft
 - `0.2.0`: Turn standardizations into guidelines
+- `0.2.1`: Add reference to SEP-46
+
+[SEP-46]: ./sep-0046.md


### PR DESCRIPTION
This PR adds metadata key registry to SEP-46.
We should not make any attempts to strictly standardize it (i.e. it's okay for SEP to not list some fields using by some libraries or tools, but they are free to add the keys they are using to this list). With SEP-9 we discovered that it's sometimes hard to predict the usage of the SEP by the ecosystem, and very often people are using some fields that are not defined by the SEP. Given that, I strongly suggest we do not make any keys mandatory, at least not for the 'minimal' contract (or use case).
That being said, another SEPs (such as contract version SEP-49) should define mandatory (for this SEP) metadata keys, and I think it's a good idea to keep this "common" keys in once place.

This PR adds table of 'commonly used keys', that currently consists of:
1. Keys that support Cargo.toml key inheritance introduced in [this scaffold-stellar PR](https://github.com/AhaLabs/scaffold-stellar/pull/108) 
2. Keys set by stellar-cli (`rsver` and `rssdkver`)
3. Keys introduced by SEP-47 and SEP-49 (`sep` and `binver` respectfully)

