### PR TITLE
SEP: Replace Active status with Living status

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -23,9 +23,9 @@ All SEPs have individuals fulfilling the following roles:
 - **FCP** - A SEP that has entered a Final Comment Period (FCP). An author
   places their SEP in FCP when they wish to signal that they plan to cease
   making changes. After at least one week has passed the SEP's status should
-  move to `Active` or `Final`, or back to `Draft`. If changes are required, it
+  move to `Living` or `Final`, or back to `Draft`. If changes are required, it
   should be moved back to `Draft`.
-- **Active** - A SEP ready to be adopted, and the proposal is a living document
+- **Living** - A SEP ready to be adopted, and the proposal is a living document
   and may still receive changes. The author intends the SEP in its current form
   to be actively adopted. Changes can be made without changing the SEP number,
   although in the interest of growing an ecosystem of interopable participants
@@ -48,28 +48,28 @@ All SEPs have individuals fulfilling the following roles:
 
 | Number                  | Title                                                                  | Author                                                        | Status |
 | ----------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------- | ------ |
-| [SEP-0001](sep-0001.md) | Stellar Info File                                                      | SDF                                                           | Active |
+| [SEP-0001](sep-0001.md) | Stellar Info File                                                      | SDF                                                           | Living |
 | [SEP-0002](sep-0002.md) | Federation Protocol                                                    | SDF                                                           | Final  |
 | [SEP-0004](sep-0004.md) | Tx Status Endpoint                                                     | SDF                                                           | Final  |
 | [SEP-0005](sep-0005.md) | Key Derivation Methods for Stellar Accounts                            | SDF                                                           | Final  |
-| [SEP-0006](sep-0006.md) | Deposit and Withdrawal API                                             | SDF                                                           | Active |
+| [SEP-0006](sep-0006.md) | Deposit and Withdrawal API                                             | SDF                                                           | Living |
 | [SEP-0007](sep-0007.md) | URI Scheme to facilitate delegated signing                             | Interstellar                                                  | Final  |
 | [SEP-0008](sep-0008.md) | Regulated Assets                                                       | Interstellar                                                  | Final  |
-| [SEP-0009](sep-0009.md) | Standard KYC Fields                                                    | SDF                                                           | Active |
-| [SEP-0010](sep-0010.md) | Stellar Authentication                                                 | Sergey Nebolsin, Tom Quisel                                   | Active |
-| [SEP-0011](sep-0011.md) | Txrep: Human-Readable Low-Level Representation of Stellar Transactions | David Mazières                                                | Active |
-| [SEP-0012](sep-0012.md) | KYC API                                                                | Interstellar                                                  | Active |
+| [SEP-0009](sep-0009.md) | Standard KYC Fields                                                    | SDF                                                           | Living |
+| [SEP-0010](sep-0010.md) | Stellar Authentication                                                 | Sergey Nebolsin, Tom Quisel                                   | Living |
+| [SEP-0011](sep-0011.md) | Txrep: Human-Readable Low-Level Representation of Stellar Transactions | David Mazières                                                | Living |
+| [SEP-0012](sep-0012.md) | KYC API                                                                | Interstellar                                                  | Living |
 | [SEP-0014](sep-0014.md) | Dynamic Asset Metadata                                                 | OrbitLens, Paul Tiplady                                       | Draft  |
-| [SEP-0018](sep-0018.md) | Data Entry Namespaces                                                  | Mister.Ticot                                                  | Active |
-| [SEP-0020](sep-0020.md) | Self-verification of validator nodes                                   | Johan Stén                                                    | Active |
-| [SEP-0023](sep-0023.md) | Muxed Account Strkeys                                                  | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Active |
-| [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal                                          | SDF                                                           | Active |
+| [SEP-0018](sep-0018.md) | Data Entry Namespaces                                                  | Mister.Ticot                                                  | Living |
+| [SEP-0020](sep-0020.md) | Self-verification of validator nodes                                   | Johan Stén                                                    | Living |
+| [SEP-0023](sep-0023.md) | Muxed Account Strkeys                                                  | David Mazières, Tomer Weller, Leigh McCulloch, Alfonso Acosta | Living |
+| [SEP-0024](sep-0024.md) | Hosted Deposit and Withdrawal                                          | SDF                                                           | Living |
 | [SEP-0028](sep-0028.md) | XDR Base64 Encoding                                                    | SDF                                                           | Final  |
-| [SEP-0029](sep-0029.md) | Account Memo Requirements                                              | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières      | Active |
-| [SEP-0031](sep-0031.md) | Cross-Border Payments API                                              | SDF                                                           | Active |
-| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts                                        | Lobstr.co, Gleb Pitsevich                                     | Active |
-| [SEP-0046](sep-0046.md) | Contract Meta                                                          | Leigh McCulloch                                               | Active |
-| [SEP-0048](sep-0048.md) | Contract Interface Specification                                       | Leigh McCulloch                                               | Active |
+| [SEP-0029](sep-0029.md) | Account Memo Requirements                                              | OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières      | Living |
+| [SEP-0031](sep-0031.md) | Cross-Border Payments API                                              | SDF                                                           | Living |
+| [SEP-0033](sep-0033.md) | Identicons for Stellar Accounts                                        | Lobstr.co, Gleb Pitsevich                                     | Living |
+| [SEP-0046](sep-0046.md) | Contract Meta                                                          | Leigh McCulloch                                               | Living |
+| [SEP-0048](sep-0048.md) | Contract Interface Specification                                       | Leigh McCulloch                                               | Living |
 
 ### Draft Proposals
 
@@ -87,7 +87,7 @@ All SEPs have individuals fulfilling the following roles:
 | [SEP-0035](sep-0035.md) | Operation IDs                                                  | Isaiah Turner, Debnil Sur, Scott Fleckenstein | Draft                |
 | [SEP-0037](sep-0037.md) | Address Directory API                                          | OrbitLens                                     | Draft                |
 | [SEP-0038](sep-0038.md) | Anchor RFQ API                                                 | Jake Urban and Leigh McCulloch                | Draft                |
-| [SEP-0039](sep-0039.md) | Interoperability Recommendations for NFTs                      | SDF, Litemint.io                              | Active               |
+| [SEP-0039](sep-0039.md) | Interoperability Recommendations for NFTs                      | SDF, Litemint.io                              | Living               |
 | [SEP-0040](sep-0040.md) | Oracle Consumer Interface                                      | Alex Mootz, OrbitLens, Markus Paulson-Luna    | Draft                |
 | [SEP-0041](sep-0041.md) | Soroban Token Interface                                        | Jonathan Jove, Siddharth Suresh               | Draft                |
 | [SEP-0045](sep-0045.md) | Stellar Web Authentication for Contract Accounts               | Philip Liu, Marcelo Salloum, Leigh McCulloch  | Draft                |
@@ -194,34 +194,34 @@ From there, the following process will happen:
 
 When you're ready for others to adopt the proposal:
 
-- Decide if the proposal should be a living document and move to `Active`, or
+- Decide if the proposal should be a living document and move to `Living`, or
   an immutable document and move to `Final`.
 - Submit a PR changing the status in the draft to
-  `Final Comment Period (Active)` or `Final Comment Period (Final)`.
+  `Final Comment Period (Living)` or `Final Comment Period (Final)`.
 - Keep the proposal in FCP for at least one week, then submit a PR changing the
-  status to `Active`, `Final`, or back to `Draft`.
+  status to `Living`, `Final`, or back to `Draft`.
 
-#### Deciding Active vs Final
+#### Deciding Living vs Final
 
-You choose whether your proposal targets an Active or Final status.
+You choose whether your proposal targets an Living or Final status.
 
-Active proposals are living documents that the author intends to iterate on and
+Living proposals are living documents that the author intends to iterate on and
 maintain over time, such as a specification that expects evolution in a
 responsible manner with regards to backwards compatibility, and semver usage.
 
 Final documents are immutable documents that the author intends to write once,
 but do not intend to maintain over time.
 
-### FCP (Active) -> Active
+### FCP (Living) -> Living
 
 After at least one week in FCP:
 
-- Submit a PR changing the status to `Active` and setting the version to
+- Submit a PR changing the status to `Living` and setting the version to
   `v1.0.0`.
 - A maintainer of the stellar-protocol repository will review the PR to ensure
   the changes are limited to changing the status and updating the version.
 
-### Active: Further Iteration
+### Living: Further Iteration
 
 - Increment the major, minor, or patch versions on each change. See [SEP
   Versioning].
@@ -242,7 +242,7 @@ After at least one week in FCP:
 - No changes will be made to a finalized SEP aside from fixing errata.
 - Fixing errata should be so minor it is not accompanied by a version change.
 - Much consideration should be given before moving to Final status, it is OK
-  for SEPs to live in Draft or Active status for a long time.
+  for SEPs to live in Draft or Living status for a long time.
 - Any significant changes should be proposed as a new SEP.
 
 ## SEP Versioning
@@ -253,7 +253,7 @@ they are implementing or discussing. SEPs use [semantic versioning] in the form
 `vMAJOR.MINOR.PATCH` to determine an appropriate version for each change.
 
 During draft a SEP should have a major version of `0` to indicate that anything
-in the SEP may change at anytime. Once a SEP moves to Active it should be
+in the SEP may change at anytime. Once a SEP moves to Living it should be
 changed to `v1.0.0` and the rules of semantic versioning apply.
 
 All changes to a SEP should be accompanied by an update to its version, no

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -4,7 +4,7 @@
 SEP: 0001
 Title: Stellar Info File
 Author: stellar.org
-Status: Active
+Status: Living
 Created: 2017-10-30
 Updated: 2025-01-16
 Version: 2.7.0

--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -4,7 +4,7 @@
 SEP: 0006
 Title: Deposit and Withdrawal API
 Author: SDF
-Status: Active (Interactive components are deprecated in favor of SEP-24)
+Status: Living (Interactive components are deprecated in favor of SEP-24)
 Created: 2017-10-30
 Updated: 2024-11-05
 Version 4.2.0

--- a/ecosystem/sep-0007.md
+++ b/ecosystem/sep-0007.md
@@ -4,7 +4,7 @@
 SEP: 0007
 Title: URI Scheme to facilitate delegated signing
 Author: Nikhil Saraf (Lightyear.io / SDF)
-Status: Active
+Status: Living
 Created: 2018-05-07
 Updated: 2020-07-29
 Version: 2.1.0

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -4,7 +4,7 @@
 SEP: 0008
 Title: Regulated Assets
 Author: Tomer Weller <@tomerweller>, Howard Chen <@howardtw>, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
-Status: Active
+Status: Living
 Created: 2018-08-22
 Updated: 2022-02-21
 Version 1.7.4

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -4,7 +4,7 @@
 SEP: 0009
 Title: Standard KYC Fields
 Author: stellar.org
-Status: Active
+Status: Living
 Created: 2018-07-27
 Updated: 2024-04-22
 Version 1.17.0

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -4,7 +4,7 @@
 SEP: 0010
 Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
-Status: Active
+Status: Living
 Created: 2018-07-31
 Updated: 2024-03-20
 Version: 3.4.1

--- a/ecosystem/sep-0011.md
+++ b/ecosystem/sep-0011.md
@@ -4,7 +4,7 @@
 SEP: 0011
 Title: Txrep: human-readable low-level representation of Stellar transactions
 Author: David Mazières
-Status: Active
+Status: Living
 Created: 2018-08-31
 Updated: 2021-10-09
 Version: 1.1.0

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -4,7 +4,7 @@
 SEP: 0012
 Title: KYC API
 Author: Interstellar
-Status: Active
+Status: Living
 Created: 2018-09-11
 Updated: 2024-07-23
 Version 1.15.0

--- a/ecosystem/sep-0014.md
+++ b/ecosystem/sep-0014.md
@@ -4,7 +4,7 @@
 SEP: 0014
 Title: Dynamic Asset Metadata
 Author: OrbitLens <orbit.lens@gmail.com>, Paul Tiplady <paul@qwil.com>
-Status: Active
+Status: Living
 Created: 2018-09-30
 Updated: 2019-03-12
 Discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/stellar-dev/-S7FIXJAi2A

--- a/ecosystem/sep-0018.md
+++ b/ecosystem/sep-0018.md
@@ -4,7 +4,7 @@
 SEP: 0018
 Title: Data Entry Namespaces
 Author: MisterTicot (@misterticot), Leigh McCulloch (@leighmcculloch)
-Status: Active
+Status: Living
 Created: 2018-10-26
 Updated: 2020-06-30
 Version: 0.3.0

--- a/ecosystem/sep-0020.md
+++ b/ecosystem/sep-0020.md
@@ -2,7 +2,7 @@
 SEP: 0020
 Title: Self-verification of validator nodes
 Author: Johan Stén <johan@futuretense.io>
-Status: Active
+Status: Living
 Created: 2018-05-06
 Discussion: https://github.com/stellar/stellar-protocol/issues/111
 ```

--- a/ecosystem/sep-0023.md
+++ b/ecosystem/sep-0023.md
@@ -4,7 +4,7 @@
 SEP: 0023
 Title: Strkeys
 Author: David Mazières, Tomer Weller <@tomerweller>, Leigh McCulloch <@leighmcculloch>, Alfonso Acosta <@2opremio>
-Status: Active
+Status: Living
 Created: 2019-09-16
 Updated: 2025-02-07
 Version: 1.3.0

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -4,7 +4,7 @@
 SEP: 0024
 Title: Hosted Deposit and Withdrawal
 Author: SDF
-Status: Active
+Status: Living
 Created: 2019-09-18
 Updated: 2024-08-07
 Version 3.7.1

--- a/ecosystem/sep-0029.md
+++ b/ecosystem/sep-0029.md
@@ -4,7 +4,7 @@
 SEP: 0029
 Title: Account Memo Requirements
 Author: OrbitLens, Tomer Weller, Leigh McCulloch, David Mazières
-Status: Active
+Status: Living
 Created: 2019-12-27
 Updated: 2020-05-04
 Version: 0.5.0

--- a/ecosystem/sep-0031.md
+++ b/ecosystem/sep-0031.md
@@ -4,7 +4,7 @@
 SEP: 0031
 Title: Cross-Border Payments API
 Author: SDF
-Status: Active
+Status: Living
 Created: 2020-04-07
 Updated: 2024-11-05
 Version 3.1.0

--- a/ecosystem/sep-0033.md
+++ b/ecosystem/sep-0033.md
@@ -4,7 +4,7 @@
 SEP: 0033
 Title: Identicons for Stellar Accounts
 Author: Lobstr.co, Gleb Pitsevich (@pitsevich)
-Status: Active
+Status: Living
 Created: 2019-11-20
 Updated: 2021-04-20
 Version: 1.0.1

--- a/ecosystem/sep-0046.md
+++ b/ecosystem/sep-0046.md
@@ -4,7 +4,7 @@
 SEP: 0046
 Title: Contract Meta
 Author: Leigh McCulloch
-Status: Active
+Status: Living
 Created: 2025-02-13
 Updated: 2025-04-16
 Version: 1.0.0
@@ -172,6 +172,6 @@ any SEP that defines meta keys.
 
 ## Changelog
 
-- `v1.0.0`: Status changed to Active.
+- `v1.0.0`: Status changed to Living.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
   soroban-sdk and stellar-cli.

--- a/ecosystem/sep-0048.md
+++ b/ecosystem/sep-0048.md
@@ -4,7 +4,7 @@
 SEP: 0048
 Title: Contract Interface Specification
 Author: Leigh McCulloch
-Status: Active
+Status: Living
 Created: 2025-03-26
 Updated: 2025-04-16
 Version: 1.0.0
@@ -1415,7 +1415,7 @@ do not exist. Or a contract may omit spec entries for functions that do exist.
 
 ## Changelog
 
-- `v1.0.0`: Status changed to Active.
+- `v1.0.0`: Status changed to Living.
 - `v0.1.0`: Initial draft capturing the status quo as implemented in
   [`soroban-sdk`].
 

--- a/sep-template.md
+++ b/sep-template.md
@@ -47,6 +47,6 @@ Example:
 
 - `v1.1.1`: Fix misleading statements about the P parameter. [#3499](https://github.com/stellar/stellar-protocol/pulls/3499)
 - `v1.1.0`: Add new paremeters to the X endpoint. [#3498](https://github.com/stellar/stellar-protocol/pulls/3498)
-- `v1.0.0`: Updated status to Active. [#1234](https://github.com/stellar/stellar-protocol/pulls/1234)
+- `v1.0.0`: Updated status to Living. [#1234](https://github.com/stellar/stellar-protocol/pulls/1234)
 - `v0.2.0`: Redesigned the API. [#1004](https://github.com/stellar/stellar-protocol/pulls/1004)
 - `v0.1.0`: Initial draft. [#1000](https://github.com/stellar/stellar-protocol/pulls/1000)


### PR DESCRIPTION
### What
  Replace all instances of 'Active' status with 'Living' status across SEP documentation.

  ### Why
  The term Active is not descriptive, or communicate the intent well. Living more accurately describes SEPs that authors intend to maintain and evolve over time. Living is also the term used by the Ethereum ecosystem for the same type of document, although it is used more rarely there than the Stellar ecosystem will.


cc @tomerweller  @rice2000 @accordeiro @JakeUrban @johncanneto @janewang 