### PR TITLE
CAP-66: Specify that Wasm entries are also cached in memory.

### DIFF
--- a/core/cap-0066.md
+++ b/core/cap-0066.md
@@ -299,8 +299,10 @@ which was the case for `write_fee_per_1kb`.
 #### `CONTRACT_CODE` size calculation for limits and fees
 
 `CONTRACT_CODE` entries have two "sizes" that are relevant to fees and limits:
- - "Disk Size": The size of the `CONTRACT_CODE` LedgerEntry XDR.
- - "In-memory Size": The memory size of the Wasm *module* corresponding to the Wasm stored in the `CONTRACT_CODE` entry, as calculated by the cost model. More specifically, the in-memory size of a given `CONTRACT_CODE` is defined as the metered memory consumption of parsing the Wasm code into a Wasm VM module.
+ - "Disk Size": The size of the `CONTRACT_CODE` `LedgerEntry` XDR.
+ - "In-memory Size": The total memory footprint for a contract code entry. We store every `CONTRACT_CODE` in memory in two different places: once in the Soroban ledger entry cache and once in the global Soroban module cache. Thus in-memory entry size is a sum of two components:     
+    - The memory size of the Wasm *module* corresponding to the Wasm stored in the `CONTRACT_CODE` entry, as calculated by the cost model. More specifically, the in-memory size of a given `CONTRACT_CODE` is defined as the metered memory consumption of parsing the Wasm code into a Wasm VM module.
+    - The size of the `CONTRACT_CODE` `LedgerEntry` XDR.
 
 Disk size is consistent between protocol upgrades, as the `CONTRACT_CODE` bytes themselves are immutable. However, the
 in-memory size is dependent on the cost model. For this reason, limits can not be based on in-memory size. If in-memory size
@@ -309,7 +311,7 @@ increases.
 
 For this reason, `contractMaxSizeBytes` limit enforcement will continue to be based on disk size. But in-memory size will be used for accounting `CONTRACT_CODE` entries towards the Soroban state size, as well as the rent computations.
 
-Since the in-memory size may be significantly larger than the disk size (up to 40x as of protocol 23) the rent fees will be adjusted with the protocol upgrade in order to keep the effective rent fees for contract code close to those in protocol 22 (since these fees seemed to be reasonable enough for DOS protection). Moreover, in order to reduce the gap in rent fees between code and data entries a discount factor of `2` will be applied to the final rent fees. This is the highest possible discount the protocol can implement without creating an incentive to store the contract data in code entries - the minimum ratio between the disk and in-memory size for any Wasm is greater than 2 as of protocol 23.
+Since the in-memory size may be significantly larger than the disk size (up to 40x as of protocol 23) the rent fees will be adjusted with the protocol upgrade in order to keep the effective rent fees for contract code close to those in protocol 22 (since these fees seemed to be reasonable enough for DOS protection). Moreover, in order to reduce the gap in rent fees between code and data entries a discount factor of `3` will be applied to the final rent fees. This is the highest possible discount the protocol can implement without creating an incentive to store the contract data in code entries - the minimum ratio between the disk and in-memory size for any Wasm is greater than 3 as of protocol 23 (the Wasm module size is at least 2x of the actual Wasm size, and another 1x Wasm size is charged for the entry cache).
 
 To summarize, here is the breakdown of the sizes used for `CONTRACT_CODE` in different contexts:
 
@@ -317,7 +319,7 @@ To summarize, here is the breakdown of the sizes used for `CONTRACT_CODE` in dif
 - Disk read bytes limit and fee - disk size
 - Disk write bytes limit and fee - disk size
 - Soroban state size accounting - in-memory size
-- Rent fee - in-memory size, with an additional `2` times discount
+- Rent fee - in-memory size, with an additional `3` times discount
 
 While instantiated contract code is significantly larger than it's on disk size, this is not true for cached contract data.
 For this reason, rent fees for `CONTRACT_DATA` will continue to be based on the serialized XDR disk size.
@@ -359,8 +361,8 @@ Given these constraints, the following rent fee settings will be updated to the 
 - `sorobanStateTargetSizeBytes` set to `3'000'000'000` (3 GB)
 - `rentFee1KBSorobanStateSizeLow` set to `-17'000`
 - `rentFee1KBSorobanStateSizeHigh` set to `10'000`
-- `persistentRentRateDenominator ` set to `1'823`
-- `tempRentRateDenominator` set to `3'645`
+- `persistentRentRateDenominator ` set to `1'215`
+- `tempRentRateDenominator` set to `2'430`
 
 #### `archivedEntries` Vector
 


### PR DESCRIPTION
Previously it was assumed that Wasm entries are only stored in the module cache, i.e. the actual XDR doesn't leave a memory footprint. However, this would have been hard to implement in practice, which is why code entries will also be stored in the Soroban entry cache. Since the minimum size increase for Wasm is 3x now, updated the rent discount from 2x to 3x and adjusted the fees accordingly, such that the overall rent cost decrease for Wasm stays at 20x.