### PR TITLE
SEP-53: Updated examples to display signatures in both base64 and hex formats for clarity.

### DIFF
--- a/ecosystem/sep-0053.md
+++ b/ecosystem/sep-0053.md
@@ -158,24 +158,33 @@ function stellarVerifyMessage(publicKey, message, signature):
 - Message: `Hello, World!`
 - Seed: `SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW`
 - Address: `GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L`
-- Signature (base64 encoded):
-  `fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==`
+- Signature:
+  - base64 encoded:
+    `fO5dbYhXUhBMhe6kId/cuVq/AfEnHRHEvsP8vXh03M1uLpi5e46yO2Q8rEBzu3feXQewcQE5GArp88u6ePK6BA==`
+  - hex encoded:
+    `7cee5d6d885752104c85eea421dfdcb95abf01f1271d11c4bec3fcbd7874dccd6e2e98b97b8eb23b643cac4073bb77de5d07b0710139180ae9f3cbba78f2ba04`
 
 2. Sign a Japanese message
 
 - Message: `こんにちは、世界！`
 - Seed: `SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW`
 - Address: `GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L`
-- Signature (base64 encoded):
-  `CDU265Xs8y3OWbB/56H9jPgUss5G9A0qFuTqH2zs2YDgTm+++dIfmAEceFqB7bhfN3am59lCtDXrCtwH2k1GBA==`
+- Signature:
+  - base64 encoded:
+    `CDU265Xs8y3OWbB/56H9jPgUss5G9A0qFuTqH2zs2YDgTm+++dIfmAEceFqB7bhfN3am59lCtDXrCtwH2k1GBA==`
+  - hex encoded:
+    `083536eb95ecf32dce59b07fe7a1fd8cf814b2ce46f40d2a16e4ea1f6cecd980e04e6fbef9d21f98011c785a81edb85f3776a6e7d942b435eb0adc07da4d4604`
 
 3. Sign a binary message
 
 - Message (base64 encoded): `2zZDP1sa1BVBfLP7TeeMk3sUbaxAkUhBhDiNdrksaFo=`
 - Seed: `SAKICEVQLYWGSOJS4WW7HZJWAHZVEEBS527LHK5V4MLJALYKICQCJXMW`
 - Address: `GBXFXNDLV4LSWA4VB7YIL5GBD7BVNR22SGBTDKMO2SBZZHDXSKZYCP7L`
-- Signature (base64 encoded):
-  `VA1+7hefNwv2NKScH6n+Sljj15kLAge+M2wE7fzFOf+L0MMbssA1mwfJZRyyrhBORQRle10X1Dxpx+UOI4EbDQ==`
+- Signature:
+  - base64 encoded:
+    `VA1+7hefNwv2NKScH6n+Sljj15kLAge+M2wE7fzFOf+L0MMbssA1mwfJZRyyrhBORQRle10X1Dxpx+UOI4EbDQ==`
+  - hex encoded:
+    `540d7eee179f370bf634a49c1fa9fe4a58e3d7990b0207be336c04edfcc539ff8bd0c31bb2c0359b07c9651cb2ae104e4504657b5d17d43c69c7e50e23811b0d`
 
 ## Limitations
 


### PR DESCRIPTION
In SEP-43, signatures are represented using hex strings, so it would be better to update the examples in SEP-53 as well.