### PR TITLE
Update SEP 0054 to use fixed config file path

### DIFF
--- a/ecosystem/sep-0054.md
+++ b/ecosystem/sep-0054.md
@@ -7,7 +7,7 @@ Author: Tamir Sen <@tamirms>
 Status: Draft
 Created: 2025-03-11
 Updated: 2025-03-11
-Version: 0.2.0
+Version: 0.1.0
 Discussion: https://github.com/orgs/stellar/discussions/1678
 ```
 
@@ -138,12 +138,12 @@ for the given compression algorithm will be used as a suffix in the batch name.
 ### Configuration File
 
 The data store includes a configuration JSON object stored under the key
-`/<config-path>`. This file contains the following properties:
+`/<ledgers-path>/.config.json`. This file contains the following properties:
 
 - `networkPassphrase` - (string) the passphrase for the Stellar network
   associated with the ledgers.
-- `ledgersPath` - (string) the `/<ledgers-path>` directory which contains all
-  the partitions and batches.
+- `version` - (string) the version of the configuration file schema which
+  aligns with this SEP.
 - `compression` - (string) the compression algorithm used to compress ledger
   objects (currently only [`zstd`]([https://facebook.github.io/zstd/) is
   supported).
@@ -156,7 +156,7 @@ The data store includes a configuration JSON object stored under the key
 ```json
 {
   "networkPassphrase": "Public Global Stellar Network ; September 2015",
-  "ledgersPath": "/stellar/pubnet/ledgers",
+  "version": "0.1.0",
   "compression": "zstd",
   "ledgersPerBatch": 2,
   "batchesPerPartition": 8
@@ -167,21 +167,20 @@ The data store includes a configuration JSON object stored under the key
 
 ### Example Key Structure
 
-Below is an example list of keys (with `/<config-path>` set to
-`/stellar/pubnet/config.json`) for ledger batches based on the above example
-configuration:
+Below is an example list of keys (with `/<ledgers-path>` set to
+`/stellar/pubnet`) for ledger batches based on the above example configuration:
 
 ```
-/stellar/pubnet/config.json
-/stellar/pubnet/ledgers/FFFFFFEF--16-31/FFFFFFED--18-19.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr.zst
-/stellar/pubnet/ledgers/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr.zst
+/stellar/pubnet/.config.json
+/stellar/pubnet/FFFFFFEF--16-31/FFFFFFED--18-19.xdr.zst
+/stellar/pubnet/FFFFFFEF--16-31/FFFFFFEF--16-17.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFF1--14-15.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFF3--12-13.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFF5--10-11.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFF7--8-9.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFF9--6-7.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFFB--4-5.xdr.zst
+/stellar/pubnet/FFFFFFFF--0-15/FFFFFFFD--2-3.xdr.zst
 ```
 
 [![](https://mermaid.ink/img/pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNpt0clugzAQBuBXQXPOhDokIeFQqYRy6L6dGjhYsQOR2GSM1DbKu3dq4raJ8MHC_B8zNt7DphYSAsgUb3LnLUoqh8bV2i2kyKRq3dRBvHTCdWzGdYzI5ugxNz1KE6-OcUzxBbKZTfs5NObGloioxALZcvwh1Pir1el_dXvaiPlnqp9Xxt7ZrozslNqe2V7dW-WRmiDzBtWDVTNSdAQ2qB6t8hEXaE5wkj_ZfIk4R3-wxrM1IeIUh_f8Yg39qwn-7RhGUEpV8p2gK9v_fJGAzmUpEwjoUcgt7wqdQFIdiPJO16-f1QYCrTo5AlV3WQ7BlhctrbpGcC2jHaerL3_fNrx6r2u7PnwDAJ6W4g)
@@ -217,4 +216,3 @@ been altered.
 ## Changelog
 
 - `v0.1.0`: Initial draft
-- `v0.2.0`: Make ledgers path and config path configurable

--- a/ecosystem/sep-0054.md
+++ b/ecosystem/sep-0054.md
@@ -39,7 +39,8 @@ The data store is a key-value store where:
 
 - **Keys** are strings following a specific hierarchical format.
 - **Values** are binary blobs representing compressed `LedgerCloseMetaBatch`
-  XDR values.
+  XDR values. The one exception is the value representing the JSON config which
+  is described later on in more detail.
 
 The key-value store must support:
 
@@ -72,7 +73,7 @@ struct LedgerCloseMetaBatch
 };
 ```
 
-- A LedgerCloseMetaBatch represents a contiguous range of one or more
+- A `LedgerCloseMetaBatch` represents a contiguous range of one or more
   consecutive ledgers.
 
 - All batches in a data store instance contain the same number of ledgers.
@@ -187,6 +188,36 @@ Below is an example list of keys (with `/<ledgers-path>` set to
 
 **Note:** The genesis ledger starts at sequence number 2, so the oldest batch
 must have a `batchStartLedgerSequence` of 2.
+
+---
+
+### Metadata
+
+Every `LedgerCloseMetaBatch` value also has the following metadata associated
+with it:
+
+- `start-ledger` - (string) the starting ledger of the range of ledgers
+  enclosed in the `LedgerCloseMetaBatch` value.
+- `end-ledger` - (string) the last ledger of the range of ledgers enclosed in
+  the `LedgerCloseMetaBatch` value.
+- `start-ledger-close-time` - (string) the unix time stamp of the close time
+  for the starting ledger.
+- `end-ledger-close-time` - (string) the unix time stamp of the close time for
+  the last ledger.
+- `protocol-version` - (string) the protocol version of the last ledger.
+- `core-version` - (string) the version of stellar-core which produced the
+  ledgers enclosed in the `LedgerCloseMetaBatch` value.
+- `network-passphrase` - (string) the network passphrase for the Stellar
+  network which produced the ledgers.
+- `compression-type` - (string) the compression algorithm used to compress the
+  `LedgerCloseMetaBatch` value (currently only
+  [`zstd`]([https://facebook.github.io/zstd/) is supported).
+- `version` - (string) the version of
+  [galexie](https://github.com/stellar/go/tree/master/services/galexie) used to
+  insert the `LedgerCloseMetaBatch` value in the data store.
+
+These metadata key-value pairs can be implemented as user-defined object
+metadata in GCS or S3.
 
 ## Design Rationale
 


### PR DESCRIPTION
In response to feedback from @leighmcculloch in https://github.com/orgs/stellar/discussions/1678#discussioncomment-13812481 and https://github.com/orgs/stellar/discussions/1678#discussioncomment-13812511 , I have decided to update the sep with the following changes:

- only `/<ledgers-path>` is configurable and the config file will located at `/<ledgers-path>/.config.json`. The advantage of this approach is that the config file is always co-located with the partitions. Also, because the config filename starts with a period, it will always precede the partitions lexicographically, whereas a filename of "config.json" could be interspersed lexicographically with the partition folders. Having a fixed config file path is easier for the operator because they only need to configure `/<ledgers-path>` as opposed to both `/<ledgers-path>` and `/<config-path>`
- added a `version` field to the config file which is aligned with the SEP. This will make it easier to introduce modifications to the config schema in the future.

Note that I opted against including a "server" field because I thought it would be confusing. The config file is only written once while ledgers can be continuously added to the data store. I think if we included a galexie version in the "server" field it would not be clear whether this is the version that initialized the config file or if it's the version which added the most recent ledgers to the data store.