### PR TITLE
SEP-47: Fix title in ecosystem README

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -91,7 +91,7 @@ All SEPs have individuals fulfilling the following roles:
 | [SEP-0040](sep-0040.md) | Oracle Consumer Interface                                      | Alex Mootz, OrbitLens, Markus Paulson-Luna    | Draft                |
 | [SEP-0041](sep-0041.md) | Soroban Token Interface                                        | Jonathan Jove, Siddharth Suresh               | Draft                |
 | [SEP-0045](sep-0045.md) | Stellar Web Authentication for Contract Accounts               | Philip Liu, Marcelo Salloum, Leigh McCulloch  | Draft                |
-| [SEP-0047](sep-0047.md) | Standard Interface Discovery                                   | Leigh McCulloch                               | Draft                |
+| [SEP-0047](sep-0047.md) | Contract Interface Discovery                                   | Leigh McCulloch                               | Draft                |
 | [SEP-0049](sep-0049.md) | Upgradeable Contracts                                          | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Draft                |
 | [SEP-0050](sep-0050.md) | Non-Fungible Tokens                                            | OpenZeppelin, Boyan Barakov, Özgün Özerk      | Draft                |
 | [SEP-0051](sep-0051.md) | XDR-JSON                                                       | Leigh McCulloch                               | Draft                |


### PR DESCRIPTION
### What

Change the title of SEP-47 in the ecosystem README to Contract Interface Discovery, to match the title of the SEP.

### Why

In https://github.com/stellar/stellar-protocol/pull/1703 I renamed SEP-47 to Contract Interface Discovery and updated the ecosystem README. In https://github.com/stellar/stellar-protocol/pull/1704 I accidentally renamed it back, probably as the result of a botched merge fix up.