### PR TITLE
SEP-41: Add muxed address support to token interface

### DIFF
--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -3,11 +3,11 @@
 ```
 SEP: 0041
 Title: Soroban Token Interface
-Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>
+Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2025-03-13
-Version 0.3.0
+Updated: 2025-08-28
+Version 0.4.0
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
 
@@ -97,15 +97,17 @@ pub trait TokenInterface {
     ///
     /// - `from` - The address holding the balance of tokens which will be
     /// withdrawn from.
-    /// - `to` - The address which will receive the transferred tokens.
+    /// - `to` - The address which will receive the transferred tokens. A MuxedAddress or Address.
     /// - `amount` - The amount of tokens to be transferred.
     ///
     /// # Events
     ///
     /// Emits an event with:
     /// - topics - `["transfer", from: Address, to: Address]`
-    /// - data - `amount: i128`
-    fn transfer(env: Env, from: Address, to: Address, amount: i128);
+    /// - data - `amount: i128` or `{ amount: i128, to_muxed_id: Option<u64 | String | BytesN<32>> }`
+    /// If the transfer involves a muxed address the address and muxed details
+    /// are separated in the event.
+    fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
     /// Transfer `amount` from `from` to `to`, consuming the allowance of
     /// `spender`. Authorized by spender (`spender.require_auth()`).
@@ -200,6 +202,9 @@ The event has topics:
 The event has data:
 
 - `i128` the amount transferred.
+- or `map` containing:
+  - `amount: i128` the amount minted.
+  - `to_muxed_id: Option<u64 | String | Bytes<32>>` void is no muxed ID, or the u64 muxed ID, or for Stellar assets also string and bytes.
 
 #### Burn Event
 
@@ -226,6 +231,9 @@ The event has topics:
 The event has data:
 
 - `i128` the amount minted.
+- or `map` containing:
+  - `amount: i128` the amount minted.
+  - `to_muxed_id: Option<u64 | string | bytes>` void is no muxed ID, or the u64 muxed ID, or for Stellar assets also string and bytes.
 
 #### Clawback Event
 
@@ -254,6 +262,7 @@ functions as they see fit. The contract is free to define how they want to
 - `v0.1.0` - Initial draft based on [CAP-46-6].
 - `v0.2.0` - Remove `spendable_balance`.
 - `v0.3.0` - Add `mint` and `clawback` event
+- `v0.4.0` - Add muxed support to transfer, and mint.
 
 ## Implementations
 


### PR DESCRIPTION
### What
  Add support for muxed addresses to SEP-41 Soroban token interface in the transfer and mint actions.

  ### Why
  Updating SEP-41 for consistency with the proposals in CAP-67. SEP-41 is updated to completely encompass a unified view into the movement of value in the same reasons that mint and clawback events were recently added to SEP-41. The MuxedAddress type is a special Soroban type in that it is compatible with the Address type and can contain it and be converted to it automatically when no muxed address details are present. This makes the changes to the transfer function largely backwards compatible with existing token implementations. The changes to the events expand the possible events consumers should expect to see, but existing token contracts and implementations can continue to emit the existing events if desired.