### PR TITLE
CAP-71 - Add delegated signers getter.

### DIFF
--- a/core/cap-0071.md
+++ b/core/cap-0071.md
@@ -48,7 +48,7 @@ Each of the delegated addresses has its own signature and its own authentication
 
 `delegate_account_auth` calls can also be nested recursively, and every authentication call will still inherit the 'top-level' arguments.
 
-Another host function called `get_delegated_signers` is also introduced for standardizing and simplifying the delegated signers access by providing the direct access to the delegated signers populated in the authorization payload.
+Another host function called `get_delegated_signers_for_current_auth_check` is also introduced for standardizing and simplifying the delegated signers access by providing the direct access to the delegated signers populated in the authorization payload.
 
 With these changes only a single authorization entry is necessary to accommodate an arbitrary number of potentially nested delegated signers, which reduces the transaction size greatly and simplifies the simulation logic.
 
@@ -135,7 +135,7 @@ The diff is based on commit `f5153ff476ce7e68ee0bda278188cded135ff301` of `rs-so
 
 ```diff mddiffcheck.ignore=true
 diff --git a/soroban-env-common/env.json b/soroban-env-common/env.json
-index 50293483..0e7a5547 100644
+index 50293483..269862fc 100644
 --- a/soroban-env-common/env.json
 +++ b/soroban-env-common/env.json
 @@ -2467,6 +2467,25 @@
@@ -145,7 +145,7 @@ index 50293483..0e7a5547 100644
 +                },
 +                {
 +                    "export": "7",
-+                    "name": "get_delegated_signers",
++                    "name": "get_delegated_signers_for_current_auth_check",
 +                    "args": [],
 +                    "return": "VecObject",
 +                    "docs": "Returns a vector of `Address`es of all the delegated signers that have attached signatures to authorize the current account contract invocation. **Important**: These are user-provided inputs and should be treated accordingly, in a similar fashion to the actual signatures. Specifically, the account contract must ensure that these signers actually belong to it, and perform authentication for every one of them via `delegate_account_auth`. This may only be called within `__check_auth` contract function inside a custom account."
@@ -187,9 +187,9 @@ More formally, the algorithm for handling `delegate_account_auth` is defined as 
   3. Call `B.__check_auth(P, current_delegate_list[i].signature, C)`.
      - For the call, set `current_delegate_list` to the value of `current_delegate_list[i].nestedDelegates` and mark every delegate as unused.
 
-#### `get_delegated_signers` function
+#### `get_delegated_signers_for_current_auth_check` function
 
-`get_delegated_signers` is a supplementary host function that simplifies the usage of `delegate_account_auth`. It returns the `current_delegate_list` populated as per the algorithm in the previous section as a vector of addresses. 
+`get_delegated_signers_for_current_auth_check` is a supplementary host function that simplifies the usage of `delegate_account_auth`. It returns the `current_delegate_list` populated as per the algorithm in the previous section as a vector of addresses. 
 
 This allows account contracts to have `Void`/empty signature when only the delegated signers are being used, which further reduces the transaction size and complexity, and simplifies the contract itself.
 
@@ -215,7 +215,7 @@ The ability to nest the delegated signers makes protocol a bit more complex and 
 
 ### Delegated signer getter
 
-``get_delegated_signers` function is technically optional for this CAP, as smart accounts could get away with defining a special signature type to account for the delegated signers.
+``get_delegated_signers_for_current_auth_check` function is technically optional for this CAP, as smart accounts could get away with defining a special signature type to account for the delegated signers.
 
  However, this creates some unnecessary duplication in the transaction data (as delegated signers would need to be specified twice), and introduces unnecessary fragmentation into how delegated signers work, as different contracts may use slightly different UDTs to represent them in signatures. This CAP already provides a standardized approach for storing the delegated signers in the transaction, so there is no good reason not to benefit from that on the contract implementation side as well, while also avoiding duplication.
 

--- a/core/cap-0071.md
+++ b/core/cap-0071.md
@@ -48,6 +48,8 @@ Each of the delegated addresses has its own signature and its own authentication
 
 `delegate_account_auth` calls can also be nested recursively, and every authentication call will still inherit the 'top-level' arguments.
 
+Another host function called `get_delegated_signers` is also introduced for standardizing and simplifying the delegated signers access by providing the direct access to the delegated signers populated in the authorization payload.
+
 With these changes only a single authorization entry is necessary to accommodate an arbitrary number of potentially nested delegated signers, which reduces the transaction size greatly and simplifies the simulation logic.
 
 ## Specification
@@ -133,16 +135,23 @@ The diff is based on commit `f5153ff476ce7e68ee0bda278188cded135ff301` of `rs-so
 
 ```diff mddiffcheck.ignore=true
 diff --git a/soroban-env-common/env.json b/soroban-env-common/env.json
-index 50293483..65669fb1 100644
+index 50293483..0e7a5547 100644
 --- a/soroban-env-common/env.json
 +++ b/soroban-env-common/env.json
-@@ -2467,6 +2467,18 @@
+@@ -2467,6 +2467,25 @@
                      "return": "Val",
                      "docs": "Returns the executable corresponding to the provided address. When the address does not exist on-chain, returns `Void` value. When it does exist, returns a value of `AddressExecutable` contract type. It is an enum with `Wasm` value and the corresponding Wasm hash for the Wasm contracts, `StellarAsset` value for Stellar Asset contract instances, and `Account` value for the 'classic' (G-) accounts.",
                      "min_supported_protocol": 23
 +                },
 +                {
 +                    "export": "7",
++                    "name": "get_delegated_signers",
++                    "args": [],
++                    "return": "VecObject",
++                    "docs": "Returns a vector of `Address`es of all the delegated signers that have attached signatures to authorize the current account contract invocation. **Important**: These are user-provided inputs and should be treated accordingly, in a similar fashion to the actual signatures. Specifically, the account contract must ensure that these signers actually belong to it, and perform authentication for every one of them via `delegate_account_auth`. This may only be called within `__check_auth` contract function inside a custom account."
++                },
++                {
++                    "export": "8",
 +                    "name": "delegate_account_auth",
 +                    "args": [
 +                        {
@@ -178,6 +187,11 @@ More formally, the algorithm for handling `delegate_account_auth` is defined as 
   3. Call `B.__check_auth(P, current_delegate_list[i].signature, C)`.
      - For the call, set `current_delegate_list` to the value of `current_delegate_list[i].nestedDelegates` and mark every delegate as unused.
 
+#### `get_delegated_signers` function
+
+`get_delegated_signers` is a supplementary host function that simplifies the usage of `delegate_account_auth`. It returns the `current_delegate_list` populated as per the algorithm in the previous section as a vector of addresses. 
+
+This allows account contracts to have `Void`/empty signature when only the delegated signers are being used, which further reduces the transaction size and complexity, and simplifies the contract itself.
 
 #### Signature payload for `SorobanAddressCredentialsWithDelegates`
 
@@ -198,6 +212,12 @@ Note, that in the 'legacy' delegation flow that currently exists in the protocol
 ### Delegated signer recursive nesting
 
 The ability to nest the delegated signers makes protocol a bit more complex and requires 4 bytes of additional space in credentials even if it's not being used. This is introduced mostly for the sake of completeness and consistency, so that any accounts could be used as delegated signers (including ones that have delegated signers of their own). This may also potentially help some complex protocols that may come in the future. The relative protocol complexity increase is pretty marginal and thus should be tolerable.
+
+### Delegated signer getter
+
+``get_delegated_signers` function is technically optional for this CAP, as smart accounts could get away with defining a special signature type to account for the delegated signers.
+
+ However, this creates some unnecessary duplication in the transaction data (as delegated signers would need to be specified twice), and introduces unnecessary fragmentation into how delegated signers work, as different contracts may use slightly different UDTs to represent them in signatures. This CAP already provides a standardized approach for storing the delegated signers in the transaction, so there is no good reason not to benefit from that on the contract implementation side as well, while also avoiding duplication.
 
 ## Protocol Upgrade Transition
 


### PR DESCRIPTION
This is not strictly required, but not doing this would introduce some unnecessary annoyance for the contract implementation and transaction building, including CAP-72 as well.