### PR TITLE
CAP-72 - Switch to the approach of modifying the AccountEntry directly

### DIFF
--- a/core/cap-0072.md
+++ b/core/cap-0072.md
@@ -35,15 +35,13 @@ This CAP is aligned with the following Stellar Network Goals:
 
 ## Abstract
 
-This CAP introduces a new kind of G-account signers, called 'delegated signers', that are accessible only from within the smart contract environment. Delegated signers have a signature weight, similarly to the existing ed25519 account signers. Instead of performing the cryptographic verification, `require_auth` host function will be called for the delegated signer's address in order to perform authentication. Thus, if the delegated signer is a contract, then `__check_auth` will be called for it, which allows for the G-account authentication customization.
+This CAP introduces a new kind of G-account signers, called 'delegated signers', that are usable only from within the smart contract environment, i.e. these signers can not be used to sign the transactions directly, but can be used to sign for `SorobanAuthorizationEntry`. Delegated signers are stored in the `AccountEntry` in the same fashion as any other G-account signer and they also can be managed via `SetOptionsOp`.
 
-Since delegated signers are only accessible in the smart contract environment, in order to fulfill the account management requirement, every G-account is treated as a built-in smart contract with an interface that provides all the account management capabilities necessary for the recovery flows. Unlike the Stellar Asset contract, every account on chain will be implicitly instantiated as a contract, i.e. its address will just become callable without any additional actions required from the users.
+Delegated signers have a signature weight, similarly to the existing ed25519 account signers. However, instead of performing the cryptographic verification, `delegate_account_auth` (introduced in [CAP-71](./cap-0071.md)) host function will be called for the delegated signer's address in order to perform authentication. Thus, if the delegated signer is a contract, then `__check_auth` will be called for it, which allows for the G-account authentication logic customization.
 
-When managing the G-account via contract functions the new data will be written to a special new 'additional signers' contract data entry, while the modifications and deletions can happen both in the 'additional signers' entry and in the `AccountEntry` itself.
+Since delegated signers can only be used for authentication in the smart contract environment, in order to fulfill the requirement for being able to use customizable authentication for managing the account, every G-account is treated as a built-in smart contract with an interface that provides all the account management capabilities necessary for the recovery flows. Unlike the Stellar Asset contract, every account on chain will be implicitly instantiated as a contract, i.e. its address will just become callable without any additional actions required from the users.
 
-Delegated signers are not allowed to sign the transactions. However, the protocol will allow using ed25519 account signers that come from the 'additional signers' contract data entry. This way it will be possible to recover full access to the account from the built-in contract, including the ability to sign transactions.
-
-Additional account signers are stored in a contract data entry and thus it may be archived. Protocol will still allow to sign transactions with the signers that remain in the account entry, but account merges will only be allowed after the 'additional signers' entry has been restored.
+ Modifications performed to delegated and regular (ed25519) signers via the G-account built-in contract require updating the account base reserves and removing the sponsorships on deletion. This sets a precedent for the classic base reserves being managed from the Soroban environment, including releasing the reserves from the sponsoring accounts on deletion. Using a new sponsorship itself won't be possible for the signers added via G-account contract, so a G-account *must* hold a sufficient XLM balance in order to add new signers via its contract.
 
 ## Specification
 
@@ -52,125 +50,45 @@ Additional account signers are stored in a contract data entry and thus it may b
 This patch of XDR changes is based on the XDR files in commit `4b7a2ef7931ab2ca2499be68d849f38190b443ca` of stellar-xdr.
 
 ```diff mddiffcheck.ignore=true
-diff --git a/Stellar-contract.x b/Stellar-contract.x
-index 0e67dc3..1845616 100644
---- a/Stellar-contract.x
-+++ b/Stellar-contract.x
-@@ -63,14 +63,20 @@ enum SCValType
-     SCV_ADDRESS = 18,
- 
-     // The following are the internal SCVal variants that are not
--    // exposed to the contracts. 
-+    // exposed to the contracts.
-+
-+    // A special value type for holding contract instance data.
-     SCV_CONTRACT_INSTANCE = 19,
- 
-     // SCV_LEDGER_KEY_CONTRACT_INSTANCE and SCV_LEDGER_KEY_NONCE are unique
-     // symbolic SCVals used as the key for ledger entries for a contract's
-     // instance and an address' nonce, respectively.
-     SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20,
--    SCV_LEDGER_KEY_NONCE = 21
-+    SCV_LEDGER_KEY_NONCE = 21,
-+
-+    // A special value type for holding additional signers of a Stellar account 
-+    // as contract data.
-+    SCV_ACCOUNT_SIGNERS = 22
- };
- 
- enum SCErrorType
-@@ -226,6 +232,30 @@ struct SCContractInstance {
-     SCMap* storage;
- };
- 
-+enum SCAccountSignerType
-+{
-+    ACCOUNT_SIGNER_CLASSIC = 0,
-+    ACCOUNT_SIGNER_DELEGATED = 1
-+};
-+
-+struct SCDelegatedAccountSigner {
-+    SCAddress address;
-+    uint32 weight;
-+};
-+
-+union SCAccountSigner switch (SCAccountSignerType type)
-+{
-+case ACCOUNT_SIGNER_CLASSIC:
-+    Signer signer;
-+case ACCOUNT_SIGNER_DELEGATED:
-+    SCDelegatedAccountSigner delegatedSigner;
-+};
-+
-+struct SCAccountSigners {
-+    ExtensionPoint ext;
-+    SCAccountSigner signers<MAX_SIGNERS>;
-+};
-+
- union SCVal switch (SCValType type)
- {
- 
-@@ -285,6 +315,8 @@ case SCV_LEDGER_KEY_CONTRACT_INSTANCE:
-     void;
- case SCV_LEDGER_KEY_NONCE:
-     SCNonceKey nonce_key;
-+case SCV_ACCOUNT_SIGNERS:
-+    SCAccountSigners signers;
- };
- 
- struct SCMapEntry
-diff --git a/Stellar-ledger-entries.x b/Stellar-ledger-entries.x
-index b9a9a16..7deba93 100644
---- a/Stellar-ledger-entries.x
-+++ b/Stellar-ledger-entries.x
-@@ -124,12 +124,18 @@ enum AccountFlags
-     // Trustlines are created with clawback enabled set to "true",
-     // and claimable balances created from those trustlines are created
-     // with clawback enabled set to "true"
--    AUTH_CLAWBACK_ENABLED_FLAG = 0x8
-+    AUTH_CLAWBACK_ENABLED_FLAG = 0x8,
-+
-+    // General purpose flags
-+    // Indicates that an account has a contract data entry with additional 
-+    // signers.
-+    ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG = 0x10,
- };
- 
- // mask for all valid flags
- const MASK_ACCOUNT_FLAGS = 0x7;
- const MASK_ACCOUNT_FLAGS_V17 = 0xF;
-+const MASK_ACCOUNT_FLAGS_V24 = 0x1F;
- 
- // maximum number of signers
- const MAX_SIGNERS = 20;
 diff --git a/Stellar-transaction.x b/Stellar-transaction.x
-index 9a14d6e..479ae9f 100644
+index 9a14d6e..0d89002 100644
 --- a/Stellar-transaction.x
 +++ b/Stellar-transaction.x
-@@ -1378,7 +1378,10 @@ enum SetOptionsResultCode
-     SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
-     SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
-     SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
--        -10 // auth revocable is required for clawback
-+        -10, // auth revocable is required for clawback
-+    // There is an additional signers entry for this account that has been 
-+    // archived. It has to be restored first before options can be modified.
-+    SET_OPTIONS_ADDITIONAL_SIGNERS_ARCHIVED = -11
+@@ -1999,7 +1999,10 @@ enum TransactionResultCode
+     txBAD_SPONSORSHIP = -14,        // sponsorship not confirmed
+     txBAD_MIN_SEQ_AGE_OR_GAP = -15, // minSeqAge or minSeqLedgerGap conditions not met
+     txMALFORMED = -16,              // precondition is invalid
+-    txSOROBAN_INVALID = -17         // soroban-specific preconditions were not met
++    txSOROBAN_INVALID = -17,        // soroban-specific preconditions were not met
++    // Transaction had an extra signer of type SIGNER_KEY_TYPE_SC_DELEGATED, 
++    // which is not supported.
++    txACCOUNT_DELEGATED_SIGNER_NOT_SUPPORTED = -18 
  };
  
- union SetOptionsResult switch (SetOptionsResultCode code)
-@@ -1478,7 +1481,10 @@ enum AccountMergeResultCode
-     ACCOUNT_MERGE_SEQNUM_TOO_FAR = -5,  // sequence number is over max allowed
-     ACCOUNT_MERGE_DEST_FULL = -6,       // can't add source balance to
-                                         // destination balance
--    ACCOUNT_MERGE_IS_SPONSOR = -7       // can't merge account that is a sponsor
-+    ACCOUNT_MERGE_IS_SPONSOR = -7,      // can't merge account that is a sponsor
-+    // There is an additional signers entry for this account that has been 
-+    // archived. It has to be restored first before account can be merged.
-+    ACCOUNT_MERGE_ADDITIONAL_SIGNERS_ARCHIVED = -8 
+ // InnerTransactionResult must be binary compatible with TransactionResult
+diff --git a/Stellar-types.x b/Stellar-types.x
+index f383d2e..ff1ed72 100644
+--- a/Stellar-types.x
++++ b/Stellar-types.x
+@@ -47,7 +47,8 @@ enum SignerKeyType
+     SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+     SIGNER_KEY_TYPE_PRE_AUTH_TX = KEY_TYPE_PRE_AUTH_TX,
+     SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X,
+-    SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD
++    SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD = KEY_TYPE_ED25519_SIGNED_PAYLOAD,
++    SIGNER_KEY_TYPE_SC_DELEGATED = 4
  };
  
- union AccountMergeResult switch (AccountMergeResultCode code)
+ union PublicKey switch (PublicKeyType type)
+@@ -74,6 +75,8 @@ case SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD:
+         /* Payload to be raw signed by ed25519. */
+         opaque payload<64>;
+     } ed25519SignedPayload;
++case SIGNER_KEY_TYPE_SC_DELEGATED:
++    SCAddress delegatedSCSigner;
+ };
+ 
+ // variable size as the size depends on the signature scheme used
 ```
 
 ### Stellar(G-) account contract interface
@@ -224,61 +142,28 @@ pub trait StellarAccountInterface {
     fn update_thresholds(env: Env, low: Option<u32>, med: Option<u32>, high: Option<u32>);
 }
 ```
+### Classic transaction semantics
 
-### 'Classic' transaction semantics
+A new type of G-account signer `SIGNER_KEY_TYPE_SC_DELEGATED` is added. It is supported in most of the contexts where the `Signer` struct is used, such as the `SetOptionsOp`, which thus allows adding/removing/updating the delegated signers.
 
-#### Ledger entry for additional account signers
+The only context where `SIGNER_KEY_TYPE_SC_DELEGATED` is explicitly not supported is the `extraSigners` transaction precondition, which allows users specifying the `SignerKey` that must sign a transaction. If `SignerKey` is of type `SIGNER_KEY_TYPE_SC_DELEGATED`, then the transaction will be considered not valid with the `txACCOUNT_DELEGATED_SIGNER_NOT_SUPPORTED` error.
 
-Every new or existing G-account on-chain may have up to 1 `ContractDataEntry` that contains additional signers (further referred to as 'additional signers entry'). The specification for the entry is as follows:
-
-- `contract` - the `SCAddress` corresponding to the account
-- `key` - `SCV_SYMBOL` `SCVal` with value `"SIGNERS" `
-- `durability` - `PERSISTENT`
-- `val` - `SCV_ACCOUNT_SIGNERS` `SCVal`
-
-`SCAccountSigners` payload may contain up to `MAX_SIGNERS` additional signers of type `SCAccountSigner` for the account (where `MAX_SIGNERS` is the same constant as one used for the `AccountEntry`, currently set to `20`). This new value type is introduced in the XDR changes above.
-
-`SCAccountSigner` may represent either a 'classic' account signer of type `Signer` (the same type as the one used for the `AccountEntry` itself), or a new kind of signer - `SCDelegatedAccountSigner`. For the `Signer` kind of signers only keys of type `SIGNER_KEY_TYPE_ED25519` will be allowed as of this CAP.
-
-`SCDelegatedAccountSigner` contains only an address to require authorization from and its weight. The maximum supported weight is 255, the same as the maximum weight for any other signer type.
-
-When the additional signers entry is created, the account flag `ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG` is set to 1, and when the entry is removed, the flag is set to 0. The flag can be used by the protocol for optimizing the account signer lookup, as well as for the downstream consumers for the purpose of account fetching and audit.
-
-#### Transaction signature verification rules update
-
-Transaction signature verification rules are updated to account for the additional account signers entry.
-
-When performing transaction or operation signature validation for a given G-account, account signers will be loaded from both the corresponding `AccountEntry` and the corresponding *live* additional signers entry when `ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG` is set. Only signers of type `ACCOUNT_SIGNER_CLASSIC` will be loaded. 
-
-If additional signers entry is not in the live state, then the signers will be treated as non-existent until the additional signers entry has been restored, so the transactions using such signers will be considered invalid. The error returned in that scenario is `txBAD_AUTH`. Clarifying message specifying that the additional signers entry is archived will be written into the diagnostic events when transaction is rejected on submission.
-
-#### `AccountMerge` operation update
-
-Account merges have to completely clean up the account state. Thus, the additional signers entry will be removed as a part of the account merge operation.
-
-In case if the additional signers entry is not in the live state, `AccountMerge` operation will fail at apply time. The check for entry being live is only performed when `ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG` is set, so there is no need to ever lookup the Hot Archive or potentially require non-existence proofs in the future protocols.
-
-`ACCOUNT_MERGE_ADDITIONAL_SIGNERS_ARCHIVED` operation error will be returned if the additional signers entry is archived.
-
-#### `SetOptions` operation update
-
-`SetOptions` operation has to take the additional signers entry into account when signer updates are performed. Classic signers from both the `AccountEntry` and additional signers entry will be considered when signer is modification is performed. A new signer will only be added if it's not present in the additional signers entry, signer weight may be modified in the additional signers entry, and signer may be removed from the additional signers entry.
-
-In case if options are modified for a signer that is not present in the `AccountEntry` and the additional signers entry is not in the live state, `SetOptions` operation will fail at apply time. The check for entry being live is only performed when `ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG` is set, in the same fashion as for the `AccountMerge` operation.
-
-`SET_OPTIONS_ADDITIONAL_SIGNERS_ARCHIVED` operation error will be returned if any signer options are modified and additional signers entry is archived.
-
-Note, that it is not possible to modify `ACCOUNT_SIGNER_DELEGATED` signers via `SetOptions`.
+Delegated signers are ignored during the transaction signature verification and they can't even be logically matched to the transaction signature hint due to `SCAddress` payload.
 
 ### Smart contract semantics
 
 #### G-account authentication
 
-The algorithm for verifying detached (non-`SOURCE_ACCOUNT`) smart contract authorization in Soroban host is updated to account for the additional signers, as well as to enable delegated account support.
+The algorithm for verifying detached (non-`SOURCE_ACCOUNT`) smart contract authorization payload in Soroban host is updated to enable delegated account support. The authentication is updated in the following way:
 
-Similarly to the transaction signature verification rules update, account signers will be loaded both from the `AccountEntry` and the additional signers entry when `ACCOUNT_ADDITIONAL_SIGNERS_ENTRY_FLAG` is set. The authentication logic is not changed for the 'classic' signers (`ACCOUNT_SIGNER_CLASSIC`). For the delegated signers, `delegate_account_auth` will be called with the corresponding delegated signer address and handled as per the section above.
-
-The signer weight processing remains unchained, but the weights may come from any account signer
+- `get_delegated_signers` host function (defined in CAP-71) is used to retrieve all the delegated signers corresponding to the authentication
+- If the total number of signatures and delegated signers is `0` or exceeds `MAX_ACCOUNT_SIGNATURES` (20), fail
+- If the delegated signers are not sorted in the ascending order, or contain duplicates, fail
+- If any delegated signer is not stored in the `AccountEntry`, fail
+- Call `delegate_account_auth` for every delegated signer, and fail if the call fails
+- Add the weight of every delegated signer to the signature weight
+- Process the regular signatures passed with the authorization entries according to [CAP-46-11](./cap-0046-11.md#stellar-account-authentication) and add their weights to the total weight
+- Compare the total signature weight to the required threshold (`MEDIUM` or `HIGH`, see details below)
 
 An additional change is made in order to use the proper signature threshold for the account management. Currently, G-account authentication rules in Soroban use `MEDIUM` threshold when authenticating an account for any Soroban operation, i.e. the built-in G-account contract ignores the authorization context completely.
 
@@ -290,45 +175,51 @@ Every G-account on-chain gets an implicit contract 'instance' which is just repr
 
 When a contract call is performed on a G-address, the implementation of GAC built into host will handle the call. This is similar to the Stellar Asset contract handling (SAC), with the only difference being that a non-contract address is being used for routing the calls.
 
-When GAC functions add new signers, the new signers are written to the additional signers contract data entry. The entry will be created in case if it didn't exist before, or removed when there are no additional signers remaining.
+#### `AccountEntry` updates from Soroban host
 
-Every GAC function calls `require_auth` for the corresponding G-account. Authentication procedure will require `HIGH` signature threshold, as per G-account authentication semantics described above.
+All GAC operations have to update the `AccountEntry` that belongs to the corresponding G-account. Updates to the signers require following the base reserve semantics in the same fashion as for the `SetOptions` operation.
+
+When a signer is added to the `AccountEntry`, the number of account sub-entries is increased, so the base reserve has to go up. If the account does not have sufficient balance for increasing the base reserve, then the function call will fail. Sponsorship is not supported for the Soroban operations in general, so there is no way to sponsor the base reserve instead.
+
+When a signer is removed from the `AccountEntry`, it might be sponsored. If there is no sponsorship, then the sub-entries count is just reduced for the entry. If there is a sponsorship, then information is updated accordingly in both the affected account and its sponsor, i.e. base reserve is returned to the sponsor. This update does not require additional authorization from the sponsor, so it can be performed by the Soroban Host by just changing 2 account entries accordingly.
+
+##### GAC functions
+
+Every GAC function calls `require_auth` for the corresponding G-account. Authentication procedure will require `HIGH` signature threshold, as per G-account authentication semantics described in the authentication [section](#g-account-authentication).
 
 The following sections describe semantics of all the GAC functions.
 
-##### `update_ed25519_signer`
+###### `update_ed25519_signer`
 
-Adds a new ed25519 signer with the provided 32-byte public key and the provided weight to the additional signers entry as `ACCOUNT_SIGNER_CLASSIC` signer. If the signer already exists in either the `AccountEntry`, or the additional signers entry, updates its weight instead.
+Adds a new ed25519 signer with the provided 32-byte public key to the account. If the signer already exists, updates its weight instead.
 
-Fails if a new signer is being added and an account already has `MAX_SIGNERS` (20) additional signers in the contract data entry.
+Fails if a new signer is being added and an account already has `MAX_SIGNERS` (20) signers.
 
-##### `remove_ed25519_signer`
+###### `remove_ed25519_signer`
 
-Removes an existing ed25519 signer from the account. The signer may be present in either the `AccountEntry`, or the additional signers entry (if any).
-
-When a signer is removed from the `AccountEntry`, it might be sponsored. In that case the sponsorship information is updated accordingly in both the affected account and its sponsor, i.e. base reserve is returned to the sponsor. This update does not require additional authorization from the sponsor, so it can be performed by the Soroban Host by just changing 2 account entries accordingly.
+Removes an existing ed25519 signer from the account.
 
 Fails if the signer does not exist.
 
-##### `update_delegated_signer`
+###### `update_delegated_signer`
 
-Adds a new delegated signer with the provided `Address` and the provided weight to the additional signers entry as `ACCOUNT_SIGNER_DELEGATED` signer. If the signer already exists, updates the weight instead.
+Adds a new delegated signer with the provided `Address` and the provided weight. If the signer already exists, updates the weight instead.
 
-Fails if a new signer is being added and an account already has `MAX_SIGNERS` (20) additional signers in the contract data entry.
+Fails if a new signer is being added and an account already has `MAX_SIGNERS` (20) signers.
 
-##### `remove_delegated_signer`
+###### `remove_delegated_signer`
 
-Removes an existing delegated signer from the account's additional signers entry.
+Removes an existing delegated signer from the account.
 
 Fails if the signer does not exist.
 
-##### `set_master_weight`
+###### `set_master_weight`
 
-Sets the weight of the 'master' key, i.e. the public key that identifies the account. The weight is updated in the `AccountEntry`.
+Sets the weight of the 'master' key, i.e. the public key that identifies the account.
 
-##### `update_thresholds`
+###### `update_thresholds`
 
-Updates the signature thresholds of the account when the corresponding arguments are set for the low/medium/high thresholds. The threshold are updated in the `AccountEntry`.
+Updates the signature thresholds of the account when the corresponding arguments are set for the low/medium/high thresholds.
 
 ## Design Rationale
 
@@ -336,11 +227,15 @@ Updates the signature thresholds of the account when the corresponding arguments
 
 There is no need to explicitly created a contract instance for the G-accounts. This reduces the complexity compared to the Stellar Asset contract and reduces the necessary ledger state size. While this approach means that there is no way to opt out from the account being accessible via GAC, the account implementation has the same authorization requirements as the existing account management operation (`SetOptionsOp`), so there is no additional risk surface or cost induced by the implicit GAC instances.
 
-### Additional signers entry and state archival
+### Account base reserve management from Soroban
 
-This CAP sets the precedent for using the contract data that is subject to state archival in the 'classic' flows, both during the transaction validation for every transaction on-chain, as well as in the classic operation (account merge). This is not the only possible approach: an alternative could be to add delegated signers directly to the `Signer` XDR and store them in the `AccountEntry`. However, that would come with an additional complexity when interacting with the classic semantics from Soroban, as normally Soroban does not interact with sponsorships and doesn't increase base reserves.
+Until now, Soroban used to only modify a few fields in the 'classic' entries, which haven't required making any changes to the account base reserves and sponsorships. This CAP introduces modifications that require updating the base reserves and sponsorships from Soroban.
 
-The design used in the proposal avoids the potential issues that using the archived state in the classic flows could introduce. Only live Soroban state lookups are necessary during the signature validation and transaction execution, which is cheap because the state is in memory.
+This has a somewhat non-intuitive consequence of Soroban authorization being used to modify XLM balance of the account for the fee purposes, which hasn't been the case before. However, the behavior is consistent with the classic protocol itself, so in the end it's unlikely to cause significant confusion for the users.
+
+There is also no full feature parity with the classic protocol, as using the sponsorships is not possible in Soroban, and thus the specific account that entries are being added to has to hold XLM balance.
+
+These issues could be avoided by moving the new signers to a separate contract data entry that is subject to the State Archival. The sponsorships removals would still need to be performed on the Soroban side (unless we forfeit `remove_ed25519_signer` function). This approach allows anyone to pay fee for creating the new entries. However, the downside of the contract data approach as it requires much more Soroban semantics support in the 'classic' part of protocol vs the amount of the 'classic' support in Soroban proposed in this CAP. State archival would affect every operation that works with the account signers (including the transaction validation). Since it's not cheap to tell if an entry is archived, it is not possible to provide a clear error to the users in case if the entry is archived without introducing the DOS risks. The change scope is just generally larger and thus more risky, and wallets would have a harder time adapting to the extended account structure.
 
 ### CAP-71 dependency
 

--- a/core/cap-0072.md
+++ b/core/cap-0072.md
@@ -37,7 +37,7 @@ This CAP is aligned with the following Stellar Network Goals:
 
 This CAP introduces a new kind of G-account signers, called 'delegated signers', that are usable only from within the smart contract environment, i.e. these signers can not be used to sign the transactions directly, but can be used to sign for `SorobanAuthorizationEntry`. Delegated signers are stored in the `AccountEntry` in the same fashion as any other G-account signer and they also can be managed via `SetOptionsOp`.
 
-Delegated signers have a signature weight, similarly to the existing ed25519 account signers. However, instead of performing the cryptographic verification, `delegate_account_auth` (introduced in [CAP-71](./cap-0071.md)) host function will be called for the delegated signer's address in order to perform authentication. Thus, if the delegated signer is a contract, then `__check_auth` will be called for it, which allows for the G-account authentication logic customization.
+Delegated signers have a signature weight, similarly to the existing ed25519 account signers. However, instead of performing the cryptographic verification, `delegate_account_auth` (introduced in [CAP-71](./cap-0071.md)) host function will be called for the delegated signer's address in order to perform authentication. Thus, if the delegated signer is a contract, then `__check_auth` will be called for it, which allows for the G-account authentication logic customization. In case if delegated signer is a G-account itself, the `__check_auth` implementation for G-accounts built into Soroban host will be called.
 
 Since delegated signers can only be used for authentication in the smart contract environment, in order to fulfill the requirement for being able to use customizable authentication for managing the account, every G-account is treated as a built-in smart contract with an interface that provides all the account management capabilities necessary for the recovery flows. Unlike the Stellar Asset contract, every account on chain will be implicitly instantiated as a contract, i.e. its address will just become callable without any additional actions required from the users.
 
@@ -51,10 +51,21 @@ This patch of XDR changes is based on the XDR files in commit `4b7a2ef7931ab2ca2
 
 ```diff mddiffcheck.ignore=true
 diff --git a/Stellar-transaction.x b/Stellar-transaction.x
-index 9a14d6e..0d89002 100644
+index 9a14d6e..0735db7 100644
 --- a/Stellar-transaction.x
 +++ b/Stellar-transaction.x
-@@ -1999,7 +1999,10 @@ enum TransactionResultCode
+@@ -1378,7 +1378,9 @@ enum SetOptionsResultCode
+     SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+     SET_OPTIONS_INVALID_HOME_DOMAIN = -9,    // malformed home domain
+     SET_OPTIONS_AUTH_REVOCABLE_REQUIRED =
+-        -10 // auth revocable is required for clawback
++        -10, // auth revocable is required for clawback
++    // A signer with unsupported type was specified.
++    SET_OPTIONS_SIGNER_TYPE_NOT_SUPPORTED = -11
+ };
+ 
+ union SetOptionsResult switch (SetOptionsResultCode code)
+@@ -1999,7 +2001,10 @@ enum TransactionResultCode
      txBAD_SPONSORSHIP = -14,        // sponsorship not confirmed
      txBAD_MIN_SEQ_AGE_OR_GAP = -15, // minSeqAge or minSeqLedgerGap conditions not met
      txMALFORMED = -16,              // precondition is invalid
@@ -144,7 +155,7 @@ pub trait StellarAccountInterface {
 ```
 ### Classic transaction semantics
 
-A new type of G-account signer `SIGNER_KEY_TYPE_SC_DELEGATED` is added. It is supported in most of the contexts where the `Signer` struct is used, such as the `SetOptionsOp`, which thus allows adding/removing/updating the delegated signers.
+A new type of G-account signer `SIGNER_KEY_TYPE_SC_DELEGATED` is added. It is supported in most of the contexts where the `Signer` struct is used, such as the `SetOptionsOp`, which thus allows adding/removing/updating the delegated signers. Only delegated signers with types convertible to the Soroban `Address` are supported, i.e. those with types `SC_ADDRESS_TYPE_ACCOUNT` and `SC_ADDRESS_TYPE_CONTRACT`. Otherwise, the operation will fail with `SET_OPTIONS_SIGNER_TYPE_NOT_SUPPORTED` error.
 
 The only context where `SIGNER_KEY_TYPE_SC_DELEGATED` is explicitly not supported is the `extraSigners` transaction precondition, which allows users specifying the `SignerKey` that must sign a transaction. If `SignerKey` is of type `SIGNER_KEY_TYPE_SC_DELEGATED`, then the transaction will be considered not valid with the `txACCOUNT_DELEGATED_SIGNER_NOT_SUPPORTED` error.
 
@@ -156,7 +167,7 @@ Delegated signers are ignored during the transaction signature verification and 
 
 The algorithm for verifying detached (non-`SOURCE_ACCOUNT`) smart contract authorization payload in Soroban host is updated to enable delegated account support. The authentication is updated in the following way:
 
-- `get_delegated_signers` host function (defined in CAP-71) is used to retrieve all the delegated signers corresponding to the authentication
+- `get_delegated_signers_for_current_auth_check` host function (defined in CAP-71) is used to retrieve all the delegated signers corresponding to the authentication
 - If the total number of signatures and delegated signers is `0` or exceeds `MAX_ACCOUNT_SIGNATURES` (20), fail
 - If the delegated signers are not sorted in the ascending order, or contain duplicates, fail
 - If any delegated signer is not stored in the `AccountEntry`, fail


### PR DESCRIPTION
After describing the contract data-based approach in the first iteration, it became pretty apparent that this approach is more complex than I've originally anticipated, and just extending the `Signer` seems like a much easier way to go (as proven by the -100 lines of diffs in this PR). Also, if we want to do trustline management from Soroban, we'd need to do pretty much the same thing anyways.