### PR TITLE
SEP-56: Update event representation

### DIFF
--- a/ecosystem/sep-0056.md
+++ b/ecosystem/sep-0056.md
@@ -7,8 +7,8 @@ Author: OpenZeppelin, Boyan Barakov <@brozorec>, Özgün Özerk <@ozgunozerk>, S
 Track: Standard
 Status: Draft
 Created: 2025-11-04
-Updated: 2025-11-04
-Version: 0.1.0
+Updated: 2025-11-06
+Version: 0.1.1
 Discussion: https://github.com/orgs/stellar/discussions/1787
 ```
 
@@ -274,37 +274,50 @@ pub trait TokenizedVault: TokenInterface {
 The deposit event is emitted when underlying assets are deposited into the
 vault in exchange for shares.
 
-#### Topics:
-
-- `operator: Address` - The address that initiated the deposit transaction
-- `from: Address` - The address that provides the underlying assets
-- `receiver: Address` - The address that receives the vault shares being minted
-
-#### Data:
-
-- `assets: i128` - The amount of underlying assets being deposited into the
-  vault
-- `shares: i128` - The amount of vault shares being minted in exchange for the
-  assets
+```rust
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Deposit {
+    /// The address that initiated the deposit transaction
+    #[topic]
+    pub operator: Address,
+    /// The address that provides the underlying assets
+    #[topic]
+    pub from: Address,
+    /// The address that receives the vault shares being minted
+    #[topic]
+    pub receiver: Address,
+    /// The amount of underlying assets being deposited into the vault
+    pub assets: i128,
+    /// The amount of vault shares being minted in exchange for the assets
+    pub shares: i128,
+}
+```
 
 ### Withdraw Event
 
 The withdraw event is emitted when shares are exchanged back for underlying
 assets and assets are withdrawn from the vault.
 
-#### Topics:
-
-- `operator: Address` - The address that initiated the withdrawal transaction
-- `receiver: Address` - The address that receives the underlying assets being
-  withdrawn
-- `owner: Address` - The address that owns the vault shares being burned
-
-#### Data:
-
-- `assets: i128` - The amount of underlying assets being withdrawn from the
-  vault
-- `shares: i128` - The amount of vault shares being burned in exchange for the
-  assets
+```rust
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Withdraw {
+    /// The address that initiated the withdrawal transaction
+    #[topic]
+    pub operator: Address,
+    /// The address that receives the underlying assets being withdrawn
+    #[topic]
+    pub receiver: Address,
+    /// The address that owns the vault shares being burned
+    #[topic]
+    pub owner: Address,
+    /// The amount of underlying assets being withdrawn from the vault
+    pub assets: i128,
+    /// The amount of vault shares being burned in exchange for the assets
+    pub shares: i128,
+}
+```
 
 ## Design Rationale
 
@@ -462,3 +475,4 @@ https://github.com/OpenZeppelin/stellar-contracts/blob/main/packages/tokens/src/
 ## Changelog
 
 - `v0.1.0` - Initial draft
+- `v0.1.1` - Updated events representation with `#[contractevent]`


### PR DESCRIPTION
Consolidated event descriptions into the `#[contractevent]` format inline code.

@leighmcculloch, let me know if you also want to get rid of `[` and `]` in the trait comments, but we have them in other SEPs, and throughout our library as well. Nevertheless, we are open for this change if you think it still creates confusion even with the `#[contractevent]` notation down below 👍 