### PR TITLE
SEP-56: Remove textual event representation

### DIFF
--- a/ecosystem/sep-0056.md
+++ b/ecosystem/sep-0056.md
@@ -146,7 +146,7 @@ pub trait TokenizedVault: TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits `[Deposit]` event.
+    /// Emits [`Deposit`] event.
     fn deposit(e: &Env, assets: i128, receiver: Address, from: Address, operator: Address) -> i128;
 
     /// Returns the maximum amount of vault shares that can be minted
@@ -181,7 +181,7 @@ pub trait TokenizedVault: TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits `[`Deposit]` event.
+    /// Emits [`Deposit`] event.
     fn mint(e: &Env, shares: i128, receiver: Address, from: Address, operator: Address) -> i128;
 
     /// Returns the maximum amount of underlying assets that can be
@@ -216,7 +216,7 @@ pub trait TokenizedVault: TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits `[Withdraw]` event.
+    /// Emits [`Withdraw`] event.
     fn withdraw(
         e: &Env,
         assets: i128,
@@ -256,7 +256,7 @@ pub trait TokenizedVault: TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits `[Withdraw]` event.
+    /// Emits [`Withdraw`] event.
     fn redeem(e: &Env, shares: i128, receiver: Address, owner: Address, operator: Address) -> i128;
 }
 ```


### PR DESCRIPTION
also removes the `#[derive]` from the macros