### PR TITLE
SEP-54: Make metadata optional for non-supporting stores

### DIFF
--- a/ecosystem/sep-0054.md
+++ b/ecosystem/sep-0054.md
@@ -6,8 +6,8 @@ Title: Ledger Metadata Storage
 Author: Tamir Sen <@tamirms>
 Status: Draft
 Created: 2025-03-11
-Updated: 2025-03-11
-Version: 0.1.0
+Updated: 2026-01-07
+Version: 0.2.0
 Discussion: https://github.com/orgs/stellar/discussions/1678
 ```
 
@@ -217,7 +217,9 @@ with it:
   insert the `LedgerCloseMetaBatch` value in the data store.
 
 These metadata key-value pairs can be implemented as user-defined object
-metadata in GCS or S3.
+metadata in GCS or S3. Metadata is optional for data store implementations that
+do not support user-defined object metadata, such as file systems and other
+non-S3, non-GCS data stores.
 
 ## Design Rationale
 
@@ -246,4 +248,5 @@ been altered.
 
 ## Changelog
 
+- `v0.2.0`: Make metadata optional for data stores that don't support it.
 - `v0.1.0`: Initial draft


### PR DESCRIPTION
### What

Make metadata optional for data store implementations that do not support user-defined object metadata, such as file systems and other non-S3, non-GCS data stores.

### Why

The current specification states metadata can be stored as user-defined object metadata in GCS or S3, but this approach doesn't work for local filesystem storage, simple HTTP file servers, or other key-value stores without native metadata capabilities. Filesystem-based data stores are useful for testing and development. Rather than requiring a sidecar metadata file approach, this change treats metadata as optional for stores that lack explicit support.

See https://github.com/orgs/stellar/discussions/1678#discussioncomment-15425157