### PR TITLE
Add disk read entries per tx increase for SLP-4.

### DIFF
--- a/limits/slp-0004.md
+++ b/limits/slp-0004.md
@@ -24,6 +24,7 @@ The summary of the proposed changes is as follows:
 
 | Resource                  | Current Per-tx | Proposed Per-tx | Current Ledger | Proposed Ledger | New Ledger/Tx Ratio |
 |---------------------------|----------------|-----------------|----------------|-----------------|---------------------|
+| Disk Read Entries         | 100            | 200             | 1000           | 1000            | 5                   |
 | Disk Read Bytes           | 200000         | 200000          | 7000000        | 400000          | 2                   |
 | Write Entries             | 50             | 200             | 500            | 1000            | 5                   |
 | Write Bytes               | 132096         | 132096          | 143360         | 286720          | 2.17                |


### PR DESCRIPTION
Not including that was an oversight, given that we're already increasing the footprint size and write entries to 200 entries.