### PR TITLE
[CAP-73] Rename `allow_trust` to `trust`

### DIFF
--- a/core/cap-0073.md
+++ b/core/cap-0073.md
@@ -38,7 +38,7 @@ This CAP is aligned with the following Stellar Network Goals:
 
 ## Abstract
 
-This CAP introduces a new Stellar Asset contract function `allow_trust` for creating trustlines. The `allow_trust` function creates an unlimited trustline for a G-account if it does not already exist. The trustline creation semantics are the same as for the existing `ChangeTrustOp`. Account authorization is required for actually creating the trustline, but not for calling `allow_trust`.
+This CAP introduces a new Stellar Asset contract function `trust` for creating trustlines. The `trust` function creates an unlimited trustline for a G-account if it does not already exist. The trustline creation semantics are the same as for the existing `ChangeTrustOp`. Account authorization is required for actually creating the trustline, but not for calling `trust`.
 
 This also updates the `transfer` and `transfer_from` functions specifically for the 'native' asset (i.e. for the XLM SAC). When an XLM transfer is coming to a G-address that doesn't have a corresponding account entry yet, the account will be created as long as the transfer amount covers the minimum allowed account balance.
 
@@ -59,16 +59,16 @@ The following new functions are added to the Stellar Asset contract:
 ///
 /// Panics only during trustline creation if the asset issuer does not exist, or
 /// when a new trustline can not be created.
-fn allow_trust(env: Env, address: Address);
+fn trust(env: Env, address: Address);
 ```
 
 ### Semantics
 
-#### `allow_trust` function
+#### `trust` function
 
-`allow_trust` SAC function is a simplified version of the existing `ChangeTrustOp` that can only be used to create new trustlines. There are only a few Soroban-specified adjustments:
+When `trust` SAC function creates a new trustline, it follows the semantics of `ChangeTrustOp` with the respective input arguments. There are only a few Soroban-specified adjustments:
 
-- The asset for which the trustline is managed is implied by the SAC instance for which `allow_trust` is called
+- The asset for which the trustline is managed is implied by the SAC instance for which `trust` is called
   - Thus, unlike for `ChangeTrustOp`, only the regular `Asset` trustlines can be created, as liquidity pool shares don't have a SAC associated with them
 - There is no fine control over the limits, a new trustline with limit `i64::MAX` is created if no trustline exists for a given address. Limit is not modified otherwise
 - Input `address` can be a C-address, but passing it is always a no-op
@@ -98,13 +98,13 @@ The newly created account will immediately become available to interact with, in
 
 This CAP introduces a way to create and remove the classic trustline entries from Soroban. Most of the design coincide with those for the G-account signer management in [CAP-72](./cap-0072.md#account-base-reserve-management-from-soroban). Signers could in theory be stored in a contract data entry and that would require a relatively small amount of changes. However, if Soroban created trustlines only as contract data entries, then almost every classic operation would need to be modified to account for these entries. Thus, that alternative is even less feasible than in the case of CAP-72.
 
-### `allow_trust` function vs automatic trustline creation
+### `trust` function vs automatic trustline creation
 
 Transfers to accounts without a trustline could initiate trustline creation in a similar fashion to the account entry creation in case of XLM SAC. However, that would likely result in confusing user experience: an additional signature from the transfer _receiver_ would be required (in order to approve the trustline creation). It's not generally expected for the transfer to expect the receiver signature, and that scenario would also happen very rarely in a general case, so there is a high chance for developers to miss it.
 
-`allow_trust` function allows contract developers to explicitly request trustline creation from the users. That requires a conscious effort to support the trustline creation behavior, which reduces the chance of the additional required signature payload to go unnoticed.
+`trust` function allows contract developers to explicitly request trustline creation from the users. That requires a conscious effort to support the trustline creation behavior, which reduces the chance of the additional required signature payload to go unnoticed.
 
-### `allow_trust` function granularity
+### `trust` function granularity
 
 Over the last year over 98% of the active trustlines had limit over 1e18 (effectively unlimited, 95+% of trustlines are also at int64 max), so unlimited trust is going to be sufficient most of the time. For the remaining small amount of cases, it is not likely that there is a good generalized approach to managing the exact trustline limit on the contract side, so it's not obvious that a more granular function would actually end up being useful.
 


### PR DESCRIPTION
Also clarify the wording around the semantics - the intent there is really to highlight the differences between the Soroban and Classic implementations.