### PR TITLE
SEP-0045: Add Build Attestation link

### DIFF
--- a/ecosystem/sep-0045.md
+++ b/ecosystem/sep-0045.md
@@ -613,6 +613,8 @@ the following networks:
     `3c8d0b8b347752e57abe0b50380401ca8f5793bc971b685fd072571bbf5d54cc`
   - Deployed code:
     https://github.com/stellar/sep45-reference/blob/3dcabc965f01512a631d2c0c6999786f5f6a01cd/contracts/web_auth/src/lib.rs
+  - Build Attestation:
+    https://github.com/stellar/sep45-reference/attestations/16654165
 
 ## Changelog
 


### PR DESCRIPTION
### What
Add Build Attestation link to SEP-45.

### Why
We may as well link directly to the attestation, it makes tracing and verifying that the info there is accurate a little easier as it doesn't require using the gh cli to look for it.