### PR TITLE
CAP-77 updates

### DIFF
--- a/core/cap-0077.md
+++ b/core/cap-0077.md
@@ -266,7 +266,7 @@ The list of the operations that explicitly specify the payment destination:
 
 #### Apply time validation
 
-Some operations don't contain the information necessary to identify the trustlines or accounts being modified. For these operations the frozen keys are handled at apply time. Note, that `unfrozenTxHashes` setting is ignored for the apply-time checks, i.e. the few operations validated at apply time can not be unfrozen.
+Some operations don't contain the information necessary to identify the trustlines or accounts being modified. For these operations the frozen keys are handled at apply time. Note, that `freezeBypassTxs` setting is ignored for the apply-time checks, i.e. the few operations validated at apply time can not be unfrozen.
 
 ##### Operations with opaque source/destination
 


### PR DESCRIPTION
- Fixes for the freezing semantics: clarify pool share trustline validation, add a missed operation (account merge)
- Add a mechanism for unfreezing specified transaction hashes to bypass the key freeze