### PR TITLE
[CAP-77] Exclude issuer trustlines from the frozen keys.

### DIFF
--- a/core/cap-0077.md
+++ b/core/cap-0077.md
@@ -321,7 +321,7 @@ The CAP aims at supporting freezing the minimum viable set of ledger key types i
 Soroban keys are a straightforward choice as they contain arbitrary data. Account and trustline entries are the only remaining entries that contain user value. Claimable balances and liquidity pools technically contain user value as well, but they might be frozen by a trustline proxy (e.g. a claimable balance can be frozen by freezing the trustlines of the claimers). It's also important to note that the data corruption or hack risk is much lower for the claimable balances and liquidity pools, as these are not interfacing with Soroban, are not actively developed, and can't be used standalone to transfer value.
 For the trustline keys we also exclude:
 - Pool share trustlines, as they are only used for liquidity pools and thus can be frozen by freezing the respective liquidity pool's asset trustlines.
-- Issuer trustlines, as these cannot exist as real ledger entries, but can introduce some unnecessary maintenance complexity in the apply paths. If token mint has to be prevented, then the issuer account can be frozen instead.
+- Issuer trustlines, as these cannot exist as real ledger entries, but can introduce some unnecessary maintenance complexity in the apply paths.
 
 ### DEX handling
 


### PR DESCRIPTION
Also add rationale on the supported key types.