### PR TITLE
SEP-41: Clarify allowance behavior

### DIFF
--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -178,8 +178,8 @@ address (`spender`) authorizing that spender to transfer or burn up to a
 specified `amount` of the holder's tokens, until a specified ledger number
 (`live_until_ledger`).
 
-Allowances follow the same rules as those of the Stellar Asset contract defined
-in [CAP-46-6]:
+Allowances follow the rules below. These rules match the behavior of the
+Stellar Asset Contract (see [CAP-46-6] for its interface definition):
 
 - Allowances are tracked independently for each `(from, spender)` pair. A
   single `from` may grant distinct allowances to any number of different

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,8 +6,8 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2025-08-28
-Version 0.4.1
+Updated: 2026-04-28
+Version 0.4.2
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
 
@@ -171,6 +171,46 @@ pub trait TokenInterface {
 }
 ```
 
+### Allowances
+
+An allowance is a permission granted by a token holder (`from`) to another
+address (`spender`) authorizing that spender to transfer or burn up to a
+specified `amount` of the holder's tokens, until a specified ledger number
+(`live_until_ledger`).
+
+Allowances follow the same rules as those of the Stellar Asset contract defined
+in [CAP-46-6]:
+
+- Allowances are tracked independently for each `(from, spender)` pair. A
+  single `from` may grant distinct allowances to any number of different
+  spenders, and changing one does not affect the others.
+- `approve` MUST be authorized by `from` (`from.require_auth()`).
+- `approve` overwrites any existing allowance for the `(from, spender)` pair,
+  replacing both the `amount` and the `live_until_ledger`. It does not add to
+  or subtract from the previous amount, and there is no separate increase or
+  decrease operation. Implementations MUST NOT require the existing allowance
+  to be reset to 0 before it can be changed to a new non-zero value.
+- `transfer_from` and `burn_from` consume the allowance of `spender` from
+  `from` by the amount transferred or burned. The allowance's
+  `live_until_ledger` is unchanged. If the current effective allowance is less
+  than the requested amount, the call MUST fail without consuming any of the
+  allowance or moving any tokens.
+- An allowance whose `live_until_ledger` is less than the current ledger number
+  is treated as a zero-amount allowance regardless of the amount recorded, and
+  cannot be consumed by `transfer_from` or `burn_from`. The value returned by
+  `allowance` reflects this: it returns the recorded `amount` if
+  `live_until_ledger` is greater than or equal to the current ledger number,
+  and 0 otherwise.
+- `live_until_ledger` MUST NOT be less than the current ledger number unless
+  `amount` is being set to 0. Setting `amount` to 0 always succeeds and
+  effectively revokes the allowance, regardless of the value of
+  `live_until_ledger`.
+- An allowance may exceed `from`'s current balance. The allowance itself does
+  not reserve or lock any tokens; it only limits how much `spender` may move on
+  `from`'s behalf. A `transfer_from` or `burn_from` will still fail if `from`'s
+  balance is insufficient at the time of the call, even when the allowance is
+  sufficient.
+
 ### Events
 
 #### Approve Event
@@ -283,6 +323,9 @@ and a clawback action that emits a clawback event must reduce total supply.
 - `v0.4.0` - Add muxed support to transfer, and mint.
 - `v0.4.1` - Clarify that clawback burns tokens reducing total supply and that
   no separate burn or transfer event is emitted alongside the clawback event.
+- `v0.4.2` - Document the allowance model, including how `approve`,
+  `transfer_from`, and `burn_from` interact with allowances, expiration
+  behavior, and that allowances are independent of holder balance.
 
 ## Implementations
 

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,7 +6,7 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2026-06-08
+Updated: 2026-07-31
 Version 0.5.0
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
@@ -51,7 +51,8 @@ indistinguishable.
 
 ```rust
 pub trait TokenInterface {
-    /// Returns the allowance for `spender` to transfer from `from`.
+    /// Returns the amount which `spender` is still allowed to withdraw from
+    /// `from`, or 0 if the allowance has expired.
     ///
     /// # Arguments
     ///
@@ -59,15 +60,28 @@ pub trait TokenInterface {
     /// - `spender` - The address spending the tokens held by `from`.
     fn allowance(env: Env, from: Address, spender: Address) -> i128;
 
-    /// Set the allowance by `amount` for `spender` to transfer/burn from
-    /// `from`.
+    /// Allows `spender` to withdraw from `from` multiple times, up to a total
+    /// of `amount`, until `live_until_ledger`. If this function is called again
+    /// it overwrites the current allowance with `amount` and
+    /// `live_until_ledger`.
+    ///
+    /// NOTE: An allowance is a spending limit, not a reservation. It does not
+    /// lock any of `from`'s balance and may exceed it.
+    ///
+    /// NOTE: Because calling this function again replaces the current allowance
+    /// rather than adding to it, `spender` may spend the current allowance
+    /// before the new allowance is set, and so spend more than intended.
+    /// Clients SHOULD set the allowance to 0 and confirm that none of the
+    /// current allowance was spent before setting a new amount. Contracts
+    /// SHOULD NOT require this.
     ///
     /// # Arguments
     ///
     /// - `from` - The address holding the balance of tokens to be drawn from.
     /// - `spender` - The address being authorized to spend the tokens held by
     /// `from`.
-    /// - `amount` - The tokens to be made available to `spender`.
+    /// - `amount` - The tokens to be made available to `spender`. Set to 0 to
+    /// revoke the allowance.
     /// - `live_until_ledger` - The ledger number where this allowance expires.
     /// Cannot be less than the current ledger number unless the amount is being
     /// set to 0.  An expired entry (where live_until_ledger < the current
@@ -106,8 +120,10 @@ pub trait TokenInterface {
     /// are separated in the event.
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
-    /// Transfer `amount` from `from` to `to`, consuming the allowance of
-    /// `spender`. Authorized by spender (`spender.require_auth()`).
+    /// Transfer `amount` from `from` to `to`, using `spender`'s allowance to
+    /// withdraw from `from`. Authorized by spender (`spender.require_auth()`).
+    /// Reduces the allowance by `amount` without changing when it expires.
+    /// Fails if the allowance or `from`'s balance is less than `amount`.
     ///
     /// # Arguments
     ///
@@ -140,7 +156,10 @@ pub trait TokenInterface {
     /// - data - `amount: i128` or `{ amount: i128 }`
     fn burn(env: Env, from: Address, amount: i128);
 
-    /// Burn `amount` from `from`, consuming the allowance of `spender`.
+    /// Burn `amount` from `from`, using `spender`'s allowance to withdraw from
+    /// `from`. Reduces the allowance by `amount` without changing when it
+    /// expires. Fails if the allowance or `from`'s balance is less than
+    /// `amount`.
     ///
     /// # Arguments
     ///

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,8 +6,8 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2026-07-31
-Version 0.5.0
+Updated: 2026-08-03
+Version 0.5.1
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
 
@@ -51,8 +51,8 @@ indistinguishable.
 
 ```rust
 pub trait TokenInterface {
-    /// Returns the amount which `spender` is still allowed to withdraw from
-    /// `from`, or 0 if the allowance has expired.
+    /// Returns the amount which `spender` is still allowed to transfer from
+    /// `from`.
     ///
     /// # Arguments
     ///
@@ -60,7 +60,9 @@ pub trait TokenInterface {
     /// - `spender` - The address spending the tokens held by `from`.
     fn allowance(env: Env, from: Address, spender: Address) -> i128;
 
-    /// Allows `spender` to withdraw from `from` multiple times, up to a total
+    /// Set the allowance of `spender` to `amount`.
+    ///
+    /// Allows `spender` to transfer from `from` multiple times, up to a total
     /// of `amount`, until `live_until_ledger`. If this function is called again
     /// it overwrites the current allowance with `amount` and
     /// `live_until_ledger`.
@@ -120,8 +122,9 @@ pub trait TokenInterface {
     /// are separated in the event.
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
 
-    /// Transfer `amount` from `from` to `to`, using `spender`'s allowance to
-    /// withdraw from `from`. Authorized by spender (`spender.require_auth()`).
+    /// Transfer `amount` from `from` to `to`, consuming the allowance of
+    /// `spender`. Authorized by spender (`spender.require_auth()`).
+    ///
     /// Reduces the allowance by `amount` without changing when it expires.
     /// Fails if the allowance or `from`'s balance is less than `amount`.
     ///
@@ -156,10 +159,10 @@ pub trait TokenInterface {
     /// - data - `amount: i128` or `{ amount: i128 }`
     fn burn(env: Env, from: Address, amount: i128);
 
-    /// Burn `amount` from `from`, using `spender`'s allowance to withdraw from
-    /// `from`. Reduces the allowance by `amount` without changing when it
-    /// expires. Fails if the allowance or `from`'s balance is less than
-    /// `amount`.
+    /// Burn `amount` from `from`, consuming the allowance of `spender`.
+    ///
+    /// Reduces the allowance by `amount` without changing when it expires.
+    /// Fails if the allowance or `from`'s balance is less than `amount`.
     ///
     /// # Arguments
     ///
@@ -328,6 +331,10 @@ and a clawback action that emits a clawback event must reduce total supply.
   no separate burn or transfer event is emitted alongside the clawback event.
 - `v0.5.0` - Document the single-value/vec and map data formats for all events,
   generalizing the form already used by `transfer` and `mint`.
+- `v0.5.1` - Clarify in the interface doc comments that `approve` overwrites
+  the current allowance rather than adding to it, that an allowance is a
+  spending limit and not a reservation of balance, and that `transfer_from` and
+  `burn_from` reduce the allowance and fail if it or the balance is short.
 
 ## Implementations
 

--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -1021,8 +1021,8 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
-- `v2.0.1`: Update to `TransactionEnvelope` example to match latest
-  stellar-xdr definitions.
+- `v2.0.1`: Update to `TransactionEnvelope` example to match latest stellar-xdr
+  definitions.
 - `v2.0.0`: Change 64bit integer (Hyper and Unsigned Hyper) to map to JSON
   strings instead of JSON numbers. Add string encoding of 128/256bit integer
   types. Matches Protocol v23 XDR-JSON.


### PR DESCRIPTION
## Summary

Documents how allowances behave in SEP-41 — most importantly, that approving a spender a second time replaces the previous allowance rather than adding to it.

The question that prompted this: _if I approve a spender for 40 XLM, then approve the same spender 50 XLM, is their total allowance 90 or 50?_ The answer is 50, but that is answerable today only from a security caution on developers.stellar.org — not from SEP-41, and not from CAP-46-6, which specifies the interface rather than these semantics. Discussion: stellar/stellar-protocol#1919.

The behavior is described in the doc comments of the functions it applies to, in the register [ERC-20](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-20.md) uses: what a caller can do, rather than what values change internally. Each function keeps a brief one-line summary for rustdoc, with the added detail in a following paragraph.

Wording only — no new normative requirements and no interface change — so this is a patch bump to `Version 0.5.1`.

## What's in this PR

One file, `ecosystem/sep-0041.md`:

- `allowance` — returns the amount `spender` is _still_ allowed to transfer from `from`.
- `approve` — permits repeated transfers up to `amount`, and a second call overwrites the first rather than adding to it.
- `approve` notes — an allowance is a spending limit, not a reservation of balance; and zeroing-then-checking before replacing one is a client responsibility, explicitly not a contract requirement.
- `transfer_from` / `burn_from` — reduce the allowance without changing when it expires, and fail if the allowance or the balance is short.
- Preamble and changelog — `Version 0.5.1`, `Updated: 2026-08-03`, with a matching changelog entry.

## Deliberately not specified

Review feedback was that the first version of this PR risked over-specifying by reaching into implementation details. These are left to implementations:

- **Storage layout** — allowances are not described as keyed per `(from, spender)` pair, and values are not described as recorded entries.
- **Auth requirements** — no `require_auth` requirement is added to `approve`.
- **Failure atomicity** — that a failed call moves nothing follows from the host, and is not restated as a token-level rule.
- **Allowance events** — no event is emitted when an allowance is consumed. Mandating one would be an interface change rather than a clarification, so it is raised separately on #1919.
- **Expiry, in `allowance`'s return description** — the `live_until_ledger` argument doc already states that an expired entry is treated as a 0 amount allowance. Restating it on the return value adds nothing, and enumerating every case that returns 0 (never set, revoked, reset) would be noise.

## Test plan

- [x] `yarn sep-check` clean
- [x] `ecosystem/sep-0041.md` is the only file touched, rebased on current `master`
- [x] Each question raised in #1919 is answerable from the interface block alone: 40-then-50 → 50; does `transfer_from` decrement → yes; allowance vs. balance → a limit, not a reservation
- [ ] CI green
