### PR TITLE
Add details on PREPARE message validation to CAP-0083

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -114,7 +114,7 @@
 | [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Accepted |
 | [CAP-0071](cap-0071.md) | Authentication delegation for custom accounts | Dmytro Kozhevin | Draft |
 | [CAP-0072](cap-0072.md) | Contract signers for Stellar accounts | Dmytro Kozhevin | Draft |
-| [CAP-0083](cap-0083.md) | Add `StellarValue` type representing a skipped ledger | Brett Boston | Draft |
+| [CAP-0083](cap-0083.md) | Allow validators to vote to skip the current ledger | Brett Boston | Draft |
 
 ### Rejected Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0083.md
+++ b/core/cap-0083.md
@@ -2,21 +2,22 @@
 
 ```
 CAP: 0083
-Title: Add StellarValue type representing a skipped ledger
+Title: Allow validators to vote to skip the current ledger
 Working Group:
     Owner: Brett Boston <@bboston7>
     Authors: Brett Boston <@bboston7>
     Consulted: Nicolas Barry <@MonsieurNicolas>, Giuliano Losa <@nano-o>, Marta Lokhova <@marta-lokhova>
 Status: Draft
 Created: 2026-03-31
-Discussion: https://github.com/orgs/stellar/discussions/1865
+Discussion: https://github.com/orgs/stellar/discussions/1865 and https://github.com/orgs/stellar/discussions/1907
 Protocol version: TBD
 ```
 
 ## Simple Summary
 
 This CAP introduces a new `StellarValue` type to allow validators to explicitly
-skip the ledger that is being voted on.
+skip the ledger that is being voted on. It also relaxes validation criteria on
+PREPARE messages.
 
 ## Working Group
 
@@ -37,6 +38,10 @@ prevents consensus from getting stuck waiting for a transaction set that may
 never arrive, as a valid transaction set is required before moving on to the
 CONFIRM phase of balloting.
 
+Relaxing validity checks on PREPARE messages is necessary to enable early
+balloting without requiring that all network participants have the transaction
+set being voted on.
+
 ### Goals Alignment
 
 This CAP is aligned with the following Stellar Network Goal:
@@ -50,6 +55,11 @@ With this change, validators may switch their ballot to a `STELLAR_VALUE_SKIP`
 during the PREPARE phase of balloting prior to setting `c`[^1].
 `STELLAR_VALUE_SKIP` includes information about the value that a validator was
 considering before switching to voting to skip the ledger.
+
+This CAP also relaxes the validation of PREPARE messages to permit invalid
+transaction sets. This change ensures the network does not drop ballots from
+honest network participants that may unknowingly vote for invalid values in
+early balloting stages.
 
 ## Specification
 
@@ -131,7 +141,7 @@ struct StellarValue
 #### XDR Example
 TBD
 
-### Semantics
+### Skip Value Semantics
 
 #### Skip Value Representation
 
@@ -153,6 +163,16 @@ At apply time, ledgers containing a skip value should be treated as ledgers with
 empty transaction sets. In every other way, they should be treated as normal
 `STELLAR_VALUE_SIGNED` ledgers.
 
+### PREPARE Message Validation
+
+Validators must not drop incoming PREPARE messages on the basis of an invalid or
+missing transaction set. This ensures that the network can make progress when a
+transaction set is determined to be invalid during the PREPARE phase of
+balloting.
+
+Validators must continue to drop any CONFIRM or EXTERNALIZE messages containing
+ballots for `STELLAR_VALUE_SIGNED` values with invalid transaction sets.
+
 ## Design Rationale
 
 We considered a few alternative methods to achieve parallel downloading of transaction sets before landing on this protocol change:
@@ -164,6 +184,7 @@ We considered a few alternative methods to achieve parallel downloading of trans
 
 `STELLAR_VALUE_SKIP` values will become valid on the network at the protocol boundary. However, validators will not generate them unless they have enabled parallel transaction set downloading.  Parallel transaction set downloading will initially be disabled by default, and we would like to gradually enable it across the validator network.
 
+Validation of PREPARE messages will be relaxed at the protocol boundary.
 
 ### Downstream Impact
 
@@ -206,6 +227,6 @@ This CAP introduces a new method by which malicious validators could negatively 
 TBD
 
 ## Implementation
-TBD
+Draft implementation: https://github.com/stellar/stellar-core/pull/5209
 
 [^1]: See the [SCP IETF draft](https://www.ietf.org/archive/id/draft-mazieres-dinrg-scp-05.txt) for a complete semantics of `c`


### PR DESCRIPTION
This change adds important information about how to treat PREPARE messages that may contain invalid values. It also renames the CAP to be less specific to `STELLAR_VALUE_SKIP` and adds a link to the draft PR containing the implementation of this change.