### PR TITLE
SEP-51: Fix formatting

### DIFF
--- a/ecosystem/sep-0051.md
+++ b/ecosystem/sep-0051.md
@@ -1021,8 +1021,8 @@ Two types of breaking changes can occur in relation to XDR-JSON:
 
 ## Changelog
 
-- `v2.0.1`: Update to `TransactionEnvelope` example to match latest
-  stellar-xdr definitions.
+- `v2.0.1`: Update to `TransactionEnvelope` example to match latest stellar-xdr
+  definitions.
 - `v2.0.0`: Change 64bit integer (Hyper and Unsigned Hyper) to map to JSON
   strings instead of JSON numbers. Add string encoding of 128/256bit integer
   types. Matches Protocol v23 XDR-JSON.


### PR DESCRIPTION
### What

Reflow a single bullet in the SEP-0051 changelog so ``Update to `TransactionEnvelope` example to match latest stellar-xdr definitions.`` conforms to prettier's 80-column print width.

### Why

The SEP prettier check has been failing on `ecosystem/sep-0051.md` since #1889 merged with a failing prettier check. The workflow only runs on `pull_request` events, so master is never re-checked — but every new PR that touches `ecosystem/*.md` now starts red (e.g. #1922). Fixing this unblocks future PRs.