### PR TITLE
SLP-0006: Freeze YieldBlox Exploit Stellar Accounts

### DIFF
--- a/limits/slp-0006.md
+++ b/limits/slp-0006.md
@@ -11,7 +11,7 @@ Created: 2026-05-07
 
 ## Summary
 
-This proposal freezes three account entries using the frozen ledger key mechanism defined in [CAP 77](../core/cap-0077.md). These accounts are currently blocked by validators at the overlay layer. This proposal moves the block to a validator voted protocol setting.
+This proposal freezes three account entries using the frozen ledger key mechanism defined in [CAP-0077](../core/cap-0077.md). These accounts are currently blocked by validators at the overlay layer. This proposal moves the block to a network configuration.
 
 ## Background
 
@@ -19,17 +19,17 @@ On February 22, 2026, an attacker manipulated the USTRY price feed used by the S
 
 The YieldBlox V2 pool was placed on ice after the incident, and response efforts were coordinated across the Stellar community. Tier 1 validators later quarantined attacker accounts at the overlay layer. The incident report states that this quarantine locked about 48M XLM.
 
-CAP 77 introduced protocol support for freezing ledger entries through network configuration. This proposal uses that existing mechanism for the account entries listed below.
+CAP-0077 introduced protocol support for freezing ledger entries through network configuration. This proposal uses that existing mechanism for the account entries listed below.
 
 ## Goals Alignment
 
-This proposal supports network safety and reliability by using a validator voted protocol setting for incident response. It replaces an overlay layer block with a protocol setting that is visible through network configuration.
+This proposal supports network safety and reliability by using a network configuration upgrade instead of the overlay layer to freeze exploit accounts.
 
-The proposal is limited to three account entries that are already subject to overlay layer blocking. It does not introduce new freeze semantics.
+The proposal is limited to three account entries that are already subject to overlay layer blocking.
 
 ## Proposed Settings
 
-This proposal applies a `CONFIG_SETTING_FROZEN_LEDGER_KEYS_DELTA` settings update as defined by CAP 77.
+This proposal applies a `CONFIG_SETTING_FROZEN_LEDGER_KEYS_DELTA` configuration upgrade as defined by CAP-0077.
 
 The `keysToFreeze` value contains the following account ledger keys.
 
@@ -72,12 +72,12 @@ Transactions:
 This account is included because it received a large payment from `GATD`.
 
 Transaction:
-* 500k XLM create account operation from `GATD` [a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf](https://stellar.expert/explorer/public/tx/a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf)
+* 500k XLM via a `CreateAccount` operation from `GATD` [a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf](https://stellar.expert/explorer/public/tx/a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf)
 
 ## Security and Operational Considerations
 
-CAP 77 allows account entries to be included in the frozen ledger key list. A transaction that accesses a frozen account entry is handled according to the validation and apply rules defined by CAP 77.
+CAP-0077 allows account entries to be included in the frozen ledger key list. A transaction that accesses a frozen account entry is handled according to the validation and apply rules defined by CAP-0077.
 
-The main operational risk is freezing an account entry that is not in scope for this incident response. Reviewers should verify that the account IDs are correct, that the encoded ledger keys correspond to the intended account entries, and that no additional ledger keys are included in the settings update.
+The main operational risk is freezing an account entry that is not in scope for this incident response. Reviewers should verify that the account IDs are correct, that the encoded ledger keys correspond to the intended account entries, and that no additional ledger keys are included in the network configuration upgrade.
 
-The change can be reversed by a later validator voted settings update that includes the account ledger keys in `keysToUnfreeze`. This proposal does not define any bypass transactions.
+The change can be reversed by a later network configuration upgrade that includes the account ledger keys in `keysToUnfreeze`. This proposal does not define any bypass transactions.

--- a/limits/slp-0006.md
+++ b/limits/slp-0006.md
@@ -54,9 +54,9 @@ The `keysToUnfreeze` value is empty. This proposal does not add any transaction 
 This account is identified as the account that conducted the USTRY oracle manipulation exploit.
 
 Transactions: 
-* The exploiters 61M XLM borrow against USTRY [3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657](https://stellar.expert/explorer/public/tx/3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657)
+* The exploiter borrowed about 61M XLM against USTRY [3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657](https://stellar.expert/explorer/public/tx/3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657)
 
-For additional information, please review the transaction log in the [Script3 incident report](https://x.com/script3official/status/2029289721114051073)
+For additional information, please review the transaction log in the [Script3 incident report](https://x.com/script3official/status/2029289721114051073).
 
 ### Freeze GATDQL767ZM2JQTBEG4BQ5WKOQNGAGWZDUN4GYT2UINPEU3RT2UAMVZH
 

--- a/limits/slp-0006.md
+++ b/limits/slp-0006.md
@@ -1,0 +1,83 @@
+## Preamble
+
+```
+SLP: 0006
+Title: Freeze YieldBlox Exploit Stellar Accounts
+Authors: Alex Mootz <@mootz12>
+Consulted:
+Status: Draft
+Created: 2026-05-07
+```
+
+## Summary
+
+This proposal freezes three account entries using the frozen ledger key mechanism defined in [CAP 77](../core/cap-0077.md). These accounts are currently blocked by validators at the overlay layer. This proposal moves the block to a validator voted protocol setting.
+
+## Background
+
+On February 22, 2026, an attacker manipulated the USTRY price feed used by the Stellar DEX Reflector oracle. The manipulated price was used against the YieldBlox V2 Blend pool. According to the [Script3 incident report](https://x.com/script3official/status/2029289721114051073), the attacker borrowed about 61.3M XLM and 1.01M USDC against inflated USTRY collateral.
+
+The YieldBlox V2 pool was placed on ice after the incident, and response efforts were coordinated across the Stellar community. Tier 1 validators later quarantined attacker accounts at the overlay layer. The incident report states that this quarantine locked about 48M XLM.
+
+CAP 77 introduced protocol support for freezing ledger entries through network configuration. This proposal uses that existing mechanism for the account entries listed below.
+
+## Goals Alignment
+
+This proposal supports network safety and reliability by using a validator voted protocol setting for incident response. It replaces an overlay layer block with a protocol setting that is visible through network configuration.
+
+The proposal is limited to three account entries that are already subject to overlay layer blocking. It does not introduce new freeze semantics.
+
+## Proposed Settings
+
+This proposal applies a `CONFIG_SETTING_FROZEN_LEDGER_KEYS_DELTA` settings update as defined by CAP 77.
+
+The `keysToFreeze` value contains the following account ledger keys.
+
+```
+LedgerKey ACCOUNT GBO7VUL2TOKPWFAWKATIW7K3QYA7WQ63VDY5CAE6AFUUX6BHZBOC2WXC
+LedgerKey ACCOUNT GATDQL767ZM2JQTBEG4BQ5WKOQNGAGWZDUN4GYT2UINPEU3RT2UAMVZH
+LedgerKey ACCOUNT GCJOPSQNJDUYMWVJ3U7LYWWHM4N7NPWNF3RTOHB76PA67NH6DLWODES4
+```
+
+The full base64 XDR encoded `ConfigSettingEntry` value is listed below.
+
+```
+AAAAEgAAAAMAAAAoAAAAAAAAAABd+tF6m5T7FBZQJot9W4YB+0PbqPHRAJ4BaUv4J8hcLQAAACgAAAAAAAAAACY4L/7+WaTCYSG4GHbKdBpgGtkdG8NieqIa8lNxnqgGAAAAKAAAAAAAAAAAkufKDUjphlqp3T68WsdnG/a+zS7jNxw/88HvtP4a7OEAAAAA
+```
+
+The `keysToUnfreeze` value is empty. This proposal does not add any transaction hashes to `freezeBypassTxs`.
+
+## Settings Change Rationale
+
+### Freeze GBO7VUL2TOKPWFAWKATIW7K3QYA7WQ63VDY5CAE6AFUUX6BHZBOC2WXC
+
+This account is identified as the account that conducted the USTRY oracle manipulation exploit.
+
+Transactions: 
+* The exploiters 61M XLM borrow against USTRY [3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657](https://stellar.expert/explorer/public/tx/3e81a3f7b6e17cc22d0a1f33e9dcf90e5664b125b9e61f108b8d2f082f2d4657)
+
+For additional information, please review the transaction log in the [Script3 incident report](https://x.com/script3official/status/2029289721114051073)
+
+### Freeze GATDQL767ZM2JQTBEG4BQ5WKOQNGAGWZDUN4GYT2UINPEU3RT2UAMVZH
+
+This account is included because it received large payments from the exploit account `GBO7`.
+
+Transactions:
+* 3m XLM payment from `GBO7` [3bebed0a423a2091396ac08591b46baa98cfa51c938c6ae04d38c54c6f361c1c](https://stellar.expert/explorer/public/tx/3bebed0a423a2091396ac08591b46baa98cfa51c938c6ae04d38c54c6f361c1c)
+* 5m XLM payment from `GBO7` [ddba30c7be45b713a9764e6a97ead96dd76d43747aeefe9ba2025eb65ff09c64](https://stellar.expert/explorer/public/tx/ddba30c7be45b713a9764e6a97ead96dd76d43747aeefe9ba2025eb65ff09c64)
+
+
+### Freeze GCJOPSQNJDUYMWVJ3U7LYWWHM4N7NPWNF3RTOHB76PA67NH6DLWODES4
+
+This account is included because it received a large payment from `GATD`.
+
+Transaction:
+* 500k XLM create account operation from `GATD` [a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf](https://stellar.expert/explorer/public/tx/a9c3a68d47975beab4d7e26da1bf9bb305fd3c7f1d2de68b2b03104edb6211bf)
+
+## Security and Operational Considerations
+
+CAP 77 allows account entries to be included in the frozen ledger key list. A transaction that accesses a frozen account entry is handled according to the validation and apply rules defined by CAP 77.
+
+The main operational risk is freezing an account entry that is not in scope for this incident response. Reviewers should verify that the account IDs are correct, that the encoded ledger keys correspond to the intended account entries, and that no additional ledger keys are included in the settings update.
+
+The change can be reversed by a later validator voted settings update that includes the account ledger keys in `keysToUnfreeze`. This proposal does not define any bypass transactions.


### PR DESCRIPTION
### What

Created a SLP to freeze the YieldBlox exploit accounts via CAP-77.

### Why

This uses protocol 26's addition of CAP-77 to enforce the account freeze at the protocol level.