### PR TITLE
Autonomous Prediction Market Oracle Interface: initial SEP draft

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -102,6 +102,7 @@ All SEPs have individuals fulfilling the following roles:
 | [SEP-0056](sep-0056.md) | Tokenized Vault Standard                                       | OpenZeppelin, Boyan Barakov, Özgün Özerk, Sentinel         | Draft                        |
 | [SEP-0057](sep-0057.md) | T-REX (Token for Regulated EXchanges)                          | OpenZeppelin, Boyan Barakov, Özgün Özerk, Dennis O'Connell | Draft                        |
 | [SEP-0058](sep-0058.md) | Contract Build Reproducibility for Verification                | Leigh McCulloch                                            | Draft                        |
+| [SEP-0059](sep-0059.md) | Autonomous Prediction Market Oracle Interface                  | Fermah Labs, Patricio Napoli                               | Draft                        |
 
 ### Abandoned Proposals
 

--- a/ecosystem/sep-0059.md
+++ b/ecosystem/sep-0059.md
@@ -1,0 +1,461 @@
+## Preamble
+
+```
+SEP:        0059
+Title:      Autonomous Prediction Market Oracle Interface
+Authors:    Fermah Labs, Patricio Napoli <patricio@fermah.xyz>
+Status:     Draft
+Created:    2026-05-10
+Updated:    2026-05-18
+Discussion: https://github.com/orgs/stellar/discussions/1936
+Version:    0.1.0
+```
+
+## Simple Summary
+
+A standard Soroban contract interface and event schema for prediction-market
+platforms whose markets resolve **autonomously** (by deterministic execution of
+rules committed at market creation) to publish those outcomes as oracles
+consumable by any Stellar contract.
+
+## Abstract
+
+This SEP defines a canonical contract interface, data model, and event schema
+for prediction-market platforms on Stellar to expose autonomously-resolved
+market outcomes as a generic oracle. A conforming market commits its resolution
+rules on-chain at creation time as a content hash. Resolution publishes both
+the outcome and a hash of the inputs the rules were executed against, allowing
+any third party to fetch the rules, fetch the inputs, re-execute, and verify
+the result. Conforming providers emit standardized events on creation and
+resolution and expose a uniform read API. Downstream consumers (lending
+protocols, insurance contracts, DAO governance, parametric DeFi, and off-chain
+applications) integrate against the standard rather than against any single
+provider.
+
+## Motivation
+
+Prediction markets produce verifiable, crowd-sourced signals about real-world
+events. Existing platforms (Polymarket, Augur, Omen) resolve these signals
+through human judgment: an optimistic resolver proposes an answer, token
+holders dispute and vote. That model works but introduces trust assumptions,
+latency (dispute windows of hours to days), and escalation risk that consuming
+protocols must reason about.
+
+A new class of prediction markets resolves autonomously. The market is created
+with a deterministic resolution rule (e.g. "did Bitcoin's 24h close on
+2026-06-01 at exchange X exceed $150,000"), the rule executes against committed
+input data at the deadline, and the outcome is final. There is no dispute
+because there is no judgment. Re-executing the rule with the same inputs always
+yields the same outcome.
+
+Autonomous resolution is the model Flashcast Social uses, and it suits the
+broader Stellar ecosystem because:
+
+- **Latency is bounded** by the data sources. Final outcomes arrive in seconds,
+  with no dispute window to wait on.
+- **Trust is verifiable.** Any consumer can independently re-execute the rule
+  against the committed inputs and confirm the published outcome.
+- **Resolution is cheap**, which makes high-frequency parametric markets
+  economically viable on Stellar's fee model.
+
+A standard interface for consuming these outcomes does not exist on Stellar
+today. Without one, every consumer must learn each provider's contract layout,
+encoding, and verification model. That per-provider integration cost has
+historically blocked oracle composability, and this SEP fills the gap.
+
+The intent mirrors [SEP-41]: standardize the read-side that consumers actually
+need, leave provider-internal concerns (positions, liquidity, payouts) out of
+scope, and let an ecosystem of competing implementations grow on top. The
+interface is designed to be complementary to [SEP-40] — a consumer can use a
+SEP-40 price feed for "what is the price of X" and a SEP-59 provider for "did
+event Y happen," and link the two via the optional `underlying: Asset`
+reference in the market spec.
+
+## Specification
+
+### Terminology
+
+- **Provider**: a contract that exposes one or more markets through this
+  interface.
+- **Market**: a single predictable event with a defined outcome space and
+  deterministic resolution rule.
+- **Resolver**: the address authorized to publish a market's outcome. The
+  resolver does not decide the outcome, it executes the rule and submits the
+  result.
+- **Consumer**: any contract or off-chain application reading outcomes via this
+  interface.
+
+### Data Model
+
+#### MarketId
+
+Each market is identified by a 32-byte content hash:
+
+```
+MarketId = sha256(canonical_spec_bytes)
+```
+
+`canonical_spec_bytes` is the deterministic XDR encoding of the `MarketSpec`.
+To guarantee that two honest providers compute the same `MarketId` for the same
+logical spec, conforming encoders MUST:
+
+- Encode fields in the order declared in this SEP.
+- Encode `Option::None` as XDR `void` (the standard `Option` encoding).
+- Use no Soroban `Map` types in the spec (`Map` ordering is non-deterministic
+  across SDK versions).
+- Encode strings as UTF-8 without normalization.
+
+Content addressing makes market identity intrinsic and tamper-evident.
+Consumers SHOULD verify `market_id == sha256(canonical_spec_bytes)` before
+trusting a returned `MarketSpec`.
+
+#### MarketSpec
+
+```rust
+struct MarketSpec {
+    question:            String,            // Human-readable question
+    outcome_type:        OutcomeType,
+    resolution_rules:    ResolutionRules,
+    resolution_deadline: u64,               // Unix seconds; resolution MAY be published at or after this time
+    resolver:            Address,           // Address authorized to publish the outcome
+    underlying:          Option<Asset>,     // Optional SEP-40 Asset this market references
+    metadata_uri:        Option<String>,    // IPFS/HTTPS URI for extended metadata
+}
+
+enum OutcomeType {
+    Binary,
+    Categorical { num_outcomes: u32 },
+    Scalar      { min: i128, max: i128, decimals: u32 },
+}
+
+struct ResolutionRules {
+    rules_format: Symbol,                   // e.g. FLASHCAST_TOON_V1
+    rules_hash:   BytesN<32>,               // Hash of the off-chain rules document
+    rules_uri:    Option<String>,           // Where to fetch the rules document
+}
+```
+
+`Asset` is the enum defined in [SEP-40]:
+
+```rust
+enum Asset {
+    Stellar(Address),
+    Other(Symbol),
+}
+```
+
+For `Outcome::Scalar`, `decimals` follows the SEP-40 convention: the
+human-readable value is `value / 10^decimals`, evaluated using safe integer
+arithmetic.
+
+`metadata_uri`, if present, SHOULD resolve to a JSON document. The schema is
+intentionally open, but conforming providers SHOULD use the following reserved
+top-level keys when applicable: `title` (String), `description` (String),
+`tags` (array of String), `image_uri` (String), `sources` (array of String URIs
+documenting the data the rule consults). Unknown keys MUST be tolerated by
+consumers.
+
+#### Outcome and Proof
+
+```rust
+enum Outcome {
+    Binary(bool),
+    Categorical(u32),
+    Scalar(i128),
+    Invalid,                                // Final outcome: resolution determined the question cannot be answered
+}
+
+struct ResolutionProof {
+    resolved_at:        u64,                // Unix seconds
+    attestation_method: Symbol,             // See "Attestation Methods" below
+    inputs_hash:        BytesN<32>,         // Hash of the inputs the rules were executed against
+    inputs_uri:         Option<String>,     // Where to fetch the inputs document
+    attestation_data:   Bytes,              // Method-specific extension payload
+}
+```
+
+The `inputs_hash` is the central primitive of autonomous resolution. Together
+with `rules_hash` from the market spec, it gives any third party everything
+required to independently re-execute and verify the published outcome.
+
+`Outcome::Invalid` is a _final_ resolution state, distinct from "not yet
+resolved" (which is signalled by `outcome()` returning `None`). It is
+appropriate when, for example, the source data the rule depends on became
+permanently unavailable, or when post-creation events rendered the question
+ambiguous. The `attestation_data` SHOULD carry a machine-readable reason code
+in this case.
+
+### Contract Interface
+
+Every conforming provider **MUST** implement:
+
+```rust
+pub trait PredictionMarketOracleTrait {
+    /// Returns the interface version supported by this provider. This SEP defines version 1.
+    fn pmo_version(env: Env) -> u32;
+
+    /// Returns the canonical specification of the market, or None if unknown.
+    fn market_spec(env: Env, market_id: BytesN<32>) -> Option<MarketSpec>;
+
+    /// Returns the resolved outcome and proof, or None if the market is unknown or unresolved.
+    ///
+    /// Once this method returns Some, subsequent calls MUST return the same value.
+    /// Resolutions are immutable. A provider that needs to amend an outcome MUST
+    /// resolve a new market with a distinct MarketId.
+    fn outcome(env: Env, market_id: BytesN<32>) -> Option<(Outcome, ResolutionProof)>;
+
+    /// Optional discovery: paginated enumeration of markets exposed by this provider.
+    ///
+    /// `cursor` is an opaque resumption token. Pass None to start from the beginning;
+    /// for subsequent pages, pass the last MarketId returned. Providers that delegate
+    /// discovery entirely to events MAY return an empty Vec.
+    fn markets(env: Env, cursor: Option<BytesN<32>>, limit: u32) -> Vec<BytesN<32>>;
+}
+```
+
+Providers MAY implement additional methods for positions, payouts, liquidity,
+or platform-specific concerns; this SEP standardizes the read-side oracle
+interface only.
+
+#### Authorization
+
+When publishing a resolution, the provider implementation MUST call
+`spec.resolver.require_auth()` before recording the outcome. The on-chain
+check, combined with `inputs_hash` commitment, is what gives the resolver field
+its meaning: a published outcome was actually authorized by the address
+committed at market creation.
+
+### Event Schema
+
+Conforming providers **MUST** emit:
+
+#### MarketCreated
+
+```
+topics: ("pm_created", market_id: BytesN<32>)
+data:   MarketSpec
+```
+
+#### MarketResolved
+
+```
+topics: ("pm_resolved", market_id: BytesN<32>)
+data:   (Outcome, ResolutionProof)
+```
+
+The `pm_` prefix on the verb topic lets a consumer subscribe to outcomes across
+every conforming provider with a single topic filter, without inventing a
+non-standard namespace topic. The full `MarketSpec` is carried in the
+`MarketCreated` event so that indexers can reconstruct provider state from
+event history without a contract call per market.
+
+### Attestation Methods
+
+The `attestation_method` symbol declares how the published outcome was
+produced. This SEP reserves:
+
+| Symbol                  | Meaning                                                                                                                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTONOMOUS_V1`         | Outcome produced by deterministic execution of `rules_hash` over `inputs_hash`. Verifiable by re-execution.                                                                                                                |
+| `RESOLVER_ASSERTION_V1` | Outcome asserted by the resolver's judgment rather than derived by deterministic execution. `attestation_data` carries the resolver's signed statement. Falls outside the verification guarantee `AUTONOMOUS_V1` provides. |
+| `ORACLE_AGG_V1`         | Outcome aggregated from multiple oracle sources. `attestation_data` carries the source list and aggregation method.                                                                                                        |
+
+`AUTONOMOUS_V1` is the model this SEP is primarily designed for. The other
+symbols are reserved so the standard remains usable by providers with different
+trust models without forcing them into a separate interface.
+
+Symbol values are constrained by Soroban's `Symbol` alphabet (`[a-zA-Z0-9_]`);
+the `_V<n>` suffix is the version discriminator. Symbols longer than 9
+characters MUST be constructed with `Symbol::new(env, ...)` rather than the
+`symbol_short!` macro.
+
+### Resolution Rules Format
+
+Resolution rules are stored off-chain and committed on-chain via `rules_hash`.
+The `rules_format` symbol identifies the schema and execution semantics.
+Providers register their own format symbols; this SEP does not mandate one.
+Format symbols SHOULD be versioned (e.g. `FLASHCAST_TOON_V1`).
+
+## Example Consumer
+
+A minimal Soroban consumer that releases an escrow when a market resolves YES,
+and verifies the resolution is autonomous before acting:
+
+```rust
+#[contracterror]
+pub enum Error {
+    Unconfigured    = 1,
+    NotResolved     = 2,
+    UntrustedMethod = 3,
+    ConditionNotMet = 4,
+}
+
+#[contractimpl]
+impl ConditionalEscrow {
+    pub fn claim(env: Env, market_id: BytesN<32>, beneficiary: Address) -> Result<(), Error> {
+        let provider: Address = env
+            .storage()
+            .instance()
+            .get(&PROVIDER_KEY)
+            .ok_or(Error::Unconfigured)?;
+
+        let oracle = PredictionMarketOracleTraitClient::new(&env, &provider);
+
+        let (outcome, proof) = oracle.outcome(&market_id).ok_or(Error::NotResolved)?;
+
+        // This consumer only trusts autonomously-resolved markets.
+        let autonomous = Symbol::new(&env, "AUTONOMOUS_V1");
+        if proof.attestation_method != autonomous {
+            return Err(Error::UntrustedMethod);
+        }
+
+        match outcome {
+            Outcome::Binary(true) => {
+                Self::release_to(&env, &beneficiary);
+                Ok(())
+            }
+            _ => Err(Error::ConditionNotMet),
+        }
+    }
+}
+```
+
+The consumer needs no knowledge of the provider's betting, liquidity, or payout
+mechanics. It needs only the standardized read interface and the attestation
+method it chooses to trust.
+
+## Design Rationale
+
+**Why autonomous resolution as the primary model?** Stellar's value proposition
+is fast, cheap, deterministic settlement. A dispute-based oracle that holds
+resolution open for 24-72 hours waiting for token-holder votes throws away that
+value. Autonomous resolution matches the chain's strengths and unlocks
+parametric markets that are uneconomical elsewhere.
+
+**Why content-addressed MarketIds?** Identity is intrinsic and tamper-evident.
+Multiple providers can independently reference the same market without
+coordination; a consumer can verify that the spec it fetched matches the ID it
+was given.
+
+**Why commit `inputs_hash` in the resolution proof?** This is the verification
+primitive. With it, anyone can fetch the rules (by `rules_hash`) and the inputs
+(by `inputs_hash`), re-execute, and detect a dishonest resolver publicly. The
+on-chain footprint is two 32-byte hashes; the verification work happens
+off-chain at no on-chain cost.
+
+**Why off-chain rules with an on-chain hash?** Rules vary from short TOON
+snippets to multi-step pipelines that consult external data. Forcing them
+on-chain would either bloat storage or constrain expressiveness. A hash makes
+tampering detectable while keeping the on-chain footprint constant.
+
+**Why `Option<MarketSpec>` and `Option<(Outcome, ResolutionProof)>` rather than
+panics?** This matches the convention SEP-40 establishes for oracle reads:
+unknown inputs return `None`, the consumer decides how to handle absence. It
+keeps cross-contract calls cheap (no panic-and-rollback path) and lets
+consumers compose multiple oracle reads in one transaction without each unknown
+asset aborting the whole call.
+
+**Why split read from write?** Most consumers only need to read outcomes.
+Forcing them to understand a provider's market-creation, betting, or settlement
+logic creates the friction that has historically blocked oracle adoption.
+
+**Why no dispute interface?** Disputes are a property of human-judgment
+resolution models; they fall out of scope for an autonomous-resolution
+standard. A future SEP can extend this one with a dispute interface for
+providers that need it, without changing what consumers of autonomous markets
+see today.
+
+**Why expose `underlying: Option<Asset>`?** Many autonomous markets are scalar
+predictions about an asset already covered by a SEP-40 feed (e.g. "BTC closing
+price at T"). Carrying the SEP-40 `Asset` in the spec is the cheapest possible
+composability hook: a consumer wanting to compare a market's resolved scalar to
+the live SEP-40 price now has the asset identifier it needs without out-of-band
+metadata.
+
+**Why `Outcome::Invalid` as a fourth variant?** Real markets occasionally
+cannot be answered: a data source disappears, an exchange delists the asset,
+the question becomes ambiguous due to a real-world event. Conflating this with
+`None` (unresolved) would force consumers to wait forever for a market that
+will never resolve. Making `Invalid` a first-class final outcome lets consumers
+release escrow paths, refund positions, or fall back cleanly.
+
+## Prior Art
+
+This SEP draws on the following bodies of prior work:
+
+- **[SEP-41] (Soroban Token Interface)**: sets the precedent for what a Stellar
+  interface SEP looks like — standardize the read-side that consumers actually
+  need, leave issuer-internal concerns out, and rely on event topics for
+  cross-provider subscription. This SEP follows that template.
+- **[SEP-40] (Oracle Consumer Interface)**: the established Stellar oracle
+  contract convention, in production via Reflector Network. SEP-59 borrows
+  SEP-40's `Asset` type for the optional `underlying` reference, the
+  `Option<T>`-on-unknown read convention, and the `value / 10^decimals`
+  encoding for scalar values. SEP-40 answers "what is the price of X"; SEP-59
+  answers "did event Y happen." A consumer can reference both in the same
+  transaction.
+- **Gnosis Conditional Tokens Framework**: the canonical content-addressed
+  market identity design, in production via Polymarket. We borrow the
+  content-hash identity pattern. We deliberately do not standardize position
+  tokens; CTF already does that well, and consumers of outcomes do not need
+  them.
+- **UMA Optimistic Oracle and Reality.eth**: the dominant human-judgment
+  resolution models. We deliberately do not adopt their dispute mechanics,
+  because they are incompatible with the autonomous-resolution model this SEP
+  standardizes. The `RESOLVER_ASSERTION_V1` attestation symbol is reserved so
+  providers using these models can still expose their outcomes through this
+  interface, though such outcomes fall outside the verification guarantee
+  `AUTONOMOUS_V1` provides.
+
+The contribution of this SEP lies in the combination of these elements applied
+to verifiable autonomous resolution on Soroban: a read-side-only,
+content-addressed interface that any consumer can integrate against and any
+third party can independently verify.
+
+## Security Concerns
+
+- **Resolver honesty under `AUTONOMOUS_V1`.** The resolver could publish an
+  outcome that does not match deterministic execution of the committed rules
+  over the committed inputs. Detection is straightforward (any third party can
+  re-execute), but enforcement is social or reputational unless the provider
+  implements on-chain slashing. Consumers SHOULD weight a provider's history of
+  honest resolutions over time when deciding how much trust to place in any
+  single outcome.
+- **Resolution timestamp staleness.** Consumers whose application is
+  time-sensitive SHOULD compare `proof.resolved_at` against
+  `spec.resolution_deadline` and reject resolutions that arrived implausibly
+  late. This is the autonomous-resolution analogue of SEP-40's staleness check
+  against `resolution()` ticks.
+- **Input availability.** If `inputs_uri` is unreachable, verifiability is
+  degraded even though the on-chain `inputs_hash` is intact. Providers SHOULD
+  pin inputs to content-addressed storage (IPFS, Arweave), and consumers SHOULD
+  verify availability before integrating against a market.
+- **Rule availability.** Same concern applies for `rules_uri`. Rules are
+  typically much smaller than inputs and SHOULD be pinned identically.
+- **Spec tampering.** Consumers SHOULD verify
+  `market_id == sha256(canonical_spec_bytes)` before trusting a returned
+  `MarketSpec`. The XDR canonicalization rules in the Data Model section MUST
+  be followed; otherwise honest providers will compute mismatched IDs.
+- **Resolver key compromise.** Providers SHOULD use multisig or
+  governance-controlled resolver addresses for high-value markets.
+- **Mixed attestation methods.** A provider may resolve some markets
+  autonomously and others by assertion. Consumers MUST check
+  `attestation_method` per resolution and apply trust assumptions accordingly.
+- **Outcome immutability.** Consumers MAY cache the first `Some` value returned
+  by `outcome()`; providers MUST NOT change a previously-published outcome. A
+  provider that violates this is broken; consumers SHOULD treat divergence as
+  evidence of compromise.
+
+## Changelog
+
+- `v0.1.0` - Initial draft.
+
+## Implementations
+
+A reference Soroban implementation will be published at:
+`github.com/fermah-labs/sep-prediction-market-oracle`
+
+The first conforming provider is Flashcast Social (`flashcast.social`).
+
+[SEP-40]: sep-0040.md
+[SEP-41]: sep-0041.md


### PR DESCRIPTION
### What
Propose SEP Draft, defining a read-side Soroban contract interface and event schema for prediction-market platforms to expose **autonomously-resolved** market outcomes as a generic oracle.

A conforming market commits its resolution rules on-chain as a content hash at creation time. Resolution publishes the outcome together with a hash of the inputs the rules were executed against, so any third party can fetch both, re-execute, and verify the published outcome off-chain.

The standardized surface is intentionally small:

- **Trait `PredictionMarketOracleTrait`**: `pmo_version`, `market_spec`, `outcome`, and an optional paginated `markets` discovery method.
- **Data model**: content-addressed `MarketId = sha256(canonical_spec_bytes)`; `Binary` / `Categorical` / `Scalar` / `Invalid` outcomes; `ResolutionProof` carrying `inputs_hash`, `attestation_method`, and a method-specific `attestation_data` payload.
- **Events**: `("pm_created", market_id)` and `("pm_resolved", market_id)` carrying the spec and the resolution respectively, so indexers can reconstruct provider state from event history.
- **Attestation symbols**: `AUTONOMOUS_V1` (primary), `RESOLVER_ASSERTION_V1` and `ORACLE_AGG_V1` reserved so providers with different trust models can still expose outcomes through the same interface.

Provider-internal concerns (positions, liquidity, payouts, settlement) are explicitly out of scope. Disputes are out of scope by design, they belong to human-judgment resolution models and can be added by a future SEP without breaking consumers of autonomous markets.

### Why
Prediction markets produce verifiable, crowd-sourced signals (event outcomes, parametric resolutions) that downstream protocols want to consume, lending hooks, insurance triggers, DAO actions, parametric DeFi. On Stellar today there is no standard for reading those outcomes, so each consumer has to learn each provider's contract layout, encoding, and trust model individually. That per-provider integration cost is what has historically blocked oracle composability.

SEP-40 solves this for price feeds, this SEP fills the analogous gap for *event resolutions*. The two are intentionally complementary: a consumer can read "what is the price of X" from a SEP-40 feed and "did event Y happen" from a SEP-59 provider in the same transaction, and link them via the optional `underlying: Asset` field that reuses SEP-40's `Asset` enum verbatim.

The reference implementation will land at `github.com/fermah-labs/sep-prediction-market-oracle`, and the first conforming provider will be Flashcast Social, whose existing autonomous-resolution pipeline is the production motivation for this SEP.

Discussion: [Github](https://github.com/orgs/stellar/discussions/1936)