### PR TITLE
Add per-CAP exit criteria for release readiness

### DIFF
--- a/cap-template.md
+++ b/cap-template.md
@@ -140,4 +140,22 @@ completed before the CAP is accepted. While there is merit to the approach of re
 the specification and rationale before writing code, the principle of "rough consensus and running
 code" is still useful when it comes to resolving many discussions of API details.
 
+## Exit Criteria
+The verifiable conditions that must be met before this CAP moves to `Implemented` and can be
+included in a protocol release. Each item should be objectively verifiable (e.g. a test run,
+transaction hash, or contract execution) and demonstrate the feature working end-to-end, not only in
+unit tests. Here are some examples:
+
+- The feature has been exercised on [Futurenet] or via [Quickstart], with Horizon and RPC up and
+  reflecting the change.
+- For Soroban CAPs, a contract using the new functionality has been executed on Futurenet or
+  Quickstart.
+- Stellar Core `LedgerCloseMeta`s (captured via `--capture-lcm` from new tests relevant to this CAP)
+  pass through the Horizon ingestion test case.
+- The [Test Cases](#test-cases) are passing.
+
+Add any feature-specific criteria below.
+
 [stellar-core repository]: https://github.com/stellar/stellar-core
+[Futurenet]: https://developers.stellar.org/docs/networks
+[Quickstart]: https://github.com/stellar/quickstart

--- a/cap-template.md
+++ b/cap-template.md
@@ -151,7 +151,7 @@ unit tests. Here are some examples:
 - For Soroban CAPs, a contract using the new functionality has been executed on Futurenet or
   Quickstart.
 - Stellar Core `LedgerCloseMeta`s (captured via `--capture-lcm` from new tests relevant to this CAP)
-  pass through the Horizon ingestion test case.
+  pass Horizon ingestion test cases.
 - The [Test Cases](#test-cases) are passing.
 
 Add any feature-specific criteria below.

--- a/core/README.md
+++ b/core/README.md
@@ -315,10 +315,10 @@ it is possible that the proposal is rejected based on the issues that arise from
 implementation.
 
 Before the CAP can move to **Implemented**, its [exit criteria](../cap-template.md#exit-criteria)
-must be met and the evidence shared with the protocol group — for example, exercising the feature on
-Futurenet or via Quickstart (with Horizon and RPC up), and, for Soroban CAPs, executing a contract
-that uses it. Once the criteria are met and no issues arise, a CAP team member moves it to
-**Implemented**.
+must be met and the evidence shared in the Slack channel for the protocol release you're targeting
+— for example, exercising the feature on Futurenet or via Quickstart (with Horizon and RPC up), and,
+for Soroban CAPs, executing a contract that uses it. Once the criteria are met and no issues arise,
+a CAP team member moves it to **Implemented**.
 
 ### CAP Finalization
 

--- a/core/README.md
+++ b/core/README.md
@@ -315,10 +315,9 @@ it is possible that the proposal is rejected based on the issues that arise from
 implementation.
 
 Before the CAP can move to **Implemented**, its [exit criteria](../cap-template.md#exit-criteria)
-must be met and the evidence shared in the Slack channel for the protocol release you're targeting
-— for example, exercising the feature on Futurenet or via Quickstart (with Horizon and RPC up), and,
-for Soroban CAPs, executing a contract that uses it. Once the criteria are met and no issues arise,
-a CAP team member moves it to **Implemented**.
+must be met — for example, exercising the feature on Futurenet or via Quickstart (with Horizon and
+RPC up), and, for Soroban CAPs, executing a contract that uses it. Once the criteria are met and no
+issues arise, a CAP team member moves it to **Implemented**.
 
 ### CAP Finalization
 

--- a/core/README.md
+++ b/core/README.md
@@ -14,7 +14,8 @@
 - **Accepted** — A CAP that has been accepted on the merits of its idea pre-implementation, and is
   ready for implementation. It is still possible that the CAP may be rejected post-implementation
   due to the issues that may arise during an initial implementation.
-- **Implemented** - A CAP that has been implemented with the protocol version specified in the CAP. It will graduate to
+- **Implemented** - A CAP that has been implemented with the protocol version specified in the CAP,
+  and whose [exit criteria](../cap-template.md#exit-criteria) have been met. It will graduate to
   **Final** when it has been formally accepted by a majority of validators (nodes) on the network.
 - **Final** — A CAP that has been accepted by a majority of validators (nodes) on the network. A
   final CAP should only be updated to correct errata.
@@ -233,6 +234,8 @@ Finally, submit a PR of your draft via your fork of this repository.
 #### Additional Tips
 - Use `TBD` for the protocol version. Don't assign a protocol version to the CAP — this will be
   established once the CAP has reached the state of *Final* and has been formally implemented.
+- Define the CAP's [exit criteria](../cap-template.md#exit-criteria) up front — the verifiable
+  conditions, agreed with the working group, for when the feature is ready to be released.
 
 ### Draft: Merging & Further Iteration
 From there, the following process will happen.
@@ -306,7 +309,13 @@ Review**, along with the protocol version it was released in if applicable.
 
 From here the proposal is brought up again before the protocol group for additional comment, where
 it is possible that the proposal is rejected based on the issues that arise from its
-implementation. If no issues arise, it will move to **Implemented** by a CAP team member.
+implementation.
+
+Before the CAP can move to **Implemented**, its [exit criteria](../cap-template.md#exit-criteria)
+must be met and the evidence shared with the protocol group — for example, exercising the feature on
+Futurenet or via Quickstart (with Horizon and RPC up), and, for Soroban CAPs, executing a contract
+that uses it. Once the criteria are met and no issues arise, a CAP team member moves it to
+**Implemented**.
 
 ### CAP Finalization
 


### PR DESCRIPTION
## Summary
Adds a release-readiness gate to the CAP process by defining per-CAP **exit criteria** — the verifiable conditions that determine when a feature's implementation is complete and ready to ship in a protocol release. Today the process has no per-CAP definition of "done": the `Implemented → Final` transition only references validator adoption, with nothing that says the implementation actually works end-to-end before it's released.

Relates to https://github.com/stellar/pod-fsr/issues/3
