### PR TITLE
SEP-41: Add map event bodies

### DIFF
--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -75,12 +75,9 @@ pub trait TokenInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["approve", from: Address,
-    /// spender: Address], data = [amount: i128, live_until_ledger: u32]`
-    ///
     /// Emits an event with:
     /// - topics - `["approve", from: Address, spender: Address]`
-    /// - data - `[amount: i128, live_until_ledger: u32]`
+    /// - data - `[amount: i128, live_until_ledger: u32]` or `{ amount: i128, live_until_ledger: u32 }`
     fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
@@ -125,7 +122,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// - topics - `["transfer", from: Address, to: Address]`
-    /// - data - `amount: i128`
+    /// - data - `amount: i128` or `{ amount: i128 }`
     fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128);
 
     /// Burn `amount` from `from`.
@@ -140,7 +137,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// - topics - `["burn", from: Address]`
-    /// - data - `amount: i128`
+    /// - data - `amount: i128` or `{ amount: i128 }`
     fn burn(env: Env, from: Address, amount: i128);
 
     /// Burn `amount` from `from`, consuming the allowance of `spender`.
@@ -157,7 +154,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// - topics - `["burn", from: Address]`
-    /// - data - `amount: i128`
+    /// - data - `amount: i128` or `{ amount: i128 }`
     fn burn_from(env: Env, spender: Address, from: Address, amount: i128);
 
     /// Returns the number of decimals used to represent amounts of this token.

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,8 +6,8 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2025-08-28
-Version 0.4.1
+Updated: 2026-06-08
+Version 0.5.0
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
 
@@ -173,6 +173,12 @@ pub trait TokenInterface {
 
 ### Events
 
+Token events support two data formats. The original data format is the format
+defined by earlier versions of this SEP. The map data format encodes the event
+data as a `Map` with `Symbol` keys, and may contain additional keys beyond
+those defined in this SEP. Event consumers must be able to handle keys they do
+not recognize, and are expected to support both formats.
+
 #### Approve Event
 
 The `approve` event is emitted when the allowance is set.
@@ -183,10 +189,17 @@ The event has topics:
 - `Address` the address holding the balance of tokens to be drawn from.
 - `Address` the address spending the tokens held by `from`.
 
-The event has data:
+The event's original data format is:
 
-- `i128` the amount allowed to be spent.
-- `u32` the expiration ledger.
+- `Vec` containing
+  - `i128` the amount allowed to be spent.
+  - `u32` the expiration ledger.
+
+The event's map data format is:
+
+- `Map` containing entries with `Symbol` keys, and values defined as
+  - `amount: i128` the amount allowed to be spent.
+  - `live_until_ledger: u32` the expiration ledger.
 
 #### Transfer Event
 
@@ -199,15 +212,17 @@ The event has topics:
 - `Address` the address holding the balance of tokens that was drawn from.
 - `Address` the address that received the tokens.
 
-The event has data:
+The event's original data format is:
 
 - `i128` the amount transferred.
-- or `map` containing entries with `Symbol` keys, and values defined as
-  - `amount: i128` the amount minted.
+
+The event's map data format is:
+
+- `Map` containing entries with `Symbol` keys, and values defined as
+  - `amount: i128` the amount transferred.
   - `to_muxed_id: Option<u64 | String | BytesN<32>>` void, or entry absent, if
     no muxed ID, or the u64 muxed ID, or for historical legacy reasons, the
     string or bytes memo for Stellar assets.
-  - Other entries allowed as defined by the implementation.
 
 #### Burn Event
 
@@ -218,9 +233,14 @@ The event has topics:
 - `Symbol` with value `"burn"`
 - `Address` the address holding the balance of tokens that was burned.
 
-The event has data:
+The event's original data format is:
 
 - `i128` the amount burned.
+
+The event's map data format is:
+
+- `Map` containing entries with `Symbol` keys, and values defined as
+  - `amount: i128` the amount burned.
 
 #### Mint Event
 
@@ -234,15 +254,17 @@ The event has topics:
 - `Symbol` with value `"mint"`
 - `Address` the address to hold the newly minted tokens.
 
-The event has data:
+The event's original data format is:
 
 - `i128` the amount minted.
-- or `map` containing entries with `Symbol` keys, and values defined as
+
+The event's map data format is:
+
+- `Map` containing entries with `Symbol` keys, and values defined as
   - `amount: i128` the amount minted.
   - `to_muxed_id: Option<u64 | String | BytesN<32>>` void, or entry absent, if
     no muxed ID, or the u64 muxed ID, or for historical legacy reasons, the
     string or bytes memo for Stellar assets.
-  - Other entries allowed as defined by the implementation.
 
 #### Clawback Event
 
@@ -259,9 +281,14 @@ The event has topics:
 - `Address` The address holding the balance from which the clawback will take
   tokens.
 
-The event has data:
+The event's original data format is:
 
 - `i128` the amount clawed back.
+
+The event's map data format is:
+
+- `Map` containing entries with `Symbol` keys, and values defined as
+  - `amount: i128` the amount clawed back.
 
 ### Mint and Clawback Event Flexibility
 
@@ -283,6 +310,8 @@ and a clawback action that emits a clawback event must reduce total supply.
 - `v0.4.0` - Add muxed support to transfer, and mint.
 - `v0.4.1` - Clarify that clawback burns tokens reducing total supply and that
   no separate burn or transfer event is emitted alongside the clawback event.
+- `v0.5.0` - Document the original and map data formats for all events,
+  generalizing the form already used by `transfer` and `mint`.
 
 ## Implementations
 

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -173,11 +173,11 @@ pub trait TokenInterface {
 
 ### Events
 
-Token events support two data formats. The original data format is the format
-defined by earlier versions of this SEP. The map data format encodes the event
-data as a `Map` with `Symbol` keys, and may contain additional keys beyond
-those defined in this SEP. Event consumers must be able to handle keys they do
-not recognize, and are expected to support both formats.
+Events can be emitted by tokens in two data formats: a single-value/vec data
+format and a map data format. The map data format encodes the event data as a
+`Map` with `Symbol` keys, and may contain additional keys beyond those defined
+in this SEP. Event consumers must be able to handle keys they do not recognize,
+and are expected to support both formats.
 
 #### Approve Event
 
@@ -189,7 +189,7 @@ The event has topics:
 - `Address` the address holding the balance of tokens to be drawn from.
 - `Address` the address spending the tokens held by `from`.
 
-The event's original data format is:
+The event's vec data format is:
 
 - `Vec` containing
   - `i128` the amount allowed to be spent.
@@ -212,7 +212,7 @@ The event has topics:
 - `Address` the address holding the balance of tokens that was drawn from.
 - `Address` the address that received the tokens.
 
-The event's original data format is:
+The event's single-value data format is:
 
 - `i128` the amount transferred.
 
@@ -233,7 +233,7 @@ The event has topics:
 - `Symbol` with value `"burn"`
 - `Address` the address holding the balance of tokens that was burned.
 
-The event's original data format is:
+The event's single-value data format is:
 
 - `i128` the amount burned.
 
@@ -254,7 +254,7 @@ The event has topics:
 - `Symbol` with value `"mint"`
 - `Address` the address to hold the newly minted tokens.
 
-The event's original data format is:
+The event's single-value data format is:
 
 - `i128` the amount minted.
 
@@ -281,7 +281,7 @@ The event has topics:
 - `Address` The address holding the balance from which the clawback will take
   tokens.
 
-The event's original data format is:
+The event's single-value data format is:
 
 - `i128` the amount clawed back.
 
@@ -310,7 +310,7 @@ and a clawback action that emits a clawback event must reduce total supply.
 - `v0.4.0` - Add muxed support to transfer, and mint.
 - `v0.4.1` - Clarify that clawback burns tokens reducing total supply and that
   no separate burn or transfer event is emitted alongside the clawback event.
-- `v0.5.0` - Document the original and map data formats for all events,
+- `v0.5.0` - Document the single-value/vec and map data formats for all events,
   generalizing the form already used by `transfer` and `mint`.
 
 ## Implementations


### PR DESCRIPTION
Implement a `Map` data format to all SEP-41 events. Any event may be extended with further keys by other token SEPs or implementations. Consumers must tolerate unknown keys on event data.

Discussion: https://github.com/orgs/stellar/discussions/1948