### PR TITLE
Guide new SEP proposals towards discussions first

### DIFF
--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -16,7 +16,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   new-sep-proposal:
@@ -50,6 +50,20 @@ jobs:
               return;
             }
 
+            // Idempotency guard: if guidance has already been posted on this PR,
+            // do nothing. This avoids duplicate comments and re-lock errors when
+            // the workflow fires again (e.g. on reopened), and avoids re-locking
+            // a PR that a maintainer has deliberately unlocked.
+            const marker = '<!-- new-sep-proposal-guidance -->';
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pull_number, per_page: 100 }
+            );
+            if (existingComments.some((c) => c.body && c.body.includes(marker))) {
+              core.info('SEP proposal guidance already posted; nothing to do.');
+              return;
+            }
+
             // Link to the SEP process docs in ecosystem/README.md, anchored to
             // the specific sections that explain the flow and statuses.
             const defaultBranch = context.payload.repository.default_branch;
@@ -58,6 +72,7 @@ jobs:
               'https://github.com/orgs/stellar/discussions/categories/stellar-ecosystem-proposals';
 
             const body = [
+              marker,
               '👋 Thanks for your contribution!',
               '',
               'It looks like this PR is proposing a **new SEP** — it adds the following new file(s) to the `ecosystem/` directory:',

--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -1,0 +1,89 @@
+name: 'New SEP Proposal'
+
+# When a PR adds a new file to the ecosystem/ directory it is likely proposing a
+# new SEP. New ideas are meant to start as a GitHub Discussion rather than a PR,
+# so this workflow locks the PR and explains the process to the author.
+#
+# Uses pull_request_target so the GITHUB_TOKEN has write access even for PRs
+# opened from forks. No untrusted PR code is checked out or executed; the job
+# only inspects the list of changed files via the API.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - 'ecosystem/**'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  new-sep-proposal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock PR and explain SEP proposal process
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            // Find files added (not just modified) under ecosystem/.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const newSepFiles = files.filter(
+              (f) =>
+                f.status === 'added' &&
+                f.filename.startsWith('ecosystem/') &&
+                f.filename.endsWith('.md') &&
+                f.filename !== 'ecosystem/README.md'
+            );
+
+            if (newSepFiles.length === 0) {
+              core.info('No new files added under ecosystem/; nothing to do.');
+              return;
+            }
+
+            const discussionsUrl = `https://github.com/${owner}/${repo}/discussions`;
+
+            const body = [
+              '👋 Thanks for your contribution!',
+              '',
+              'It looks like this PR is proposing a **new SEP** — it adds the following new file(s) to the `ecosystem/` directory:',
+              '',
+              ...newSepFiles.map((f) => `- \`${f.filename}\``),
+              '',
+              'New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR** for now.',
+              '',
+              '### How the SEP process works',
+              '',
+              `1. 💬 **Start a discussion.** Discussion for new ideas happens on [GitHub Discussions](${discussionsUrl}). Please start a discussion there about your idea and proposal so people in the Stellar ecosystem can collaborate on it.`,
+              '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion.',
+              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your GitHub Discussion asking for this PR to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a SEP number**, and merge it.',
+              '',
+              '> ⚠️ **Never pre-allocate a SEP number in your PR.** A maintainer will assign the SEP number — please do not pick one yourself.',
+              '',
+              'Thanks for helping improve the Stellar ecosystem! 🚀',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body,
+            });
+
+            await github.rest.issues.lock({
+              owner,
+              repo,
+              issue_number: pull_number,
+              lock_reason: 'resolved',
+            });
+
+            core.info(`Locked PR #${pull_number} and posted the SEP proposal guidance.`);

--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -50,7 +50,12 @@ jobs:
               return;
             }
 
-            const discussionsUrl = `https://github.com/${owner}/${repo}/discussions`;
+            // Link to the SEP process docs in ecosystem/README.md, anchored to
+            // the specific sections that explain the flow and statuses.
+            const defaultBranch = context.payload.repository.default_branch;
+            const readmeUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/ecosystem/README.md`;
+            const discussionsUrl =
+              'https://github.com/orgs/stellar/discussions/categories/stellar-ecosystem-proposals';
 
             const body = [
               '👋 Thanks for your contribution!',
@@ -59,15 +64,17 @@ jobs:
               '',
               ...newSepFiles.map((f) => `- \`${f.filename}\``),
               '',
-              'New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR** for now.',
+              `New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR** for now. The full process, including how SEP statuses work, is documented in the [SEP Contribution Process](${readmeUrl}#contribution-process).`,
               '',
               '### How the SEP process works',
               '',
-              `1. 💬 **Start a discussion.** Discussion for new ideas happens on [GitHub Discussions](${discussionsUrl}). Please start a discussion there about your idea and proposal so people in the Stellar ecosystem can collaborate on it.`,
-              '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion.',
+              `1. 💬 **Start a discussion.** Per [Pre-SEP (Initial Discussion)](${readmeUrl}#pre-sep-initial-discussion), discussion for new ideas happens on [GitHub Discussions](${discussionsUrl}). Please start a discussion there about your idea and proposal so people in the Stellar ecosystem can collaborate on it.`,
+              '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion until it is ready to become a draft. See [Creating a SEP Draft](' + readmeUrl + '#creating-a-sep-draft).',
               '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your GitHub Discussion asking for this PR to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a SEP number**, and merge it.',
               '',
-              '> ⚠️ **Never pre-allocate a SEP number in your PR.** A maintainer will assign the SEP number — please do not pick one yourself.',
+              `> ⚠️ **Never pre-allocate a SEP number in your PR.** Leave the SEP number as "To Be Assigned" — a maintainer will assign it on merge, as described in [Creating a SEP Draft](${readmeUrl}#creating-a-sep-draft).`,
+              '',
+              `For details on what each SEP status (Draft, FCP, Active, Final, …) means, see [SEP Status Terms](${readmeUrl}#sep-status-terms).`,
               '',
               'Thanks for helping improve the Stellar ecosystem! 🚀',
             ].join('\n');


### PR DESCRIPTION
### What

Add a GitHub Actions workflow that steers new SEP proposals toward the discussion-first process the moment a pull request adds a new file under the `ecosystem/` directory. It greets the author with a comment that points them to the org's GitHub Discussions as the right place to socialize the idea, links into the relevant `ecosystem/README.md` sections (Contribution Process, Pre-SEP discussion, Creating a SEP Draft, and SEP Status Terms), and reminds them to leave the SEP number unassigned since a maintainer assigns it on merge. The PR is locked until the proposal has been collaborated on and the author requests a merge in their discussion.

### Why

New contributors sometimes open a pull request as the first step of proposing a SEP. Contributors sometimes self-assign a SEP number either to their discussion or their PR. The documented process expects ideas to be socialised and collaborated on in the org's GitHub Discussions before an idea is formalised and merged. Guiding authors to discussions first, automatically and consistently, means every new-SEP PR gets an immediate pointer to the correct process and the canonical status documentation without a maintainer having to repeat it by hand. Immediate feedback allows the contributor to act immediately while they are still engaged, rather than having that longer feedback cycle. The workflow uses `pull_request_target` so the token can comment and lock even on fork PRs, and it only inspects the changed-file list rather than checking out or running any PR code.

---
_Generated by [Claude Code](https://claude.ai/code/session_011NnJ3mQmXGKxyj4Voxi6ja)_