### PR TITLE
Convert auto-locked SEP proposal PRs to draft

### DIFF
--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -88,7 +88,7 @@ jobs:
               '',
               `1. 💬 **Start a discussion.** Per [Pre-SEP (Initial Discussion)](${readmeUrl}#pre-sep-initial-discussion), discussion for new ideas happens on [GitHub Discussions](${discussionsUrl}). Please start a discussion there about your idea and proposal so people in the Stellar ecosystem can collaborate on it.`,
               '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion until it is ready to become a draft. See [Creating a SEP Draft](' + readmeUrl + '#creating-a-sep-draft).',
-              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your GitHub Discussion asking for this PR to be merged. A maintainer will then unlock this PR, mark it ready for review, review it for formatting, **assign a SEP number**, and merge it.',
+              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your GitHub Discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a SEP number**, and merge it.',
               '',
               `> ⚠️ **Never pre-allocate a SEP number in your PR.** Leave the SEP number as "To Be Assigned" — a maintainer will assign it on merge, as described in [Creating a SEP Draft](${readmeUrl}#creating-a-sep-draft).`,
               '',

--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -82,7 +82,7 @@ jobs:
               '',
               ...newSepFiles.map((f) => `- \`${f.filename}\``),
               '',
-              `New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR and converted it to a draft** for now. The full process, including how SEP statuses work, is documented in the [SEP Contribution Process](${readmeUrl}#contribution-process).`,
+              `New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how SEP statuses work, is documented in the [SEP Contribution Process](${readmeUrl}#contribution-process).`,
               '',
               '### How the SEP process works',
               '',
@@ -97,13 +97,12 @@ jobs:
               'Thanks for helping improve the Stellar ecosystem! 🚀',
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pull_number,
-              body,
-            });
-
+            // Perform the side effects (lock, convert to draft) BEFORE posting the
+            // guidance comment. The comment carries the idempotency marker that the
+            // guard above checks, so it must be the last step: if locking or the
+            // draft conversion fails, no marker is left behind and a rerun or
+            // reopened event will retry the whole sequence instead of short-circuiting
+            // on the marker with the PR left unlocked or not a draft.
             await github.rest.issues.lock({
               owner,
               repo,
@@ -128,5 +127,14 @@ jobs:
               );
               core.info(`Converted PR #${pull_number} to a draft.`);
             }
+
+            // Post the guidance comment last; its marker records that the sequence
+            // completed so the guard above can skip subsequent runs.
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body,
+            });
 
             core.info(`Locked PR #${pull_number} and posted the SEP proposal guidance.`);

--- a/.github/workflows/new-sep-proposal.yml
+++ b/.github/workflows/new-sep-proposal.yml
@@ -2,7 +2,8 @@ name: 'New SEP Proposal'
 
 # When a PR adds a new file to the ecosystem/ directory it is likely proposing a
 # new SEP. New ideas are meant to start as a GitHub Discussion rather than a PR,
-# so this workflow locks the PR and explains the process to the author.
+# so this workflow locks the PR, converts it to a draft, and explains the
+# process to the author.
 #
 # Uses pull_request_target so the GITHUB_TOKEN has write access even for PRs
 # opened from forks. No untrusted PR code is checked out or executed; the job
@@ -16,7 +17,9 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  # write is required to convert the PR to a draft (the GraphQL
+  # convertPullRequestToDraft mutation); listing changed files only needs read.
+  pull-requests: write
 
 jobs:
   new-sep-proposal:
@@ -79,13 +82,13 @@ jobs:
               '',
               ...newSepFiles.map((f) => `- \`${f.filename}\``),
               '',
-              `New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR** for now. The full process, including how SEP statuses work, is documented in the [SEP Contribution Process](${readmeUrl}#contribution-process).`,
+              `New SEP ideas start as a **discussion**, not a pull request, so I have **locked this PR and converted it to a draft** for now. The full process, including how SEP statuses work, is documented in the [SEP Contribution Process](${readmeUrl}#contribution-process).`,
               '',
               '### How the SEP process works',
               '',
               `1. 💬 **Start a discussion.** Per [Pre-SEP (Initial Discussion)](${readmeUrl}#pre-sep-initial-discussion), discussion for new ideas happens on [GitHub Discussions](${discussionsUrl}). Please start a discussion there about your idea and proposal so people in the Stellar ecosystem can collaborate on it.`,
               '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion until it is ready to become a draft. See [Creating a SEP Draft](' + readmeUrl + '#creating-a-sep-draft).',
-              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your GitHub Discussion asking for this PR to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a SEP number**, and merge it.',
+              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your GitHub Discussion asking for this PR to be merged. A maintainer will then unlock this PR, mark it ready for review, review it for formatting, **assign a SEP number**, and merge it.',
               '',
               `> ⚠️ **Never pre-allocate a SEP number in your PR.** Leave the SEP number as "To Be Assigned" — a maintainer will assign it on merge, as described in [Creating a SEP Draft](${readmeUrl}#creating-a-sep-draft).`,
               '',
@@ -107,5 +110,23 @@ jobs:
               issue_number: pull_number,
               lock_reason: 'resolved',
             });
+
+            // Convert the PR to a draft so it is clearly not ready to merge while
+            // the idea is discussed. There is no REST endpoint for this, so use the
+            // GraphQL convertPullRequestToDraft mutation. Already-draft PRs are left
+            // as-is. node_id is the PR's GraphQL global ID from the event payload.
+            if (context.payload.pull_request.draft) {
+              core.info('PR is already a draft; skipping draft conversion.');
+            } else {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest { isDraft }
+                  }
+                }`,
+                { pullRequestId: context.payload.pull_request.node_id }
+              );
+              core.info(`Converted PR #${pull_number} to a draft.`);
+            }
 
             core.info(`Locked PR #${pull_number} and posted the SEP proposal guidance.`);


### PR DESCRIPTION
### What

When the new-sep-proposal workflow auto-locks a PR that adds a new SEP file under `ecosystem/`, it now also converts that PR to a draft via the GraphQL `convertPullRequestToDraft` mutation, skipping PRs that are already drafts, and the guidance comment now tells authors to mark the PR ready for review themselves before posting in their discussion to request a merge.

### Why

A locked PR still presents as mergeable in the PR list, so locking alone did not communicate that a new proposal is not ready to merge while the idea is still being discussed; marking it a draft makes that not-ready state explicit. Moving the "ready for review" step onto the author lets a maintainer's unlock stay focused on formatting review and assigning the SEP number rather than also flipping the PR's draft state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3saUFC7Rr5CMnF7Mfmegw)_