### PR TITLE
Rework SEP-58 source identification fields proposed change

### DIFF
--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -6,7 +6,7 @@ Title: Contract Build Reproducibility for Verification
 Author: Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2026-05-01
-Updated: 2026-06-10
+Updated: 2026-06-16
 Version: 0.4.0
 Discussion: https://github.com/orgs/stellar/discussions/1923
 ```
@@ -167,121 +167,55 @@ was not present in `bldopt`.
 
 ### 2. Source identification fields
 
-These fields identify the source tree the wasm was built from. `source_sha256`
-is always required: it is the content address of the source the wasm was built
-from, and a wasm without it cannot be verified by rebuild. `source_uri` is an
-optional retrieval hint naming where those exact bytes can be downloaded; it is
-never a trust anchor on its own. A verifier MUST confirm that whatever it
-retrieves — from a `source_uri` or any other channel — hashes to
-`source_sha256` before building from it; bytes that do not match the recorded
-hash MUST be rejected regardless of where they came from.
+These fields identify the source tree the wasm was built from. The source is
+identified as a single archive file — a `.tar`, `.tar.gz`, `.zip`, or other
+similar archive format, identified by its file extension and not otherwise
+constrained by this SEP; a producer MUST package the source such that the field
+values resolve to that archive.
 
-| key             | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | format regex                    |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `source_uri`    | Optional. URI to a downloadable source archive. The scheme names the retrieval mechanism and is open-ended; this SEP defines no fixed list of schemes. The artifact MUST be immutable so the recorded `source_sha256` stays valid — see [Producing a stable source archive](#producing-a-stable-source-archive); a forge's on-the-fly source archives do not qualify. A `source_uri` is only a retrieval hint and MUST NOT be relied on without checking the retrieved bytes against `source_sha256`. | `^[a-zA-Z][a-zA-Z0-9+.-]*:\S+$` |
-| `source_sha256` | Always required. SHA-256 of the source archive's bytes; the content address of the source the wasm was built from. Binds the exact archive contents — not merely bytes that happen to compile to the same wasm — so a verifier confirms it has the same source the producer built. Present whether or not a `source_uri` accompanies it. Not a git commit hash or any other revision identifier.                                                                                                      | `^[0-9a-f]{64}$`                |
+| key             | description                                                                                                          | format regex                    |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `source_sha256` | Required. SHA-256 of the source archive's bytes.                                                                     | `^[0-9a-f]{64}$`                |
+| `source_uri`    | Optional. URI from which the source archive can be downloaded; `https://` is expected, but the scheme is open-ended. | `^[a-zA-Z][a-zA-Z0-9+.-]*:\S+$` |
+
+`source_sha256` is the hash of the exact bytes of the one archive the producer
+created. A verifier obtains that same archive (by download or
+content-addressable lookup) and confirms its bytes hash to the recorded value.
+A producer therefore MUST publish, and keep retrievable, the exact archive it
+hashed rather than re-creating one on demand, unless it can do so using a
+deterministic method.
 
 `source_sha256` is always present; `source_uri` may or may not accompany it:
 
-- **`source_sha256` + `source_uri`**: the verifier downloads from the URI and
-  confirms the downloaded bytes hash to `source_sha256`. The hash binds the
-  exact archive; the URI provides retrieval. The URI is convenience only — the
-  verifier trusts the bytes because they match the hash, not because of where
-  they came from.
-- **`source_sha256` alone**: content-addressed, with no public retrieval
-  channel. The source archive is identified by hash and obtained by whatever
-  means the verifier has access to (e.g. shared privately with an auditor, an
-  out-of-band registry, or a content-addressable store).
+- **`source_sha256` + `source_uri`**: the verifier downloads the archive from
+  the URI, verifies its bytes against the sha256, and extracts it.
+- **`source_sha256` alone**: content-addressed. The archive is identified by
+  hash and obtained by whatever means the verifier has access to (e.g. an
+  out-of-band source mirror or content-addressable store).
 
-**Producers retain the archive; verifiers reject what does not match it.**
-`source_sha256` commits to one specific archive's exact bytes, so those exact
-bytes are what a verifier must obtain to rebuild. A producer SHOULD retain the
-archive it hashed — even when the source is private or carries no `source_uri`
-— so it can be handed to an auditor or verifier out of band later. Without the
-original archive the recorded hash is unverifiable: regenerating the archive
-from source (a different tool or version, or even the same tool at a later
-date) can produce different bytes and a different digest, so the source can no
-longer be matched to the recorded `source_sha256`. A verifier, for its part,
-MUST reject any archive whose bytes do not hash to `source_sha256` or that does
-not have the required layout (see
-[Producing a stable source archive](#producing-a-stable-source-archive)),
-regardless of where the archive came from.
+`source_sha256` is what this vocabulary uses to bind a wasm to its source, so a
+verifier relying on these fields requires it. A verifier MAY nonetheless
+support a wasm that carries no `source_sha256` if it identifies the original
+source by some alternative means — for example, a trusted authentication
+mechanism that establishes who uploaded the wasm and obtains the source from
+that uploader directly. Such mechanisms are not defined here and are out of
+scope; identifying the original source by other secure means is an area
+verifiers can innovate in.
 
-The set of URI schemes is open-ended: this SEP does not maintain a list of
-recommended or required schemes. Whatever scheme is used, `source_uri` MUST
-name the exact immutable archive bytes covered by `source_sha256` (see
-[Producing a stable source archive](#producing-a-stable-source-archive)). Each
-verifier decides which schemes it supports based on what it can fetch, so
-producers should pick a scheme their intended verifiers can reach.
+The archive MUST contain its files within a single top-level directory, so that
+extracting it yields exactly one directory holding the source tree. A producer
+MUST construct the archive this way; a verifier extracts the archive and runs
+the build commands from inside that single directory, which it treats as the
+source mounted at `/source` per §1.
 
-#### Producing a stable source archive
-
-`source_sha256` is always the SHA-256 of one specific source archive's exact
-bytes. When a `source_uri` is present, it MUST point at those same bytes, so
-the artifact it names MUST be immutable: the same URI must return the same
-bytes indefinitely. A forge's on-the-fly source-archive endpoints do NOT meet
-this bar — GitHub `…/archive/<sha>.zip`, GitLab `…/-/archive/…`, Codeberg/Gitea
-`…/archive/…`, and Bitbucket `…/get/…` are all regenerated on demand, and their
-bytes have changed across forge and git upgrades (e.g. compression or tar
-settings), which would invalidate a recorded hash even for unchanged source.
-Point `source_uri` at a stored, uploaded artifact instead. Common options:
-
-- **GitHub** — a Release asset (a file uploaded to a release):
-  `https://github.com/<owner>/<repo>/releases/download/<tag>/<file>`. Note the
-  auto-generated "Source code" links attached to a release are the unstable
-  archives above; upload your own archive as an asset.
-- **GitLab** — a Release asset or Generic Package Registry file:
-  `https://gitlab.com/<namespace>/<project>/-/releases/<tag>/downloads/<file>`.
-- **Codeberg / Gitea / Forgejo** — a release attachment:
-  `https://codeberg.org/<owner>/<repo>/releases/download/<tag>/<file>`.
-- **Bitbucket** — a Downloads file:
-  `https://bitbucket.org/<owner>/<repo>/downloads/<file>`.
-- **Anywhere else** — any static host that serves fixed bytes (object storage
-  such as S3 or GCS, or a plain web server), or a content-addressed store such
-  as Arweave (`ar:<address>`) or IPFS, which are immutable by construction.
-
-Whichever is used, the producer creates the source archive, computes its
-SHA-256, records that as `source_sha256` and the artifact's URI as
-`source_uri`, and uploads the archive so the URI is durable.
-
-The producer's archive must satisfy three requirements:
-
-1. **Format.** A single archive file (`.zip`, `.tar.gz`, or `.tar`) — the same
-   convention used by npm, PyPI, Cargo, and Homebrew.
-
-2. **Immutability.** Once the hash is recorded, the exact bytes must never
-   change. Re-creating the archive — even from identical source — with a
-   different tool, version, or compression settings may produce different bytes
-   and a different digest. Keep the original file rather than regenerating it.
-
-3. **Layout.** The archive MUST wrap its contents in a single top-level
-   directory (e.g. `my-contract-v1.0.0/`); bare archives that extract files
-   into the current directory are not conformant, and a verifier MUST reject a
-   non-conformant archive rather than guess a build root. That top-level
-   directory is the build root — mounted at `/source` (see
-   [Compatible build image](#compatible-build-image)) — and any relative
-   `bldopt` paths (e.g. `--manifest-path=contracts/foo/Cargo.toml`) resolve
-   against it. Verifiers extract the archive and run the build from this root
-   directly, applying no implicit transformation. Requiring the wrapping
-   directory matches the convention used by `git archive`, GitHub source
-   archives, npm, and Cargo, and ensures two verifiers fetching byte-identical
-   archives always agree on the build root.
-
-If you're using [Git](https://git-scm.com) for source control, you can produce
-an archive file that follows the recommendations above with
-[git archive](https://git-scm.com/docs/git-archive) and upload it as a release
-asset. For example:
+A producer can build a conformant archive with
+[git archive](https://git-scm.com/docs/git-archive), whose `--prefix` supplies
+the required top-level directory, then hash it:
 
 ```
-# the git commit you built from
-$ commit=<full-commit-sha>
-
-# generate the archive
-$ git archive --format=tar.gz --prefix=my-contract-v1.0.0/ $commit > my-contract-v1.0.0-${commit}.tar.gz
-
-# retrieve sha256
-$ sha256sum my-contract-v1.0.0-${commit}.tar.gz
-28a148275748e65c00211f3c7308e879cd246f6cc23b53b2bf7d90f8c9845063  my-contract-v1.0.0-${commit}.tar.gz
+$ git archive --format=tar.gz --prefix=my-contract-v1.0.0/ <commit> > my-contract-v1.0.0.tar.gz
+$ sha256sum my-contract-v1.0.0.tar.gz
+28a148275748e65c00211f3c7308e879cd246f6cc23b53b2bf7d90f8c9845063  my-contract-v1.0.0.tar.gz
 ```
 
 ### 3. Where these fields live
@@ -310,8 +244,8 @@ lives.
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
-- Image and source retrieval depend on registries, repos, or archive hosts
-  whose availability the SEP cannot guarantee. Content-addressed identifiers
+- Image and source retrieval depend on registries and archive hosts whose
+  availability the SEP cannot guarantee. Content-addressed identifiers
   (`bldimg`'s digest, `source_sha256`) protect integrity once the bytes are
   obtained; obtaining them is the verifier's problem.
 
@@ -373,10 +307,27 @@ one byte stream to fetch and one byte stream to hash, with no per-VCS checkout
 logic, no canonical-tree-hash algorithm, and no need to extract anything to
 validate. Because the hash is over the artifact's exact bytes, the artifact
 must be immutable; the forges developers already use provide durable uploaded
-release assets that satisfy this (see
-[Producing a stable source archive](#producing-a-stable-source-archive)), while
-their convenient on-the-fly source archives are deliberately not relied upon
-because those bytes can change.
+release assets that satisfy this, while their convenient on-the-fly source
+archives are deliberately not relied upon because those bytes can change.
+
+**Why hash the archive instead of the source tree?** `source_sha256` is the
+hash of one specific archive the producer published, not a canonical hash of
+the source content. Archiving is not deterministic — re-running `tar` over the
+same tree, especially with a different tool or version, may produce different
+bytes (ordering, timestamps, permissions, format metadata). So the spec does
+not ask a verifier to re-create the archive and re-hash it; it asks the
+verifier to obtain the producer's exact archive bytes and confirm they match.
+This keeps the hash meaningful without requiring reproducible archiving:
+archive determinism would be nice but is not relied upon, and the build's
+reproducibility depends only on the files extracted from the archive, not on
+the archive's framing.
+
+**Why require a single top-level directory in the archive?** The build runs
+with the source mounted at `/source` (§1). An archive that unpacks its files
+directly into the extraction directory, or into several sibling directories,
+leaves the verifier guessing which path to mount. Requiring exactly one
+top-level directory makes the mount point unambiguous: extract, then mount that
+one directory.
 
 **Why have both this SEP and SEP-55?** They answer overlapping but distinct
 questions. SEP-55 (attestation-based) asks "did a particular trusted CI compile
@@ -391,22 +342,13 @@ consumers maximum flexibility.
   image can emit attacker-chosen bytes from any source. Verifiers SHOULD
   restrict `bldimg` to an allowlist of independently vetted images rather than
   trust arbitrary digests.
-- **Source-host trust.** The rebuilt-wasm comparison only proves that _some_
-  source compiles to the deployed bytes — the compiler discards comments,
-  formatting, and unreachable code, so distinct source trees can produce
-  identical wasm. Without a source hash, an attacker can publish an archive
-  whose comments or docs misrepresent what the (identically-compiling) code
-  does, and it still "verifies". `source_sha256` closes this: it is
-  content-addressed over the archive's bytes, so the host cannot serve a
-  different archive under the recorded hash without a SHA-256 collision, and an
-  auditor reads the same bytes that were hashed. Producers MUST always include
-  it, and a verifier MUST NOT trust bytes fetched from a `source_uri` (or any
-  other channel) without confirming they hash to `source_sha256`. For the hash
-  to stay valid the artifact must be immutable (see
-  [Producing a stable source archive](#producing-a-stable-source-archive)); a
-  host can still stop serving it entirely — deletion or link rot — leaving
-  verifiers without retrievable source, though the recorded hash still lets
-  source obtained by other means be checked.
+- **Source-host trust.** A `source_sha256` is content-addressed: the host
+  cannot serve different bytes under the recorded hash without a SHA-256
+  collision. The host can, however, stop serving the archive at all — through
+  deletion or a moved URI — leaving verifiers without retrievable source. In
+  that case `source_uri` becomes a retrieval hint rather than a trust anchor,
+  and a verifier falls back to obtaining the archive by its hash through
+  another channel.
 - **Verifier honesty.** A verifier can publish false-positive results.
   Consumers SHOULD weigh results by verifier reputation and aggregate across
   independent verifiers.
@@ -460,7 +402,7 @@ $ docker run --rm -v "$PWD:/source" -e RUSTUP_TOOLCHAIN "$IMAGE" \
       --meta bldopt=--manifest-path=contracts/foo/Cargo.toml \
       --meta bldopt=--optimize \
       --meta source_uri=https://example.com/my-contract-v1.0.0.tar.gz \
-      --meta source_sha256=3b1f8e...64hex
+      --meta source_sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
 The wasm under `target/wasm32v1-none/release/` carries those `--meta` entries
@@ -481,23 +423,22 @@ Contract meta:
  • bldopt: --manifest-path=contracts/foo/Cargo.toml
  • bldopt: --optimize
  • source_uri: https://example.com/my-contract-v1.0.0.tar.gz
- • source_sha256: 3b1f8e...64hex
+ • source_sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ```
 
 The verifier obtains the source (here, by downloading the archive from
-`source_uri` and checking its `source_sha256`) and re-runs the same
-`docker run` with the recorded `bldimg`, passing every recorded field back
-through `--meta` so the rebuilt `contractmetav0` section is byte-identical.
-Comparing `sha256` of the rebuilt wasm to the original is the verification
-result.
+`source_uri`, verifying its bytes against `source_sha256`, and extracting the
+single top-level directory it contains) and re-runs the same `docker run` with
+the recorded `bldimg`, passing every recorded field back through `--meta` so
+the rebuilt `contractmetav0` section is byte-identical. Comparing `sha256` of
+the rebuilt wasm to the original is the verification result.
 
 ## Changelog
 
-- `v0.4.0` - Dropped `source_repo` and `source_rev`. Replaced the `tarball_url`
-  and `tarball_sha256` fields with `source_uri` (an open-ended URI to a stable,
-  immutable source archive) and `source_sha256` (SHA-256 of that archive's
-  bytes), and added guidance on producing a stable archive on common forges.
-  Made `source_sha256` always required and `source_uri` optional.
+- `v0.4.0` - Replaced the
+  `source_repo`/`source_rev`/`tarball_url`/`tarball_sha256`
+  source-identification fields with a required `source_sha256` and an optional
+  `source_uri` identifying a single source archive.
 - `v0.3.0` - Expanded best practices for images.
 - `v0.2.0` - Revised to focus on the build environment information.
 - `v0.1.0` - Initial draft.


### PR DESCRIPTION
### What

Reshape the source identification section of SEP-58 so the source is identified as a single archive file — a `.tar`, `.tar.gz`, `.zip`, or similar format named by its file extension and not otherwise constrained by the SEP — with the required `source_sha256` content address presented ahead of an optional, open-scheme `source_uri` retrieval hint, permit a producer to re-create that archive by a deterministic method rather than retaining the exact bytes, allow a verifier to establish the original source by out-of-scope means when a wasm carries no `source_sha256`, and trade the prior forge-by-forge stable-archive guidance for retaining just the concise `git archive` example alongside rationale for hashing the archive and for requiring a single top-level directory.

### Why

The source identification section had accumulated prescriptive detail — forge-by-forge upload instructions, a hard requirement to retain the exact archive bytes, and verbose field descriptions — that over-specifies how producers and verifiers operate. This narrows the SEP back toward a stable vocabulary: it pins down what the fields mean and the one invariant that matters, that the hash binds the archive's exact bytes, while leaving format choice, hosting, archive regeneration, and alternative source-identification mechanisms to implementers.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tnQKnCrETU2tRkBYYdQe2)_