### PR TITLE
Reframe SEP-58 source archive as reproducible

### DIFF
--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -181,9 +181,11 @@ values resolve to that archive.
 `source_sha256` is the hash of the exact bytes of the one archive the producer
 created. A verifier obtains that same archive (by download or
 content-addressable lookup) and confirms its bytes hash to the recorded value.
-A producer therefore MUST publish, and keep retrievable, the exact archive it
-hashed rather than re-creating one on demand, unless it can do so using a
-deterministic method.
+A producer therefore MUST be able to provide that exact archive — either by
+keeping the archive it hashed retrievable, or by regenerating its identical
+bytes on demand with a reproducible archiving method (for example,
+[reproducible `tar`](https://www.gnu.org/software/tar/manual/html_section/Reproducibility.html)
+settings).
 
 `source_sha256` is always present; `source_uri` may or may not accompany it:
 
@@ -310,17 +312,15 @@ must be immutable; the forges developers already use provide durable uploaded
 release assets that satisfy this, while their convenient on-the-fly source
 archives are deliberately not relied upon because those bytes can change.
 
-**Why hash the archive instead of the source tree?** `source_sha256` is the
-hash of one specific archive the producer published, not a canonical hash of
-the source content. Archiving is not deterministic — re-running `tar` over the
-same tree, especially with a different tool or version, may produce different
-bytes (ordering, timestamps, permissions, format metadata). So the spec does
-not ask a verifier to re-create the archive and re-hash it; it asks the
-verifier to obtain the producer's exact archive bytes and confirm they match.
-This keeps the hash meaningful without requiring reproducible archiving:
-archive determinism would be nice but is not relied upon, and the build's
-reproducibility depends only on the files extracted from the archive, not on
-the archive's framing.
+**Why hash the archive instead of the source tree?** `source_sha256` hashes one
+specific archive rather than a canonical hash computed over the source tree.
+Hashing an archive is simple: a single byte stream, hashed with standard tools,
+with no canonical-tree-hash algorithm to define or implement. Archives can be
+produced reproducibly — `tar`, for example, emits identical bytes from the same
+tree when given reproducible settings — so a producer can regenerate the exact
+bytes the hash commits to rather than being forced to retain a single original
+copy. The build's reproducibility ultimately depends only on the files
+extracted from the archive, not on the archive's framing.
 
 **Why require a single top-level directory in the archive?** The build runs
 with the source mounted at `/source` (§1). An archive that unpacks its files


### PR DESCRIPTION
### What

Reframe SEP-58's discussion of the source archive around archives being reproducible: a producer may either keep the hashed archive retrievable or regenerate its identical bytes on demand with a reproducible archiving method, and the rationale for hashing the archive (rather than a canonical source-tree hash) now rests on archive hashing being simple and on archives being reproducibly regenerable rather than on archiving being non-deterministic.

### Why

The earlier text asserted that archiving is not deterministic and that re-running `tar` may produce different bytes, so it told producers to retain the exact archive and told verifiers not to re-create it. That premise is wrong: `tar` archives are readily reproducible with the documented reproducible settings (https://www.gnu.org/software/tar/manual/html_section/Reproducibility.html), so the spec should not require hoarding a single original copy and should acknowledge that the exact bytes the hash commits to can be regenerated from source.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tnQKnCrETU2tRkBYYdQe2)_