### PR TITLE
Note advocating with SEP authors on change PRs

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -129,9 +129,10 @@ should expect each proposal to stand on its own merits and authors and
 maintainers should plan to drive adoption themselves.
 
 If you propose changes to an existing SEP, start a new discussion thread at the
-`Discussion` link in the SEP's preamble, and advocate for your change with the
-SEP's author(s). Mention the author if they have included a GitHub handle, or
-use their email address to contact them. The author maintains the proposal, so
+`Discussion` link in the SEP's preamble, or on the [GitHub discussion forum] if
+the SEP has no such link, and advocate for your change with the SEP's
+author(s). Mention the author if they have included a GitHub handle, or use
+their email address to contact them. The author maintains the proposal, so
 engaging them and earning their support is an important part of getting a
 change adopted.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -130,7 +130,7 @@ maintainers should plan to drive adoption themselves.
 
 If you open a PR proposing changes to an existing SEP, be prepared to advocate
 for your change with the SEP's author(s). Mention them on the PR using their
-GitHub handle, and where only an email address is listed you may reach out to
+GitHub handle, and where an email address is listed you may reach out to
 them respectfully by email. The author is responsible for the proposal, so
 engaging them and earning their support is an important part of getting a
 change adopted.

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -130,10 +130,9 @@ maintainers should plan to drive adoption themselves.
 
 If you open a PR proposing changes to an existing SEP, be prepared to advocate
 for your change with the SEP's author(s). Mention them on the PR using their
-GitHub handle, and where an email address is listed you may reach out to
-them respectfully by email. The author is responsible for the proposal, so
-engaging them and earning their support is an important part of getting a
-change adopted.
+GitHub handle, and where an email address is listed you may reach out to them
+respectfully by email. The author maintains the proposal, so engaging them and
+earning their support is an important part of getting a change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -128,11 +128,10 @@ participants, including SDF, may encourage adoption of a proposal, but authors
 should expect each proposal to stand on its own merits and authors and
 maintainers should plan to drive adoption themselves.
 
-If you propose changes to an existing SEP, start a new discussion thread at the
-`Discussion` link in the SEP's preamble, or on the [GitHub discussion forum] if
-the SEP has no such link, and advocate for your change with the SEP's
-author(s). The author maintains the proposal, so engaging them is an important
-part of getting a change adopted.
+If you propose changes to an existing SEP, start a discussion, either at the
+SEP's `Discussion` link or on the [GitHub discussion forum], and advocate for
+your change with the SEP's author(s). The author maintains the proposal, so
+engaging them is an important part of getting a change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -130,10 +130,8 @@ maintainers should plan to drive adoption themselves.
 
 If you propose changes to an existing SEP, start a new discussion thread at the
 `Discussion` link in the SEP's preamble, and advocate for your change with the
-SEP's author(s). Mention them on the PR using their GitHub handle, and where an
-email address is listed you may reach out to them respectfully by email. The
-author maintains the proposal, so engaging them and earning their support is an
-important part of getting a change adopted.
+SEP's author(s). The author maintains the proposal, so engaging them and
+earning their support is an important part of getting a change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -128,11 +128,12 @@ participants, including SDF, may encourage adoption of a proposal, but authors
 should expect each proposal to stand on its own merits and authors and
 maintainers should plan to drive adoption themselves.
 
-If you propose changes to an existing SEP, be prepared to advocate for your
-change with the SEP's author(s). Mention them on the PR using their GitHub
-handle, and where an email address is listed you may reach out to them
-respectfully by email. The author maintains the proposal, so engaging them and
-earning their support is an important part of getting a change adopted.
+If you propose changes to an existing SEP, start a new discussion thread at the
+`Discussion` link in the SEP's preamble, and advocate for your change with the
+SEP's author(s). Mention them on the PR using their GitHub handle, and where an
+email address is listed you may reach out to them respectfully by email. The
+author maintains the proposal, so engaging them and earning their support is an
+important part of getting a change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -131,10 +131,8 @@ maintainers should plan to drive adoption themselves.
 If you propose changes to an existing SEP, start a new discussion thread at the
 `Discussion` link in the SEP's preamble, or on the [GitHub discussion forum] if
 the SEP has no such link, and advocate for your change with the SEP's
-author(s). Mention the author if they have included a GitHub handle, or use
-their email address to contact them. The author maintains the proposal, so
-engaging them and earning their support is an important part of getting a
-change adopted.
+author(s). The author maintains the proposal, so engaging them is an important
+part of getting a change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -130,8 +130,10 @@ maintainers should plan to drive adoption themselves.
 
 If you propose changes to an existing SEP, start a new discussion thread at the
 `Discussion` link in the SEP's preamble, and advocate for your change with the
-SEP's author(s). The author maintains the proposal, so engaging them and
-earning their support is an important part of getting a change adopted.
+SEP's author(s). Mention the author if they have included a GitHub handle, or
+use their email address to contact them. The author maintains the proposal, so
+engaging them and earning their support is an important part of getting a
+change adopted.
 
 Before contributing, consider the following:
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -128,6 +128,13 @@ participants, including SDF, may encourage adoption of a proposal, but authors
 should expect each proposal to stand on its own merits and authors and
 maintainers should plan to drive adoption themselves.
 
+If you open a PR proposing changes to an existing SEP, be prepared to advocate
+for your change with the SEP's author(s). Mention them on the PR using their
+GitHub handle, and where only an email address is listed you may reach out to
+them respectfully by email. The author is responsible for the proposal, so
+engaging them and earning their support is an important part of getting a
+change adopted.
+
 Before contributing, consider the following:
 
 - Gather feedback from discussion on the [GitHub discussion forum], [Stellar

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -128,9 +128,9 @@ participants, including SDF, may encourage adoption of a proposal, but authors
 should expect each proposal to stand on its own merits and authors and
 maintainers should plan to drive adoption themselves.
 
-If you open a PR proposing changes to an existing SEP, be prepared to advocate
-for your change with the SEP's author(s). Mention them on the PR using their
-GitHub handle, and where an email address is listed you may reach out to them
+If you propose changes to an existing SEP, be prepared to advocate for your
+change with the SEP's author(s). Mention them on the PR using their GitHub
+handle, and where an email address is listed you may reach out to them
 respectfully by email. The author maintains the proposal, so engaging them and
 earning their support is an important part of getting a change adopted.
 


### PR DESCRIPTION
### What

Add a note to the SEP contribution process advising that anyone opening a PR proposing changes to an existing SEP should be prepared to advocate for their change with the SEP's author(s), mentioning them on the PR by GitHub handle and, where an email address is listed, reaching out respectfully by email.

### Why

Follow-up to #1957, which clarified that author GitHub handles let contributors mention authors on PRs against existing proposals. This makes the expectation explicit for contributors: because the author maintains the proposal, engaging them and earning their support is an important part of getting a change adopted, so a PR author should plan to reach out rather than expecting a change to land on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyCvsg4PKiUMdgvYo7Msz1)_