### PR TITLE
Clarify SEP-58 scope to common workflow

### DIFF
--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -227,11 +227,9 @@ lives.
 
 - This SEP defines a vocabulary, and a mechanism, not a complete
   implementation.
-- These fields target the common build workflow and the directions it is
-  expected to grow, not every possible build. A contract with a significantly
-  bespoke workflow may not be fully capturable by these fields, by design; such
-  contracts are expected to converge toward the common workflow rather than the
-  vocabulary expanding to cover each bespoke case (see Design Rationale).
+- These fields target the common build workflow and where it is expected to
+  grow, not every possible build; a significantly bespoke workflow may not be
+  fully capturable, by design (see Design Rationale).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
@@ -242,17 +240,13 @@ lives.
 
 ## Design Rationale
 
-**Why target the common build workflow rather than every workflow?** The fields
-here capture the inputs needed to reproduce the common contract build workflow,
-and the workflows it is expected to grow into over time. A contract built with a
-bespoke workflow that differs significantly from the common one may not be fully
-describable with these fields, and that is acceptable. The vocabulary can expand
-over time when doing so serves the common workflow, but it deliberately does not
-expand to accommodate bespoke or otherwise uncommon workflows: chasing every
-possible build would turn the SEP into an ever-growing game of whack-a-mole —
-complicated to specify and implement, and likely impossible to complete. The
-intent is the reverse — that contracts converge over time on the common workflow
-this SEP describes, rather than this SEP converging on every contract.
+**Why target the common build workflow rather than every workflow?** These
+fields capture the common contract build workflow and where it is expected to
+grow, not every possible build. A significantly bespoke workflow may not be
+fully describable here, and that is acceptable: the vocabulary expands only when
+doing so serves the common workflow, never to chase uncommon ones — that way
+lies an endless game of whack-a-mole. The goal is for contracts to converge on
+the workflow this SEP describes, not for this SEP to describe every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -227,9 +227,9 @@ lives.
 
 - This SEP defines a vocabulary, and a mechanism, not a complete
   implementation.
-- The vocabulary targets the common build workflow and how it is expected to
-  grow, not every possible build; a bespoke workflow may not be fully
-  capturable, by design (see Design Rationale).
+- The vocabulary targets the common build workflow, not every possible build; a
+  bespoke workflow's build inputs may not be fully expressible, by design (see
+  Design Rationale).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
@@ -241,13 +241,13 @@ lives.
 ## Design Rationale
 
 **Why target the common build workflow rather than every workflow?** The
-vocabulary captures the common contract build workflow and how it is expected
-to grow, not every possible build. A bespoke workflow may not be fully
-describable by it, and that is acceptable: the vocabulary is intended to expand
-when doing so serves the common workflow, not to chase uncommon ones, which
-would grow the specification without bound and could not realistically be
-completed. The goal is for contracts to converge on the workflow this SEP
-describes, not for this SEP to describe every contract.
+vocabulary captures the common contract build workflow, not every possible
+build. A bespoke workflow's build inputs may not be fully expressible, and that
+is acceptable: the vocabulary is intended to expand when doing so serves the
+common workflow, not to chase uncommon ones, which would grow the specification
+without bound and could not realistically be completed. The goal is for
+contracts to converge on the workflow this SEP describes, not for this SEP to
+describe every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -6,8 +6,8 @@ Title: Contract Build Reproducibility for Verification
 Author: Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2026-05-01
-Updated: 2026-05-09
-Version: 0.3.0
+Updated: 2026-06-18
+Version: 0.4.0
 Discussion: https://github.com/orgs/stellar/discussions/1923
 ```
 
@@ -227,6 +227,11 @@ lives.
 
 - This SEP defines a vocabulary, and a mechanism, not a complete
   implementation.
+- These fields target the common build workflow and the directions it is
+  expected to grow, not every possible build. A contract with a significantly
+  bespoke workflow may not be fully capturable by these fields, by design; such
+  contracts are expected to converge toward the common workflow rather than the
+  vocabulary expanding to cover each bespoke case (see Design Rationale).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
@@ -236,6 +241,18 @@ lives.
   obtained; obtaining them is the verifier's problem.
 
 ## Design Rationale
+
+**Why target the common build workflow rather than every workflow?** The fields
+here capture the inputs needed to reproduce the common contract build workflow,
+and the workflows it is expected to grow into over time. A contract built with a
+bespoke workflow that differs significantly from the common one may not be fully
+describable with these fields, and that is acceptable. The vocabulary can expand
+over time when doing so serves the common workflow, but it deliberately does not
+expand to accommodate bespoke or otherwise uncommon workflows: chasing every
+possible build would turn the SEP into an ever-growing game of whack-a-mole —
+complicated to specify and implement, and likely impossible to complete. The
+intent is the reverse — that contracts converge over time on the common workflow
+this SEP describes, rather than this SEP converging on every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one
@@ -396,6 +413,9 @@ wasm to the original is the verification result.
 
 ## Changelog
 
+- `v0.4.0` - Clarified that SEP-58 targets the common build workflow and the
+  directions it is expected to grow, that contracts converge onto it, and that
+  it does not expand to describe every bespoke build.
 - `v0.3.0` - Expanded best practices for images.
 - `v0.2.0` - Revised to focus on the build environment information.
 - `v0.1.0` - Initial draft.

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -408,7 +408,7 @@ wasm to the original is the verification result.
 
 ## Changelog
 
-- `v0.4.0` - Clarified that SEP-58 targets the common build workflow.
+- `v0.4.0` - Clarified that this proposal targets the common build workflow.
 - `v0.3.0` - Expanded best practices for images.
 - `v0.2.0` - Revised to focus on the build environment information.
 - `v0.1.0` - Initial draft.

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -243,11 +243,11 @@ lives.
 **Why target the common build workflow rather than every workflow?** The
 vocabulary captures the common contract build workflow, not every possible
 build. A bespoke workflow's build inputs may not be fully expressible, and that
-is acceptable: the vocabulary is intended to expand when doing so serves the
-common workflow, not to chase uncommon ones, which would grow the specification
-without bound and could not realistically be completed. The goal is for
-contracts to converge towards the workflow this SEP describes, not for this SEP
-to describe every contract.
+is acceptable. If the proposal sought to satisfy every possible build workflow
+it would grow without bound and could not realistically be completed. The goal
+is for contracts to converge towards the workflow supported by this proposal,
+not for this proposal to expand to satisfy every build workflow. The vocabulary
+can expand, but it should do so when it serves the common workflow.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -229,7 +229,7 @@ lives.
   implementation.
 - The vocabulary targets the common build workflow, not every possible build; a
   bespoke workflow's build inputs may not be fully expressible, by design (see
-  Design Rationale).
+  [Design Rationale](#design-rationale)).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -408,9 +408,7 @@ wasm to the original is the verification result.
 
 ## Changelog
 
-- `v0.4.0` - Clarified that SEP-58 targets the common build workflow and the
-  directions it is expected to grow, that contracts converge onto it, and that
-  it does not expand to describe every bespoke build.
+- `v0.4.0` - Clarified that SEP-58 targets the common build workflow.
 - `v0.3.0` - Expanded best practices for images.
 - `v0.2.0` - Revised to focus on the build environment information.
 - `v0.1.0` - Initial draft.

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -227,9 +227,9 @@ lives.
 
 - This SEP defines a vocabulary, and a mechanism, not a complete
   implementation.
-- These fields target the common build workflow and where it is expected to
-  grow, not every possible build; a significantly bespoke workflow may not be
-  fully capturable, by design (see Design Rationale).
+- These fields target the common build workflow and how it is expected to grow,
+  not every possible build; a bespoke workflow may not be fully capturable, by
+  design (see Design Rationale).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
@@ -240,13 +240,14 @@ lives.
 
 ## Design Rationale
 
-**Why target the common build workflow rather than every workflow?** These
-fields capture the common contract build workflow and where it is expected to
-grow, not every possible build. A significantly bespoke workflow may not be
-fully describable here, and that is acceptable: the vocabulary expands only when
-doing so serves the common workflow, never to chase uncommon ones — that way
-lies an endless game of whack-a-mole. The goal is for contracts to converge on
-the workflow this SEP describes, not for this SEP to describe every contract.
+**Why target the common build workflow rather than every workflow?** These meta
+fields capture the common contract build workflow and how it is expected to
+grow, not every possible build. A bespoke workflow may not be fully describable
+by the fields, and that is acceptable: the vocabulary is intended to expand when
+doing so serves the common workflow, not to chase uncommon ones, which would
+grow the specification without bound and could not realistically be completed.
+The goal is for contracts to converge on the workflow this SEP describes, not
+for this SEP to describe every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -227,9 +227,9 @@ lives.
 
 - This SEP defines a vocabulary, and a mechanism, not a complete
   implementation.
-- These fields target the common build workflow and how it is expected to grow,
-  not every possible build; a bespoke workflow may not be fully capturable, by
-  design (see Design Rationale).
+- The vocabulary targets the common build workflow and how it is expected to
+  grow, not every possible build; a bespoke workflow may not be fully
+  capturable, by design (see Design Rationale).
 - It captures the build environment and source identity, not whether the source
   itself is trustworthy, audited, or non-malicious; that is an orthogonal
   concern.
@@ -240,14 +240,14 @@ lives.
 
 ## Design Rationale
 
-**Why target the common build workflow rather than every workflow?** These meta
-fields capture the common contract build workflow and how it is expected to
-grow, not every possible build. A bespoke workflow may not be fully describable
-by the fields, and that is acceptable: the vocabulary is intended to expand when
-doing so serves the common workflow, not to chase uncommon ones, which would
-grow the specification without bound and could not realistically be completed.
-The goal is for contracts to converge on the workflow this SEP describes, not
-for this SEP to describe every contract.
+**Why target the common build workflow rather than every workflow?** The
+vocabulary captures the common contract build workflow and how it is expected
+to grow, not every possible build. A bespoke workflow may not be fully
+describable by it, and that is acceptable: the vocabulary is intended to expand
+when doing so serves the common workflow, not to chase uncommon ones, which
+would grow the specification without bound and could not realistically be
+completed. The goal is for contracts to converge on the workflow this SEP
+describes, not for this SEP to describe every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one

--- a/ecosystem/sep-0058.md
+++ b/ecosystem/sep-0058.md
@@ -246,8 +246,8 @@ build. A bespoke workflow's build inputs may not be fully expressible, and that
 is acceptable: the vocabulary is intended to expand when doing so serves the
 common workflow, not to chase uncommon ones, which would grow the specification
 without bound and could not realistically be completed. The goal is for
-contracts to converge on the workflow this SEP describes, not for this SEP to
-describe every contract.
+contracts to converge towards the workflow this SEP describes, not for this SEP
+to describe every contract.
 
 **Why a vocabulary, not an algorithm?** Verification practice is still emerging
 across CIs, registries, on-chain indexes, and ad-hoc scripts. Locking in one


### PR DESCRIPTION
### What

Add a scope statement to SEP-58 — a Design Rationale entry and a Limitations bullet — establishing that the vocabulary targets the common contract build workflow, not every possible build.

### Why

Without a stated boundary, SEP-58 invites endless expansion to capture every bespoke build; the statement makes explicit that bespoke build inputs may not be fully expressible and that contracts should converge towards the common workflow rather than the proposal growing to satisfy each one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNs7QFQe9GZkwwsfquZyKD)_