### PR TITLE
Move CAP-85 to Final Comment Period for Core CAP team to vote

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -118,6 +118,7 @@
 | [CAP-0057](cap-0057.md) | State Archival Persistent Entry Eviction | Garand Tyson | Draft |
 | [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Accepted |
 | [CAP-0072](cap-0072.md) | Contract signers for Stellar accounts | Dmytro Kozhevin | Draft |
+| [CAP-0084](cap-0084.md) | Muxed Contract Addresses | Jake Urban | Draft |
 | [CAP-0086](cap-0086.md) | Host functions for sparse Symbol-keyed map creation and unpacking | Dmytro Kozhevin | Draft |
 
 ### Rejected Proposals

--- a/core/README.md
+++ b/core/README.md
@@ -96,6 +96,7 @@
 | [CAP-0081](cap-0081.md) | TBD | TTL-Ordered Eviction | Garand Tyson | Accepted |
 | [CAP-0082](cap-0082.md) | 26 | Checked 256-bit integer arithmetic host functions | Jay Geng | Implemented |
 | [CAP-0083](cap-0083.md) | TBD | Allow validators to vote to drop the transaction set from the current ledger | Brett Boston | Accepted |
+| [CAP-0085](cap-0085.md) | TBD | Externally managed contract executables | Dmytro Kozhevin | Final Comment Period |
 
 ### Draft Proposals
 | Number | Title | Author | Status |
@@ -117,8 +118,6 @@
 | [CAP-0057](cap-0057.md) | State Archival Persistent Entry Eviction | Garand Tyson | Draft |
 | [CAP-0060](cap-0060.md) | Update to Wasmi register machine| Graydon Hoare | Accepted |
 | [CAP-0072](cap-0072.md) | Contract signers for Stellar accounts | Dmytro Kozhevin | Draft |
-| [CAP-0084](cap-0084.md) | Muxed Contract Addresses | Jake Urban | Draft |
-| [CAP-0085](cap-0085.md) | Externally managed contract executables | Dmytro Kozhevin | Draft |
 | [CAP-0086](cap-0086.md) | Host functions for sparse Symbol-keyed map creation and unpacking | Dmytro Kozhevin | Draft |
 
 ### Rejected Proposals

--- a/core/cap-0085.md
+++ b/core/cap-0085.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>, Alex Mootz <@mootz12>
     Consulted: 
-Status: Draft
+Status: Final Comment Period
 Created: 2026-06-30
 Discussion: https://github.com/orgs/stellar/discussions/1969
 Protocol version: TBD


### PR DESCRIPTION
### what
Move CAP-85 to Final Comment Period for Core CAP team to vote

### why
This was presented to the community and had enough support. Moving to the next phase as per the [CAP README](https://github.com/stellar/stellar-protocol/blob/master/core/README.md#awaiting-decision---final-comment-period-fcp).