### PR TITLE
Clarify Final Comment Period status in the core/README

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -5,9 +5,8 @@
 ### Primary Workflow
 - **Draft** — A CAP that is currently open for consideration and actively being discussed.
 - **Awaiting Decision** — A mature and ready CAP that is ready for final deliberation by the CAP
-  Core Team. After a maximum of three meetings, a vote will take place that will set the CAP's
-  intended disposition of Acceptance or Rejection for the Final Comment Period, or go back into a
-  **Draft** state.
+  Core Team. After a maximum of three meetings, a vote will take place that will move the CAP
+  to **Final Comment Period** state, or back into a **Draft** state.
 - **Final Comment Period** — A CAP that has entered a Final Comment Period with an
   intended disposition of Acceptance or Rejection. After one week has passed, during which any new concerns should be
   addressed, the CAP will move to **Accepted** or **Rejected** according to its intended
@@ -293,9 +292,9 @@ The protocol meetings will be used to decide on next step:
 - A vote will take place among the CAP Core Team.
   - A unanimous approval from the CAP Core Team will move the CAP to `Final Comment Period` with
     an intended disposition of Acceptance.
-  - Otherwise, the CAP will be given feedback and either move to `Final Comment Period` with an
-    intended disposition of Rejection (if the majority of the CAP Core Team raises concerns) or
-    return to `Draft` (if only a minority of the CAP Core Team raises concerns).
+  - Otherwise, the CAP will be given feedback and either,
+    - move to `Final Comment Period` with an intended disposition of Rejection documenting the reason (if the majority of the CAP Core Team raises concerns), or
+    - return to `Draft` (if only a minority of the CAP Core Team raises concerns).
   - It can take upwards of 3 meetings before a disposition is reached.
 
 ### Final Comment Period -> Accepted or Rejected

--- a/core/README.md
+++ b/core/README.md
@@ -6,11 +6,12 @@
 - **Draft** — A CAP that is currently open for consideration and actively being discussed.
 - **Awaiting Decision** — A mature and ready CAP that is ready for final deliberation by the CAP
   Core Team. After a maximum of three meetings, a vote will take place that will set the CAP's
-  intended FCP disposition (**FCP: Acceptance/Rejection**) or go back into a **Draft** state.
-- **FCP: [Acceptance/Rejection]** — A CAP that has entered a Final Comment Period (FCP) with an
-  intended disposition. After one week has passed, during which any new concerns should be
-  addressed, the CAP will head towards its intended disposition [**Acceptance/Rejection**] or go
-  back into a Draft state.
+  intended disposition of Acceptance or Rejection for the Final Comment Period, or go back into a
+  **Draft** state.
+- **Final Comment Period** — A CAP that has entered a Final Comment Period with an
+  intended disposition of Acceptance or Rejection. After one week has passed, during which any new concerns should be
+  addressed, the CAP will move to **Accepted** or **Rejected** according to its intended
+  disposition, or go back into a **Draft** state.
 - **Accepted** — A CAP that has been accepted on the merits of its idea pre-implementation, and is
   ready for implementation. It is still possible that the CAP may be rejected post-implementation
   due to the issues that may arise during an initial implementation.
@@ -288,17 +289,20 @@ The protocol meetings will be used to decide on next step:
   - If the CAP requires some adjustments or needs to receive more feedback from the community, the meeting is adjourned;
   - If for any reason the CAP gets abandoned, it gets a status of `Rejected`.
 
-### Awaiting Decision -> Final Comment Period (FCP)
+### Awaiting Decision -> Final Comment Period
 - A vote will take place among the CAP Core Team.
-  - A unanimous approval from the CAP Core Team will put the CAP in a `Accepted` status.
-  - Otherwise, the CAP will be given feedback and head towards a `FCP: Rejected` status (if the
-    majority of the CAP raises concerns) or a `Draft` status (if only a minority of the CAP
-    raises concerns).
+  - A unanimous approval from the CAP Core Team will move the CAP to `Final Comment Period` with
+    an intended disposition of Acceptance.
+  - Otherwise, the CAP will be given feedback and either move to `Final Comment Period` with an
+    intended disposition of Rejection (if the majority of the CAP Core Team raises concerns) or
+    return to `Draft` (if only a minority of the CAP Core Team raises concerns).
   - It can take upwards of 3 meetings before a disposition is reached.
 
-### FCP -> Accepted/Rejected
-- After a week of an Final Comment Period (FCP) where any major concerns that have not been
-  previously addressed can be brought up, the CAP will head to its final disposition.
+### Final Comment Period -> Accepted or Rejected
+- During the week-long Final Comment Period, anyone can bring up major concerns
+  that have not been previously addressed. If no such concerns remain at the
+  end of the period, the CAP will move to `Accepted` or `Rejected` according to
+  its intended disposition.
   - Concerns will be addressed on a case by case basis, and only major concerns that were not
     addressed earlier will move the CAP back to a `Draft` state.
 

--- a/core/README.md
+++ b/core/README.md
@@ -5,12 +5,12 @@
 ### Primary Workflow
 - **Draft** — A CAP that is currently open for consideration and actively being discussed.
 - **Awaiting Decision** — A mature and ready CAP that is ready for final deliberation by the CAP
-  Core Team. After a maximum of three meetings, a vote will take place that will set the CAP's
-  intended FCP disposition (**FCP: Acceptance/Rejection**) or go back into a **Draft** state.
-- **FCP: [Acceptance/Rejection]** — A CAP that has entered a Final Comment Period (FCP) with an
-  intended disposition. After one week has passed, during which any new concerns should be
-  addressed, the CAP will head towards its intended disposition [**Acceptance/Rejection**] or go
-  back into a Draft state.
+  Core Team. After a maximum of three meetings, a vote will take place that will move the CAP
+  to **Final Comment Period** state, or back into a **Draft** state.
+- **Final Comment Period** — A CAP that has entered a Final Comment Period with an
+  intended disposition of Acceptance or Rejection. After one week has passed, during which any new concerns should be
+  addressed, the CAP will move to **Accepted** or **Rejected** according to its intended
+  disposition, or go back into a **Draft** state.
 - **Accepted** — A CAP that has been accepted on the merits of its idea pre-implementation, and is
   ready for implementation. It is still possible that the CAP may be rejected post-implementation
   due to the issues that may arise during an initial implementation.
@@ -289,17 +289,21 @@ The protocol meetings will be used to decide on next step:
   - If the CAP requires some adjustments or needs to receive more feedback from the community, the meeting is adjourned;
   - If for any reason the CAP gets abandoned, it gets a status of `Rejected`.
 
-### Awaiting Decision -> Final Comment Period (FCP)
+### Awaiting Decision -> Final Comment Period
 - A vote will take place among the CAP Core Team.
-  - A unanimous approval from the CAP Core Team will put the CAP in a `Accepted` status.
-  - Otherwise, the CAP will be given feedback and head towards a `FCP: Rejected` status (if the
-    majority of the CAP raises concerns) or a `Draft` status (if only a minority of the CAP
-    raises concerns).
+  - A unanimous approval from the CAP Core Team will move the CAP to `Final Comment Period` with
+    an intended disposition of Acceptance.
+  - Otherwise, the CAP will be given feedback, and one of the following will occur:
+    - The CAP will move to `Final Comment Period` with an intended disposition of Rejection, 
+      documenting the reason, if the majority of the CAP Core Team raises concerns.
+    - The CAP will return to `Draft` if only a minority of the CAP Core Team raises concerns.
   - It can take upwards of 3 meetings before a disposition is reached.
 
-### FCP -> Accepted/Rejected
-- After a week of an Final Comment Period (FCP) where any major concerns that have not been
-  previously addressed can be brought up, the CAP will head to its final disposition.
+### Final Comment Period -> Accepted or Rejected
+- During the week-long Final Comment Period, anyone can bring up major concerns
+  that have not been previously addressed. If no such concerns remain at the
+  end of the period, the CAP will move to `Accepted` or `Rejected` according to
+  its intended disposition.
   - Concerns will be addressed on a case by case basis, and only major concerns that were not
     addressed earlier will move the CAP back to a `Draft` state.
 


### PR DESCRIPTION
### what 
Clarify Final Comment Period: Acceptance or Rejection in the core/README.

### why
To remove ambiguity around the status of CAPs.