### PR TITLE
📝 Inline fix most egregious typos

### DIFF
--- a/core/cap-0076.md
+++ b/core/cap-0076.md
@@ -98,7 +98,7 @@ The upgrade ledger will need to do a few hundred additional disk lookups, but th
 As mentioned in the 'Motivation' section this CAP performs modification of the ledger state that is not directly owned by the validators, which comes with the inherent risk of malicious modifications, or non-malicious erroneous modifications that lead to the further state corruption that can then be abused by the attackers.
 
 In order to resolve these concerns to some degree, and in order to ensure that the amendments only bring back the entries to their valid state, the Stellar Core build that performs the upgrade will contain the tools that allow anyone to ensure that:
-- During the replay of protocol 23 *only* the entries from [corrupted_hot_archive_entries](./../contents/cap-0076/corrupted_hot_archive_entries.csv) table are incorrectly incorrectly archived, and that their correct and archived states match those in the table
+- During the replay of protocol 23 *only* the entries from [corrupted_hot_archive_entries](./../contents/cap-0076/corrupted_hot_archive_entries.csv) table are incorrectly archived, and that their correct and archived states match those in the table
 - Ensure that *every* entry from the table has indeed been incorrectly archived  
 - Ensure that during the protocol upgrade only the entries from the table have been updated, and that the update has brought them back to the correct state
 

--- a/core/cap-0076.md
+++ b/core/cap-0076.md
@@ -72,8 +72,7 @@ Specifically, for every `ledger_key` in [corrupted_hot_archive_entries](./../con
 - An entry `E` corresponding to the `ledger_key` exists in the Hot Archive  
 - `E == archived_entry` (where `archived_entry` is the corresponding value from the corrupted_hot_archive_entries table)
 
-If the entry is amendable, then a new ledger entry with value ``correct_entry` - base64 encoded `LedgerEntry` XDR, the correct value that should have been archived (i.e. the value of the affected entry at the moment when it has been archived)
-` (from the table) will be written to the Hot Archive and thus become the most recent state of the entry that will be used for the restoration.
+If the entry is amendable, then a new ledger entry with value `correct_entry` (defined above) from the table will be written to the Hot Archive and thus become the most recent state of the entry that will be used for the restoration.
 
 Note, that since the amendment only occurs in the Hot Archive, the change will not be reflected in `LedgerCloseMeta`, as it can not contain Hot Archive changes. The change will only be observable due to the `bucketListHash` change in the upgrade ledger header. After the upgrade the amended changes will be observable at the moment of restoration (and they will have the state that matches the state they had prior to archival).
 


### PR DESCRIPTION
This cherry-picks the first two commits made in #1803 just four days after the CAP-76 draft proposal was released. In deference to https://github.com/stellar/stellar-protocol/pull/1913#issuecomment-4563869050's precedence for not updating after Final status, it can be added using a merge commit with the original commit metadata. This places the updates a full four days before the last adopting commit.

I worked well into the night to get this in as soon as possible after the bug. Even though I don't think all of it will get merged in, I really think we should do this minimum set of changes. https://github.com/stellar/stellar-protocol/pull/1803/changes/c96ca2a4eb6528602834b7f0f2d7de0e52df04b1 can be brought up separately if the maintainers want to keep that style uniform downstream.