### PR TITLE
CAP-84: don't extend muxed support to the mint function

### DIFF
--- a/core/cap-0084.md
+++ b/core/cap-0084.md
@@ -37,7 +37,7 @@ This CAP is aligned with the following Stellar Network Goals:
 
 ## Abstract
 
-A new `SC_ADDRESS_TYPE_MUXED_CONTRACT` variant is added to `SCAddress`, consisting of a contract id and a `uint64` multiplexing identifier. The existing `MuxedAddressObject` host object and its accessor host functions are generalized to represent muxed contract addresses in addition to muxed account addresses, requiring no new host functions. The Stellar Asset Contract `transfer` and `mint` functions accept a muxed contract address as the destination and emit the multiplexing identifier using the existing `to_muxed_id` event convention. A corresponding strkey encoding for muxed contract addresses is proposed here and will be defined normatively in SEP-23.
+A new `SC_ADDRESS_TYPE_MUXED_CONTRACT` variant is added to `SCAddress`, consisting of a contract id and a `uint64` multiplexing identifier. The existing `MuxedAddressObject` host object and its accessor host functions are generalized to represent muxed contract addresses in addition to muxed account addresses, requiring no new host functions. The Stellar Asset Contract `transfer` function accepts a muxed contract address as the destination and emits the multiplexing identifier using the existing `to_muxed_id` event convention. A corresponding strkey encoding for muxed contract addresses is proposed here and will be defined normatively in SEP-23.
 
 ## Specification
 
@@ -116,9 +116,9 @@ As with `SC_ADDRESS_TYPE_MUXED_ACCOUNT`, a muxed contract address is meant to su
 
 As with muxed account addresses, a contract that wants to use the muxing information on-chain can decompose the muxed contract address into its two parts using the provided host functions and store them in a user-defined data structure.
 
-#### Update the SAC `transfer` and `mint` functions to support muxed contract addresses
+#### Update the SAC `transfer` function to support muxed contract addresses
 
-The `transfer` and `mint` functions of the Stellar Asset Contract already accept an `AddressObject` or `MuxedAddressObject` for the `to` argument (see CAP-67). This CAP requires no change to the function signatures: a `MuxedAddressObject` that wraps a muxed contract address is now a valid input for the `to` argument. If a muxed contract address is passed, the function behaves as if the corresponding non-muxed contract `AddressObject` had been passed, with the only difference being the event payload as described below.
+The `transfer` function of the Stellar Asset Contract already accepts an `AddressObject` or `MuxedAddressObject` for the `to` argument (see CAP-67). This CAP requires no change to the function signature: a `MuxedAddressObject` that wraps a muxed contract address is now a valid input for the `to` argument. If a muxed contract address is passed, the function behaves as if the corresponding non-muxed contract `AddressObject` had been passed, with the only difference being the event payload as described below.
 
 #### Events
 
@@ -126,7 +126,7 @@ This CAP introduces no new event format. The `transfer` and `mint` events emitte
 
 The `transfer` event format involving a muxed contract destination is `topics: ["transfer", from:<non-muxed SCAddress>, to:<non-muxed contract SCAddress>] data: { amount: i128, to_muxed_id:u64 }`. The `mint` event format is `topics: ["mint", to:<non-muxed contract SCAddress>] data: { amount: i128, to_muxed_id:u64 }`. As with the `id` field of `MuxedContract`, `to_muxed_id` is always represented as an `SCV_U64`.
 
-A muxed contract destination can only originate from an invocation of the Stellar Asset Contract `transfer` or `mint` function, so none of the classic-to-event mapping rules in CAP-67 (such as deriving `to_muxed_id` from the transaction memo) apply to muxed contract addresses.
+A muxed contract destination can only originate from an invocation of the Stellar Asset Contract `transfer` function; a `mint` event carries a muxed contract destination only when the issuer is the source of such a `transfer`, following the issuer semantics defined in CAP-67. Consequently, none of the classic-to-event mapping rules in CAP-67 (such as deriving `to_muxed_id` from the transaction memo) apply to muxed contract addresses.
 
 #### Strkey encoding
 
@@ -148,11 +148,11 @@ Because the two host functions that operate on `MuxedAddressObject` (`get_addres
 
 ### Destination-only support
 
-This CAP only enables a muxed contract address to be used as the destination of a `transfer` or `mint`, matching CAP-67, which only emits multiplexing information for the destination (`to_muxed_id`) and never for the source of a transfer. Multiplexing the source of a transfer is not part of CAP-67 and is intentionally out of scope here; it can be added by a future CAP if a need arises.
+This CAP only enables a muxed contract address to be used as the destination of a `transfer`, matching CAP-67, which only emits multiplexing information for the destination (`to_muxed_id`) and never for the source of a transfer. Multiplexing the source of a transfer is not part of CAP-67 and is intentionally out of scope here; it can be added by a future CAP if a need arises.
 
-### Limiting scope to `transfer` and `mint`
+### Limiting scope to `transfer`
 
-The Stellar Asset Contract `transfer` and `mint` functions are the same functions that CAP-67 updated to accept a muxed account destination. Extending support to additional functions that take a destination argument, such as `transfer_from`, was considered but deferred to keep contract multiplexing symmetric with account multiplexing. Should a future need arise, support can be added by a subsequent CAP.
+The Stellar Asset Contract `transfer` function is the same function that CAP-67 updated to accept a muxed account destination. Extending support to additional functions that take a destination argument, such as `mint` and `transfer_from`, was considered but deferred to keep contract multiplexing symmetric with account multiplexing. Should a future need arise, support can be added by a subsequent CAP.
 
 ### Strkey defined in SEP-23
 
@@ -160,7 +160,7 @@ Strkey encodings are defined normatively in SEP-23, so the authoritative version
 
 ## Protocol Upgrade Transition
 
-On the protocol upgrade, the `SC_ADDRESS_TYPE_MUXED_CONTRACT` variant becomes a valid `SCAddress`, the `MuxedAddressObject` host object and its accessor host functions begin accepting muxed contract addresses, and the Stellar Asset Contract `transfer` and `mint` functions begin accepting a muxed contract address as the destination. The new host behavior uses the standard mechanism for protocol-gating, so a muxed contract address cannot be constructed or processed by the host before the protocol version that includes this CAP.
+On the protocol upgrade, the `SC_ADDRESS_TYPE_MUXED_CONTRACT` variant becomes a valid `SCAddress`, the `MuxedAddressObject` host object and its accessor host functions begin accepting muxed contract addresses, and the Stellar Asset Contract `transfer` function begins accepting a muxed contract address as the destination. The new host behavior uses the standard mechanism for protocol-gating, so a muxed contract address cannot be constructed or processed by the host before the protocol version that includes this CAP.
 
 ### Backwards Incompatibilities
 


### PR DESCRIPTION
CAP-84 said it extends CAP-67's muxed address support to contracts for both `transfer` and `mint`. But CAP-67 only added muxed support to the `transfer` function, not `mint`. Since CAP-84's goal is to extend existing functionality for parity, this scopes muxed contract support to the `transfer` function only.

The `mint` *event* is unchanged: it can still carry `to_muxed_id` when an issuer-source `transfer` targets a muxed contract destination, matching CAP-67's issuer semantics.