### PR TITLE
Move CAP-84 and CAP-86 to Accepted status

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -98,8 +98,8 @@
 | [CAP-0082](cap-0082.md) | 26 | Checked 256-bit integer arithmetic host functions | Jay Geng | Implemented |
 | [CAP-0083](cap-0083.md) | TBD | Allow validators to vote to drop the transaction set from the current ledger | Brett Boston | Accepted |
 | [CAP-0085](cap-0085.md) | TBD | Externally managed contract executables | Dmytro Kozhevin | Accepted |
-| [CAP-0084](cap-0084.md) | TBD | Muxed Contract Addresses | Jake Urban | Final Comment Period |
-| [CAP-0086](cap-0086.md) | TBD | Host functions for sparse Symbol-keyed map creation and unpacking | Dmytro Kozhevin | Final Comment Period |
+| [CAP-0084](cap-0084.md) | TBD | Muxed Contract Addresses | Jake Urban | Accepted |
+| [CAP-0086](cap-0086.md) | TBD | Host functions for sparse Symbol-keyed map creation and unpacking | Dmytro Kozhevin | Accepted |
 
 ### Draft Proposals
 | Number | Title | Author | Status |

--- a/core/cap-0084.md
+++ b/core/cap-0084.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: Jake Urban <jake@stellar.org>
     Authors: Jake Urban <jake@stellar.org>
     Consulted: Dmytro Kozhevin <@dmkozh>, Leigh McCulloch <@leighmcculloch>
-Status: Final Comment Period
+Status: Accepted
 Created: 2026-06-24
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1950
 Protocol version: 28

--- a/core/cap-0084.md
+++ b/core/cap-0084.md
@@ -10,7 +10,7 @@ Working Group:
 Status: Accepted
 Created: 2026-06-24
 Discussion: https://github.com/stellar/stellar-protocol/discussions/1950
-Protocol version: 28
+Protocol version: TBD
 ```
 
 ## Simple Summary

--- a/core/cap-0086.md
+++ b/core/cap-0086.md
@@ -5,7 +5,7 @@ Working Group:
     Owner: Dmytro Kozhevin <@dmkozh>
     Authors: Dmytro Kozhevin <@dmkozh>, Leigh McCulloch <@leighmcculloch>
     Consulted: 
-Status: Final Comment Period
+Status: Accepted
 Created: 2026-07-08
 Discussion: https://github.com/orgs/stellar/discussions/1877
 Protocol version: TBD


### PR DESCRIPTION
Move CAP-84 and CAP-86 to Accepted status since these have been approved by CAP Core Team. These two CAPs have been in Final Comment Period status for a week with no objection to them.