### PR TITLE
Update CAP-86 with more precise specification of the new functions.

### DIFF
--- a/core/cap-0086.md
+++ b/core/cap-0086.md
@@ -59,7 +59,7 @@ index fa41a862..8e8c6d14 100644
                      ],
                      "return": "MapObject",
 -                    "docs": "Return a new map initialized from a pair of equal-length arrays, one for keys and one for values, given by a pair of linear-memory addresses and a length in Vals."
-+                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Keys must be sorted in ascending order and have `Symbol` type, values may be arbitrary `Val`s. If the keys are not sorted in the ascending order, or if the arrays have different lengths, the function panics."
++                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Panics if any of the invariants above are violated."
                  },
                  {
                      "export": "a",
@@ -68,7 +68,7 @@ index fa41a862..8e8c6d14 100644
                      ],
                      "return": "Void",
 -                    "docs": "Copy Vals from `map` to the array `vals_pos`, selecting only the keys identified by the array `keys_pos`. Both arrays have `len` elements and are identified by linear-memory addresses."
-+                    "docs": "Copy all value `Val`s from `map` to the linear memory array at `vals_pos` address. Map keys must match the `Symbol` keys in the linear memory array at `keys_pos` address, keys array must be sorted in the ascending order, and both arrays and the map must have `len` elements, or else the function panics."
++                    "docs": "Copy all value `Val`s from `map` to the linear memory array at `vals_pos` address. Map keys must be of `Symbol` type and must match the key byte strings in the linear memory array at `keys_pos` address. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Keys must be sorted in ascending order. Panics if any of the invariants above are violated."
 +                },
 +                {
 +                    "export": "b",
@@ -88,7 +88,7 @@ index fa41a862..8e8c6d14 100644
 +                        }
 +                    ],
 +                    "return": "MapObject",
-+                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Keys must be sorted in ascending order and have `Symbol` type, values may be arbitrary `Val`s. Key-value pairs where the value is `Void` are skipped. If the keys are not sorted, or if the arrays have different lengths, the function panics.",
++                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Key-value pairs where the value is `Void` are not included into the final map. Panics if any of the invariants above are violated.",
 +                    "min_supported_protocol": 28
 +                },
 +                {
@@ -113,7 +113,7 @@ index fa41a862..8e8c6d14 100644
 +                        }
 +                    ],
 +                    "return": "Void",
-+                    "docs": "Copy all value `Val`s from `map` to the linear memory array at `vals_pos` address. Only map keys corresponding to the `Symbol` keys in the linear memory array at `keys_pos` address are copied, and `Void` values are written for keys not present in the map. Keys array must be sorted in the ascending order, and both arrays must have `len` elements, or else the function panics.",
++                    "docs": "Fetch value `Val`s from `map` to the linear memory array at `vals_pos` address according to the key byte strings stored in linear memory at `keys_pos`. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Keys must be sorted in ascending order. The map keys are expected to have `Symbol` type and its content bytes are matched to the input keys. If there is no matching map key, the corresponding value is set to `Void`. Panics if any of the invariants above are violated.",
 +                    "min_supported_protocol": 28
                  }
              ]
@@ -128,13 +128,23 @@ Note that the documentation changes to the existing host functions are purely co
 
 `sparse_map_new_from_linear_memory` host function fetches the `len` elements from the linear memory starting at `keys_pos` and `vals_pos` addresses, zips them into key-value pairs, and creates a new map with the fetched key-value pairs, skipping any pairs where the value is `Void`. The resulting map is returned.
 
-Keys array must consist of `Symbol` values sorted in the ascending order. Values array may contain arbitrary `Val`s. If the keys are not sorted in the ascending order (or any required element is not a `Symbol`), the function panics.
+Keys array is specified by `len` 8 byte slices consisting of the 4 byte pointer followed by 4 byte lengths (low-endian). The actual keys are byte strings identified by the slices. They must be byte strings sorted in the ascending order and must be convertible to `Symbol` type. 
+
+Values array is specified by `len` `Val`s starting at `vals_pos` address. Values may be arbitrary `Val`s.
+
+The output map will consist of key-value pairs, where the key is a `Symbol` converted from the corresponding key byte string, and the value is the corresponding `Val`. Any key-value pair where the value is `Void` is skipped and not included in the output map.
+
+The function panics if any of its invariants are violated.
 
 #### `sparse_map_unpack_to_linear_memory` function
 
-`sparse_map_unpack_to_linear_memory` host function fetches the `len` elements from the linear memory starting at `keys_pos` address, and for each key, it fetches the corresponding value from the map. If the key is not present in the map, the function writes `Void` value to the output array. The resulting values are written to the linear memory starting at `vals_pos` address, with the value at index `i` corresponding to the key at index `i`. Unlike `map_unpack_to_linear_memory`, the function does not try to verify that every key in the map has been fetched.
+`sparse_map_unpack_to_linear_memory` host function fetches the `len` elements from the linear memory starting at `keys_pos` address, and for each key, it fetches the corresponding value from the input map. If a key is not present in the map, the corresponding value is set to `Void`. The fetched values are written to the linear memory starting at `vals_pos` address.
 
-Keys array must consist of `Symbol` values sorted in the ascending order. If the keys are not sorted in the ascending order (or any required element is not a `Symbol`), the function panics.
+Keys array is specified by `len` 8 byte slices consisting of the 4 byte pointer followed by 4 byte lengths (low-endian). The actual keys are byte strings identified by the slices. They must be byte strings sorted in the ascending order. Note, that the function doesn't require that the input keys are valid `Symbol` values for the sake of optimization, but these may never be found in the map, and thus the corresponding values will always be set to `Void`.
+
+The function tries to find every key in the provided map. Map keys are expected to have `Symbol` type, and their content bytes are compared with the input keys. If a key is not present in the map, the corresponding value is set to `Void`.
+
+The function panics if any of its invariants are violated.
 
 ## Design Rationale
 

--- a/core/cap-0086.md
+++ b/core/cap-0086.md
@@ -47,7 +47,7 @@ Two new host functions are introduced: `sparse_map_new_from_linear_memory` and `
 
 ### New host functions
 
-The diff is based on commit `5538f572f1a68cb6a4bc2182e23e2f6e1ddd4520` of `rs-soroban-env`.
+The diff is based on commit `f0123830e1ee64c993139d86697454680c059cd0` of `rs-soroban-env`.
 
 ```diff mddiffcheck.ignore=true
 diff --git a/soroban-env-common/env.json b/soroban-env-common/env.json
@@ -59,7 +59,7 @@ index fa41a862..8e8c6d14 100644
                      ],
                      "return": "MapObject",
 -                    "docs": "Return a new map initialized from a pair of equal-length arrays, one for keys and one for values, given by a pair of linear-memory addresses and a length in Vals."
-+                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Panics if any of the invariants above are violated."
++                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte length. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Panics if any of the invariants above are violated."
                  },
                  {
                      "export": "a",
@@ -68,7 +68,7 @@ index fa41a862..8e8c6d14 100644
                      ],
                      "return": "Void",
 -                    "docs": "Copy Vals from `map` to the array `vals_pos`, selecting only the keys identified by the array `keys_pos`. Both arrays have `len` elements and are identified by linear-memory addresses."
-+                    "docs": "Copy all value `Val`s from `map` to the linear memory array at `vals_pos` address. Map keys must be of `Symbol` type and must match the key byte strings in the linear memory array at `keys_pos` address. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Keys must be sorted in ascending order. Panics if any of the invariants above are violated."
++                    "docs": "Copy all value `Val`s from `map` to the linear memory array at `vals_pos` address. `len` must match the number of entries in `map`. Map keys must be of `Symbol` type and must match the key byte strings in the linear memory array at `keys_pos` address. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte length. Keys must be sorted in ascending order. Panics if any of the invariants above are violated."
 +                },
 +                {
 +                    "export": "b",
@@ -88,7 +88,7 @@ index fa41a862..8e8c6d14 100644
 +                        }
 +                    ],
 +                    "return": "MapObject",
-+                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Key-value pairs where the value is `Void` are not included into the final map. Panics if any of the invariants above are violated.",
++                    "docs": "Return a new map initialized from a pair of equal `len` length arrays, one for keys and one for values, specified by linear memory addresses. Key strings are specified as `len` 8 byte slices consisting of the 4 byte pointer and 4 byte length. Actual keys must be byte strings sorted in ascending order and be convertible to `Symbol` type. Values may be arbitrary `Val`s. Key-value pairs where the value is `Void` are not included into the final map. Panics if any of the invariants above are violated.",
 +                    "min_supported_protocol": 28
 +                },
 +                {
@@ -113,7 +113,7 @@ index fa41a862..8e8c6d14 100644
 +                        }
 +                    ],
 +                    "return": "Void",
-+                    "docs": "Fetch value `Val`s from `map` to the linear memory array at `vals_pos` address according to the key byte strings stored in linear memory at `keys_pos`. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte lengths. Keys must be sorted in ascending order. The map keys are expected to have `Symbol` type and its content bytes are matched to the input keys. If there is no matching map key, the corresponding value is set to `Void`. Panics if any of the invariants above are violated.",
++                    "docs": "Fetch value `Val`s from `map` to the linear memory array at `vals_pos` address according to the key byte strings stored in linear memory at `keys_pos`. Key strings are specified as 8 byte slices consisting of the 4 byte pointer and 4 byte length. Keys must be sorted in ascending order. The map keys are expected to have `Symbol` type and its content bytes are matched to the input keys. If there is no matching map key, the corresponding value is set to `Void`. Panics if any of the invariants above are violated.",
 +                    "min_supported_protocol": 28
                  }
              ]


### PR DESCRIPTION
These functions are quite nuanced and I've missed some implementation details on the first pass (it doesn't help that the old functions have been under-specified as well). This doesn't change anything about the CAP conceptually, just clarifies the exact requirements for the function inputs.