### PR TITLE
📅 Specify exact maximum number of FCP meetings

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -293,7 +293,7 @@ The protocol meetings will be used to decide on next step:
   - Otherwise, the CAP will be given feedback and head towards a `FCP: Rejected` status (if the
     majority of the CAP raises concerns) or a `Draft` status (if only a minority of the CAP
     raises concerns).
-  - It can take upwards of 3 meetings before a disposition is reached.
+  - It can take up to 3 meetings before a disposition is reached.
 
 ### FCP -> Accepted/Rejected
 - After a week of an Final Comment Period (FCP) where any major concerns that have not been

--- a/core/README.md
+++ b/core/README.md
@@ -289,11 +289,11 @@ The protocol meetings will be used to decide on next step:
 
 ### Awaiting Decision -> Final Comment Period (FCP)
 - A vote will take place among the CAP Core Team.
-  - A unanimous approval from the CAP Core Team will put the CAP in a `Accepted` status.
+  - A unanimous approval from the CAP Core Team will put the CAP in an `Accepted` status.
   - Otherwise, the CAP will be given feedback and head towards a `FCP: Rejected` status (if the
     majority of the CAP raises concerns) or a `Draft` status (if only a minority of the CAP
     raises concerns).
-  - It can take up to 3 meetings before a disposition is reached.
+  - The team will reach a disposition within 3 meetings.
 
 ### FCP -> Accepted/Rejected
 - After a week of an Final Comment Period (FCP) where any major concerns that have not been


### PR DESCRIPTION
core/README.md L8 says **“a maximum of three meetings,”** but line 296 says **“upwards of 3 meetings,”** which usually means three or more.

