### PR TITLE
SEP-41: permit additional event topics

### DIFF
--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -313,8 +313,7 @@ and a clawback action that emits a clawback event must reduce total supply.
   no separate burn or transfer event is emitted alongside the clawback event.
 - `v0.5.0` - Document the single-value/vec and map data formats for all events,
   generalizing the form already used by `transfer` and `mint`.
-- `v0.5.1` - Clarify that implementers may emit additional topics, recommending
-  doing so as part of a SEP that documents the behavior.
+- `v0.5.1` - Clarify that implementers may emit additional topics.
 
 ## Implementations
 

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -177,8 +177,8 @@ in this SEP. Event consumers must be able to handle keys they do not recognize,
 and are expected to support both formats.
 
 Implementers may emit additional topics beyond those defined for each event.
-Any event may optionally include the asset name as an additional topic, emitted
-as a `String` after the defined topics.
+To improve interoperability, it is recommended to do so as part of a SEP that
+documents the behavior and when contracts should emit those additional topics.
 
 #### Approve Event
 

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,7 +6,7 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2026-08-03
+Updated: 2026-08-24
 Version 0.5.2
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -6,8 +6,8 @@ Title: Soroban Token Interface
 Authors: Jonathan Jove <@jonjove>, Siddharth Suresh <@sisuresh>, Simon Chow <@chowbao>, Leigh McCulloch <@leighmcculloch>
 Status: Draft
 Created: 2023-09-22
-Updated: 2026-06-08
-Version 0.5.0
+Updated: 2026-08-03
+Version 0.5.1
 Discussion: https://discord.com/channels/897514728459468821/1159937045322547250, https://github.com/stellar/stellar-protocol/discussions/1584
 ```
 
@@ -176,8 +176,8 @@ format and a map data format. The map data format encodes the event data as a
 in this SEP. Event consumers must be able to handle keys they do not recognize,
 and are expected to support both formats.
 
-Implementers may emit additional topics beyond those defined for each event.
-To improve interoperability, it is recommended to do so as part of a SEP that
+Implementers may emit additional topics beyond those defined for each event. To
+improve interoperability, it is recommended to do so as part of a SEP that
 documents the behavior and when contracts should emit those additional topics.
 
 #### Approve Event

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -176,6 +176,10 @@ format and a map data format. The map data format encodes the event data as a
 in this SEP. Event consumers must be able to handle keys they do not recognize,
 and are expected to support both formats.
 
+Implementers may emit additional topics beyond those defined for each event.
+Any event may optionally include the asset name as an additional topic, emitted
+as a `String` after the defined topics.
+
 #### Approve Event
 
 The `approve` event is emitted when the allowance is set.
@@ -309,6 +313,8 @@ and a clawback action that emits a clawback event must reduce total supply.
   no separate burn or transfer event is emitted alongside the clawback event.
 - `v0.5.0` - Document the single-value/vec and map data formats for all events,
   generalizing the form already used by `transfer` and `mint`.
+- `v0.5.1` - Clarify that implementers may emit additional topics, and that any
+  event may optionally include the asset name as an additional topic.
 
 ## Implementations
 

--- a/ecosystem/sep-0041.md
+++ b/ecosystem/sep-0041.md
@@ -313,8 +313,8 @@ and a clawback action that emits a clawback event must reduce total supply.
   no separate burn or transfer event is emitted alongside the clawback event.
 - `v0.5.0` - Document the single-value/vec and map data formats for all events,
   generalizing the form already used by `transfer` and `mint`.
-- `v0.5.1` - Clarify that implementers may emit additional topics, and that any
-  event may optionally include the asset name as an additional topic.
+- `v0.5.1` - Clarify that implementers may emit additional topics, recommending
+  doing so as part of a SEP that documents the behavior.
 
 ## Implementations
 


### PR DESCRIPTION
### What
Clarify that SEP-41 token implementers may emit additional topics beyond those defined, and recommend that any such extension be standardized in its own SEP for interoperability.

### Why
The spec was silent on whether implementers could extend events with extra topics, leaving consumers uncertain about what to expect and discouraging interoperable extensions. Whilst I always took this to be an assumption in the ecosystem for any contract SEP, it's become apparent in conversations that was not their assumption. SEP-41 is an important enough standard this should be documented explicitly.

Note that this is not changed behaviour, but rather capturing existing behaviour already playing out in the ecosystem.

### Discussion

- https://github.com/stellar/stellar-protocol/discussions/1995