### PR TITLE
Replace anchor validator link with github repo

### DIFF
--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -224,7 +224,7 @@ applicable fields, and exclude any that don't apply.
 
 ### Tools
 
-Use the Stellar [Anchor Validator](https://anchor-tests.stellar.org/) or the
+Use the Stellar [Anchor Validator](https://github.com/stellar/stellar-anchor-tests/) or the
 community-supported [`stellar.toml` checker](https://stellar.sui.li) to
 validate your info file.
 

--- a/ecosystem/sep-0001.md
+++ b/ecosystem/sep-0001.md
@@ -224,7 +224,8 @@ applicable fields, and exclude any that don't apply.
 
 ### Tools
 
-Use the Stellar [Anchor Validator](https://github.com/stellar/stellar-anchor-tests/) or the
+Use the Stellar
+[Anchor Validator](https://github.com/stellar/stellar-anchor-tests/) or the
 community-supported [`stellar.toml` checker](https://stellar.sui.li) to
 validate your info file.
 


### PR DESCRIPTION
anchor-tests.stellar.org was taken down due to no usage. Links now point to the GitHub repo, where users can still verify their anchors by running the suite locally.