### PR TITLE
🔄 Modernize the Conditions to Change the Protocol

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -16,8 +16,9 @@
   due to the issues that may arise during an initial implementation.
 - **Implemented** - A CAP that has been implemented with the protocol version specified in the CAP,
   and whose [exit criteria](../cap-template.md#exit-criteria) have been met. It will graduate to
-  **Final** when it has been formally accepted by a majority of validators (nodes) on the network.
-- **Final** — A CAP that has been accepted by a majority of validators (nodes) on the network.
+  **Final** when it has been formally accepted by a Stellar Consensus Protocol (SCP) quorum of
+  validators (nodes) on the network.
+- **Final** — A CAP that has been accepted by an SCP quorum of validators (nodes) on the network.
   Final CAPs can be updated only to follow procedure, add implementation considerations, or correct
   errata (such as typos).
 
@@ -324,8 +325,8 @@ issues arise, a CAP team member moves it to **Implemented**.
 ### CAP Finalization
 
 Once an implemented CAP has been released in a specified version, the CAP should be updated with
-the protocol version that the implementation targets. From there, once a majority of validators on
-the network have accepted the implementation, it will move to **Final**.
+the protocol version that the implementation targets. From there, once an SCP quorum of validators
+on the network has accepted the implementation, it will move to **Final**.
 
 ## CAP Team Members
 

--- a/core/README.md
+++ b/core/README.md
@@ -58,14 +58,14 @@
 | [CAP-0038](cap-0038.md) | 18 | Automated Market Makers | Jonathan Jove | Final |
 | [CAP-0040](cap-0040.md) | 19 | Ed25519 Signed Payload Signer for Transaction Signature Disclosure | Leigh McCulloch | Final |
 | [CAP-0042](cap-0042.md) | - | Multi-Part Transaction Sets | Nicolas Barry | Final |
-| [CAP-0046](cap-0046.md) | 20 |Soroban smart contract system overview | Graydon Hoare | Final |
+| [CAP-0046](cap-0046.md) | 20 | Soroban smart contract system overview | Graydon Hoare | Final |
 | [CAP-0046-01 (formerly 0046)](cap-0046-01.md) | 20 | WebAssembly Smart Contract Runtime Environment | Graydon Hoare | Final |
 | [CAP-0046-02 (formerly 0047)](cap-0046-02.md) | 20 | Smart Contract Lifecycle | Siddharth Suresh | Final |
 | [CAP-0046-03 (formerly 0051)](cap-0046-03.md) | 20 | Smart Contract Host Functions | Jay Geng | Final |
 | [CAP-0046-05 (formerly 0053)](cap-0046-05.md) | 20 | Smart Contract Data | Graydon Hoare | Final |
 | [CAP-0046-06 (formerly 0054)](cap-0046-06.md) | 20 | Smart Contract Standardized Asset | Jonathan Jove | Final |
 | [CAP-0046-07 (formerly 0055)](cap-0046-07.md) | 20 | Fee model in smart contracts | Nicolas Barry | Final |
-| [CAP-0046-08 (formerly 0056)](cap-0046-08.md) | 20 |Smart Contract Logging | Siddharth Suresh | Final |
+| [CAP-0046-08 (formerly 0056)](cap-0046-08.md) | 20 | Smart Contract Logging | Siddharth Suresh | Final |
 | [CAP-0046-09](cap-0046-09.md) | 20 | Network Configuration Ledger Entries | Dmytro Kozhevin | Final |
 | [CAP-0046-10](cap-0046-10.md) | 20 | Smart Contract Budget Metering | Jay Geng | Final |
 | [CAP-0046-11](cap-0046-11.md) | 20 | Soroban Authorization Framework | Dmytro Kozhevin | Final |

--- a/core/README.md
+++ b/core/README.md
@@ -17,8 +17,9 @@
 - **Implemented** - A CAP that has been implemented with the protocol version specified in the CAP,
   and whose [exit criteria](../cap-template.md#exit-criteria) have been met. It will graduate to
   **Final** when it has been formally accepted by a majority of validators (nodes) on the network.
-- **Final** — A CAP that has been accepted by a majority of validators (nodes) on the network. A
-  final CAP should only be updated to correct errata or for procedural updates.
+- **Final** — A CAP that has been accepted by a majority of validators (nodes) on the network.
+  Final CAPs can be updated only to follow procedure, add implementation considerations, or correct
+  errata (such as typos).
 
 ### Additional Statuses
 - **Rejected** - A CAP that has been formally rejected by the CAP Core Team, and will not be

--- a/core/README.md
+++ b/core/README.md
@@ -18,7 +18,7 @@
   and whose [exit criteria](../cap-template.md#exit-criteria) have been met. It will graduate to
   **Final** when it has been formally accepted by a majority of validators (nodes) on the network.
 - **Final** — A CAP that has been accepted by a majority of validators (nodes) on the network. A
-  final CAP should only be updated to correct errata.
+  final CAP should only be updated to correct errata or for procedural updates.
 
 ### Additional Statuses
 - **Rejected** - A CAP that has been formally rejected by the CAP Core Team, and will not be


### PR DESCRIPTION
Much of the policy checks in this doc were written 7 years ago in #247. Since then, the Foundation and community have come a long way. Except d9501c2e7993390ae233d847468d6b1dc1c801a8, this PR strictly changes lines from [there](https://github.com/user-attachments/files/31490134/stellar-protocol-readme-rename-diff.pdf) and #279, made 2 weeks later.

Recently, Jay Geng did an awesome job updating his CAP for both implementation and technical details in https://github.com/stellar/stellar-protocol/pull/1996/changes/2bd050664b910f2d978a248b9e399a436b60e70e. I really appreciate seeing the CAP author go back and enrich the explanation of their changes. Jay made complex changes that are way above my head, providing new specifications and concepts for anyone to explore going forward.

But not everyone is as smart as the Core devs. And certainly few have the experience to just look at the codebase and immediately understand how it works. Tomer once called it a complex spider web of interconnected functionality.

Most of my constituents fall into this group. Many of them want to understand the network, and they just need a place to start. This is difficult when many repos use direct commits to main with little or no descriptions despite substantial changes.

The CAPs solve this problem. They provide anyone a clear, ordered changelog of how the network grew over time. They link to the concentrated technical discussions, express _why_ a specific person or team suggested a change, and give a clear audit log of progress to completion.

In my last years writing over 100 PRs for the Docs, I have relied substantially on the CAPs when they relate to changes I need to document. Namely, I have promised my regulators specific protocol-level transactional specifications of claimable balances, in relation to the use case discussed in https://github.com/orgs/stellar/discussions/1504. As such, I have been working a lot with CAP-23.

CAP-23 [proposes](https://github.com/stellar/stellar-protocol/blob/8912a8047931453bb5d6a631e10a9d7125c570f3/core/cap-0023.md?plain=1#L222) the new XDR `OperationID` as the preimage union used to find the `ClaimableBalanceID`. This matters for us because regulators specifically requested improvements in our management and indexing of claimable-balance IDs. However, the final implementation [uses](https://github.com/stellar/stellar-xdr/blob/96cbfc3709bac1ff2d8a229cfa0267a4f260d337/Stellar-transaction.x#L723) a union called `HashIDPreimage`, whereas the operation ID is actually a struct.

When I updated the CAP's footnote in 2024 to explain the precomputation and XDR resolution, I mistakenly [referenced](https://github.com/stellar/stellar-protocol/blob/8912a8047931453bb5d6a631e10a9d7125c570f3/core/cap-0023.md?plain=1#L353) this final union given my reading of the spec that the union was the preimage. This is incorrect, and in fact the hex of the hash which contains the struct is only a part of the final ID downstream. I forgot to include the type discriminant.


My mistake should not sully the otherwise very well-written CAPs. And there's nothing wrong with addressing an issue like in CAP-75 when reality diverges from the proposal due to implementation. As such, I propose these changes to clarify the amendment process.

First, I've expanded the edit circumstances from just errata to also include procedural and implementation adjustments. The CAPs [can already](https://github.com/stellar/stellar-protocol/blob/8912a8047931453bb5d6a631e10a9d7125c570f3/core/README.md?plain=1#L26-L27) be adjusted in title meta when they are superseded. This first section makes that carveout explicit and public.

It can also be used for cleanups like https://github.com/stellar/stellar-protocol/pull/1803/changes/c96ca2a4eb6528602834b7f0f2d7de0e52df04b1, which was not merged in. This update applies the following linking convention, which we also have in the Docs. Outside contributions make these cleanups a breeze while preserving the great specific files referenced by the author.

https://github.com/stellar/stellar-protocol/blob/8912a8047931453bb5d6a631e10a9d7125c570f3/core/README.md?plain=1#L232-L235

Next is the main improvement, with changes based on the implementation. This stops the CAP from aging and diverging from Core, like what misled me into many hours of wasted time concluding the final discrepancy. It's not a place to renegotiate the intent of an Accepted proposal, just to clearly state real specs.

The CAPs were my starting place for understanding Stellar so many years ago, and I'm not the only one who looks to them for inspiration and explanation. The incredible Tupui [recently released](https://x.com/JFWooten4/status/2089944082629951586) a frontend reader that organizes and formats the protocol improvements by fetching this repository. I would like to see it incorporated into the Docs, which refer to the CAPs voluminously.

I can't tell you how many times I've searched specifically for the GitHub links here to draft a proposal or explain an idea. They've been the basis of many compliance explanations, and I want to see them keep improving over time. There are also future concepts like https://github.com/stellar/stellar-docs/issues/1545#issuecomment-4963489642, which the SDF's own documentation expert Elliot recommended I record here.

A network reflects the infrastructure it's built on. And I want Stellar to be as perfect as possible. By working together on these specs, we give newcomers clear and accurate direction to deploy and improve the protocol.

I'm sorry for the mistakes I've made, like this or adding new content in a merge commit. I believe very much in what we can do here since most of the implementation authors in Core are the CAP owners anyway. There are only a few exceptions like 29, where it might take a little more analysis from contributors.

Lastly, I make a correctness change since consensus comes from an SCP quorum rather than a simple majority for liveness approval. I hope that we can come to quorum on a reasonable path forward where we communicate about proposed changes and issues so that everyone ends up better. The community wants to help and spread protocol adoption if you will only let us be part of the upgrades. We can only provide big leaps in the future if we're allowed to merge tiny interactions to get our footing.
