### PR TITLE
Add New CAP Proposal workflow

### DIFF
--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -103,7 +103,7 @@ jobs:
               '',
               `> ⚠️ **Never pre-allocate a CAP number in your PR.** Name your file \`cap-TBD.md\` and use \`TBD\` for the protocol version — a maintainer will assign the number on merge, as described in [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
               '',
-              `For details on what each CAP status (Draft, FCP, Accepted, Final, …) means, see [CAP Status Terms](${readmeUrl}#cap-status-terms).`,
+              `For details on what each CAP status (Pre-Draft, Draft, FCP, Accepted, Final, …) means, see [CAP Status Terms](${readmeUrl}#cap-status-terms).`,
               '',
               'Thanks for helping improve the Stellar protocol! 🚀',
             ].join('\n');

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -1,0 +1,151 @@
+name: 'New CAP Proposal'
+
+# When a PR adds a new file to the core/ directory it is likely proposing a
+# new CAP. New ideas are meant to start as a GitHub Discussion rather than a PR,
+# so this workflow locks the PR, converts it to a draft, and explains the
+# process to the author.
+#
+# Uses pull_request_target so the GITHUB_TOKEN has write access even for PRs
+# opened from forks. No untrusted PR code is checked out or executed; the job
+# only inspects the list of changed files via the API.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - 'core/**'
+
+permissions:
+  issues: write
+  # write is required to convert the PR to a draft (the GraphQL
+  # convertPullRequestToDraft mutation); listing changed files only needs read.
+  pull-requests: write
+
+jobs:
+  new-cap-proposal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock PR and explain CAP proposal process
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            // Find files added (not just modified) under core/.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+
+            const newCapFiles = files.filter(
+              (f) =>
+                f.status === 'added' &&
+                f.filename.startsWith('core/') &&
+                f.filename.endsWith('.md') &&
+                f.filename !== 'core/README.md'
+            );
+
+            if (newCapFiles.length === 0) {
+              core.info('No new files added under core/; nothing to do.');
+              return;
+            }
+
+            // Idempotency guard: if guidance has already been posted on this PR,
+            // do nothing. This avoids duplicate comments and re-lock errors when
+            // the workflow fires again (e.g. on reopened), and avoids re-locking
+            // a PR that a maintainer has deliberately unlocked. Only markers
+            // authored by the workflow itself count, so a PR participant cannot
+            // suppress the guidance by posting the marker.
+            const marker = '<!-- new-cap-proposal-guidance -->';
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pull_number, per_page: 100 }
+            );
+            if (
+              existingComments.some(
+                (c) =>
+                  c.user?.login === 'github-actions[bot]' &&
+                  c.body &&
+                  c.body.includes(marker)
+              )
+            ) {
+              core.info('CAP proposal guidance already posted; nothing to do.');
+              return;
+            }
+
+            // Link to the CAP process docs in core/README.md, anchored to the
+            // specific sections that explain the flow and statuses.
+            const defaultBranch = context.payload.repository.default_branch;
+            const readmeUrl = `https://github.com/${owner}/${repo}/blob/${defaultBranch}/core/README.md`;
+            const discussionsUrl =
+              'https://github.com/stellar/stellar-protocol/discussions';
+            const mailingListUrl =
+              'https://groups.google.com/forum/#!forum/stellar-dev';
+
+            const body = [
+              marker,
+              '👋 Thanks for your contribution!',
+              '',
+              'It looks like this PR is proposing a **new CAP** — it adds the following new file(s) to the `core/` directory:',
+              '',
+              ...newCapFiles.map((f) => `- \`${f.filename}\``),
+              '',
+              `New CAP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`,
+              '',
+              '### How the CAP process works',
+              '',
+              `1. 💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`,
+              '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion until it is ready to become a draft. See [Creating a CAP Draft](' + readmeUrl + '#creating-a-cap-draft).',
+              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.',
+              '',
+              `> ⚠️ **Never pre-allocate a CAP number in your PR.** Name your file \`cap-TBD.md\` and use \`TBD\` for the protocol version — a maintainer will assign the number on merge, as described in [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
+              '',
+              `For details on what each CAP status (Draft, FCP, Accepted, Final, …) means, see [CAP Status Terms](${readmeUrl}#cap-status-terms).`,
+              '',
+              'Thanks for helping improve the Stellar protocol! 🚀',
+            ].join('\n');
+
+            // Perform the side effects (lock, convert to draft) BEFORE posting the
+            // guidance comment. The comment carries the idempotency marker that the
+            // guard above checks, so it must be the last step: if locking or the
+            // draft conversion fails, no marker is left behind and a rerun or
+            // reopened event will retry the whole sequence instead of short-circuiting
+            // on the marker with the PR left unlocked or not a draft.
+            await github.rest.issues.lock({
+              owner,
+              repo,
+              issue_number: pull_number,
+              lock_reason: 'resolved',
+            });
+
+            // Convert the PR to a draft so it is clearly not ready to merge while
+            // the idea is discussed. There is no REST endpoint for this, so use the
+            // GraphQL convertPullRequestToDraft mutation. Already-draft PRs are left
+            // as-is. node_id is the PR's GraphQL global ID from the event payload.
+            if (context.payload.pull_request.draft) {
+              core.info('PR is already a draft; skipping draft conversion.');
+            } else {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest { isDraft }
+                  }
+                }`,
+                { pullRequestId: context.payload.pull_request.node_id }
+              );
+              core.info(`Converted PR #${pull_number} to a draft.`);
+            }
+
+            // Post the guidance comment last; its marker records that the sequence
+            // completed so the guard above can skip subsequent runs.
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pull_number,
+              body,
+            });
+
+            core.info(`Locked PR #${pull_number} and posted the CAP proposal guidance.`);

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -103,7 +103,7 @@ jobs:
               '',
               `> ⚠️ **Never pre-allocate a CAP number in your PR.** Name your file \`cap-TBD.md\` and use \`TBD\` for the protocol version — a maintainer will assign the number on merge, as described in [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
               '',
-              `For details on what each CAP status (Pre-Draft, Draft, FCP, Accepted, Final, …) means, see [CAP Status Terms](${readmeUrl}#cap-status-terms).`,
+              `For details on what each CAP status (Draft, FCP, Accepted, Final, …) means, see [CAP Status Terms](${readmeUrl}#cap-status-terms).`,
               '',
               'Thanks for helping improve the Stellar protocol! 🚀',
             ].join('\n');

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -60,10 +60,11 @@ jobs:
             }
 
             // An author who links an existing Stellar discussion in their CAP has
-            // already followed the discussion-first process, so their PR is left
-            // unlocked and not converted to a draft; the guidance comment is still
-            // posted, since the rest of it (how numbering works, what the statuses
-            // mean) applies either way. Match a link to a specific discussion (a
+            // already followed the discussion-first process, so their PR is not
+            // converted to a draft. It is still locked, to keep the conversation in
+            // the discussion, and the guidance comment is still posted, since the
+            // rest of it (how numbering works, what the statuses mean) applies
+            // either way. Match a link to a specific discussion (a
             // discussion number), in either of the forms real CAPs use, anywhere in
             // the file — most put it on the preamble's Discussion line, but some
             // reference it in the body instead.
@@ -97,7 +98,7 @@ jobs:
             const hasDiscussion = linked.length === newCapFiles.length;
             if (hasDiscussion) {
               core.info(
-                `Every new CAP links an existing discussion (${linked.join(', ')}); leaving the PR unlocked and not a draft.`
+                `Every new CAP links an existing discussion (${linked.join(', ')}); skipping the draft conversion.`
               );
             }
 
@@ -134,12 +135,12 @@ jobs:
               'https://groups.google.com/forum/#!forum/stellar-dev';
 
             const intro = hasDiscussion
-              ? `Thanks for linking an existing discussion for this CAP — I have left this PR open and as-is. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`
+              ? `Thanks for linking an existing discussion for this CAP — I have **locked this PR** so the conversation stays in that discussion, but left it as-is otherwise. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`
               : `New CAP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`;
 
             // The discussion step is dropped for a CAP that already links one, and
-            // the merge step only mentions unlocking and marking ready for review
-            // when this run actually locked and drafted the PR.
+            // the merge step only asks the author to mark the PR ready for review
+            // when this run actually converted it to a draft.
             const steps = [];
             if (!hasDiscussion) {
               steps.push(
@@ -151,7 +152,7 @@ jobs:
                 hasDiscussion ? 'your discussion' : 'that discussion'
               } until it is ready to become a draft. See [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
               hasDiscussion
-                ? '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your discussion asking for it to be merged. A maintainer will then review it for formatting, **assign a CAP number**, and merge it.'
+                ? '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
                 : '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
             );
 
@@ -182,31 +183,32 @@ jobs:
             // draft conversion fails, no marker is left behind and a rerun or
             // reopened event will retry the whole sequence instead of short-circuiting
             // on the marker with the PR left unlocked or not a draft.
-            if (!hasDiscussion) {
-              await github.rest.issues.lock({
-                owner,
-                repo,
-                issue_number: pull_number,
-                lock_reason: 'resolved',
-              });
+            await github.rest.issues.lock({
+              owner,
+              repo,
+              issue_number: pull_number,
+              lock_reason: 'resolved',
+            });
 
-              // Convert the PR to a draft so it is clearly not ready to merge while
-              // the idea is discussed. There is no REST endpoint for this, so use the
-              // GraphQL convertPullRequestToDraft mutation. Already-draft PRs are left
-              // as-is. node_id is the PR's GraphQL global ID from the event payload.
-              if (context.payload.pull_request.draft) {
-                core.info('PR is already a draft; skipping draft conversion.');
-              } else {
-                await github.graphql(
-                  `mutation($pullRequestId: ID!) {
-                    convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
-                      pullRequest { isDraft }
-                    }
-                  }`,
-                  { pullRequestId: context.payload.pull_request.node_id }
-                );
-                core.info(`Converted PR #${pull_number} to a draft.`);
-              }
+            // Convert the PR to a draft so it is clearly not ready to merge while
+            // the idea is discussed. A CAP that already links a discussion is left
+            // out of draft. There is no REST endpoint for this, so use the GraphQL
+            // convertPullRequestToDraft mutation. Already-draft PRs are left as-is.
+            // node_id is the PR's GraphQL global ID from the event payload.
+            if (hasDiscussion) {
+              core.info('CAP links an existing discussion; skipping draft conversion.');
+            } else if (context.payload.pull_request.draft) {
+              core.info('PR is already a draft; skipping draft conversion.');
+            } else {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                    pullRequest { isDraft }
+                  }
+                }`,
+                { pullRequestId: context.payload.pull_request.node_id }
+              );
+              core.info(`Converted PR #${pull_number} to a draft.`);
             }
 
             // Post the guidance comment last; its marker records that the sequence
@@ -218,8 +220,4 @@ jobs:
               body,
             });
 
-            core.info(
-              hasDiscussion
-                ? `Posted the CAP proposal guidance on PR #${pull_number}.`
-                : `Locked PR #${pull_number} and posted the CAP proposal guidance.`
-            );
+            core.info(`Locked PR #${pull_number} and posted the CAP proposal guidance.`);

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -138,15 +138,16 @@ jobs:
               ? `Thanks for linking an existing discussion for this CAP — I have **locked this PR** so the conversation stays in that discussion, but left it as-is otherwise. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`
               : `New CAP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`;
 
-            // The discussion step is dropped for a CAP that already links one, and
-            // the merge step only asks the author to mark the PR ready for review
-            // when this run actually converted it to a draft.
+            // The discussion step stays in the list for a CAP that already links
+            // one, struck through and ticked off, so the numbered steps still read
+            // as the whole process. The merge step only asks the author to mark the
+            // PR ready for review when this run actually converted it to a draft.
+            const startDiscussion = `💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`;
+
             const steps = [];
-            if (!hasDiscussion) {
-              steps.push(
-                `💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`
-              );
-            }
+            steps.push(
+              hasDiscussion ? `~~${startDiscussion}~~ ✅` : startDiscussion
+            );
             steps.push(
               `🤝 **Collaborate.** Iterate on the proposal with the community in ${
                 hasDiscussion ? 'your discussion' : 'that discussion'

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -140,8 +140,7 @@ jobs:
 
             // The discussion step stays in the list for a CAP that already links
             // one, struck through and ticked off, so the numbered steps still read
-            // as the whole process. The merge step only asks the author to mark the
-            // PR ready for review when this run actually converted it to a draft.
+            // as the whole process.
             const startDiscussion = `💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`;
 
             const steps = [];
@@ -152,9 +151,7 @@ jobs:
               `🤝 **Collaborate.** Iterate on the proposal with the community in ${
                 hasDiscussion ? 'your discussion' : 'that discussion'
               } until it is ready to become a draft. See [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
-              hasDiscussion
-                ? '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
-                : '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
+              '✅ **Mark it ready to merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR as ready for review. That is the indicator to maintainers that it is ready to be merged: a maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
             );
 
             const body = [

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -6,8 +6,11 @@ name: 'New CAP Proposal'
 # process to the author.
 #
 # Uses pull_request_target so the GITHUB_TOKEN has write access even for PRs
-# opened from forks. No untrusted PR code is checked out or executed; the job
-# only inspects the list of changed files via the API.
+# opened from forks. It is critical that this job never checks out or executes
+# untrusted PR data: it inspects the list of changed files via the API and
+# fetches the added CAP's contents at the PR head only to regex it for a
+# discussion link. That content is never checked out, executed, or interpolated
+# anywhere.
 
 on:
   pull_request_target:
@@ -16,6 +19,9 @@ on:
       - 'core/**'
 
 permissions:
+  # read is required to fetch the added CAP's contents at the PR head;
+  # declaring permissions sets every omitted scope to none.
+  contents: read
   issues: write
   # write is required to convert the PR to a draft (the GraphQL
   # convertPullRequestToDraft mutation); listing changed files only needs read.
@@ -50,6 +56,46 @@ jobs:
 
             if (newCapFiles.length === 0) {
               core.info('No new files added under core/; nothing to do.');
+              return;
+            }
+
+            // An author who links an existing Stellar discussion in their CAP has
+            // already followed the discussion-first process, so leave their PR
+            // alone. Match a link to a specific discussion (a discussion number),
+            // in either of the forms real CAPs use, anywhere in the file — most
+            // put it on the preamble's Discussion line, but some reference it in
+            // the body instead.
+            const discussionLink =
+              /https:\/\/github\.com\/(?:orgs\/stellar|stellar\/stellar-protocol)\/discussions\/\d+/;
+
+            // Read at the PR head, since a new CAP does not exist at the base.
+            // This is untrusted PR content: it is only regexed below, never
+            // checked out, executed, or interpolated. If a fetch fails, treat the
+            // file as having no link so the guidance below still runs.
+            const headSha = context.payload.pull_request.head.sha;
+            const linked = [];
+            for (const f of newCapFiles) {
+              let content = '';
+              try {
+                const res = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: f.filename,
+                  ref: headSha,
+                });
+                content = Buffer.from(res.data.content, 'base64').toString('utf8');
+              } catch (e) {
+                core.info(`Could not read ${f.filename} at ${headSha}: ${e.message}`);
+              }
+              if (discussionLink.test(content)) {
+                linked.push(f.filename);
+              }
+            }
+
+            if (linked.length === newCapFiles.length) {
+              core.info(
+                `Every new CAP links an existing discussion (${linked.join(', ')}); nothing to do.`
+              );
               return;
             }
 

--- a/.github/workflows/new-cap-proposal.yml
+++ b/.github/workflows/new-cap-proposal.yml
@@ -60,11 +60,13 @@ jobs:
             }
 
             // An author who links an existing Stellar discussion in their CAP has
-            // already followed the discussion-first process, so leave their PR
-            // alone. Match a link to a specific discussion (a discussion number),
-            // in either of the forms real CAPs use, anywhere in the file — most
-            // put it on the preamble's Discussion line, but some reference it in
-            // the body instead.
+            // already followed the discussion-first process, so their PR is left
+            // unlocked and not converted to a draft; the guidance comment is still
+            // posted, since the rest of it (how numbering works, what the statuses
+            // mean) applies either way. Match a link to a specific discussion (a
+            // discussion number), in either of the forms real CAPs use, anywhere in
+            // the file — most put it on the preamble's Discussion line, but some
+            // reference it in the body instead.
             const discussionLink =
               /https:\/\/github\.com\/(?:orgs\/stellar|stellar\/stellar-protocol)\/discussions\/\d+/;
 
@@ -92,11 +94,11 @@ jobs:
               }
             }
 
-            if (linked.length === newCapFiles.length) {
+            const hasDiscussion = linked.length === newCapFiles.length;
+            if (hasDiscussion) {
               core.info(
-                `Every new CAP links an existing discussion (${linked.join(', ')}); nothing to do.`
+                `Every new CAP links an existing discussion (${linked.join(', ')}); leaving the PR unlocked and not a draft.`
               );
-              return;
             }
 
             // Idempotency guard: if guidance has already been posted on this PR,
@@ -131,6 +133,28 @@ jobs:
             const mailingListUrl =
               'https://groups.google.com/forum/#!forum/stellar-dev';
 
+            const intro = hasDiscussion
+              ? `Thanks for linking an existing discussion for this CAP — I have left this PR open and as-is. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`
+              : `New CAP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`;
+
+            // The discussion step is dropped for a CAP that already links one, and
+            // the merge step only mentions unlocking and marking ready for review
+            // when this run actually locked and drafted the PR.
+            const steps = [];
+            if (!hasDiscussion) {
+              steps.push(
+                `💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`
+              );
+            }
+            steps.push(
+              `🤝 **Collaborate.** Iterate on the proposal with the community in ${
+                hasDiscussion ? 'your discussion' : 'that discussion'
+              } until it is ready to become a draft. See [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
+              hasDiscussion
+                ? '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, post in your discussion asking for it to be merged. A maintainer will then review it for formatting, **assign a CAP number**, and merge it.'
+                : '✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.'
+            );
+
             const body = [
               marker,
               '👋 Thanks for your contribution!',
@@ -139,13 +163,11 @@ jobs:
               '',
               ...newCapFiles.map((f) => `- \`${f.filename}\``),
               '',
-              `New CAP ideas start as a **discussion**, not a pull request, so I have **locked this PR and marked it as a draft** for now. The full process, including how CAP statuses work, is documented in the [CAP Contribution Process](${readmeUrl}#contribution-process).`,
+              intro,
               '',
               '### How the CAP process works',
               '',
-              `1. 💬 **Start a discussion.** Per [Pre-CAP (Initial Discussion)](${readmeUrl}#pre-cap-initial-discussion), discussion for new ideas happens on the [stellar-dev mailing list](${mailingListUrl}) or [GitHub Discussions](${discussionsUrl}). Please introduce your idea there so people in the Stellar ecosystem can collaborate on it.`,
-              '2. 🤝 **Collaborate.** Iterate on the proposal with the community in that discussion until it is ready to become a draft. See [Creating a CAP Draft](' + readmeUrl + '#creating-a-cap-draft).',
-              '3. ✅ **Request a merge.** Once the proposal has been collaborated on by other people in the Stellar ecosystem, mark this PR ready for review and then post in your discussion asking for it to be merged. A maintainer will then unlock this PR, review it for formatting, **assign a CAP number**, and merge it.',
+              ...steps.map((step, i) => `${i + 1}. ${step}`),
               '',
               `> ⚠️ **Never pre-allocate a CAP number in your PR.** Name your file \`cap-TBD.md\` and use \`TBD\` for the protocol version — a maintainer will assign the number on merge, as described in [Creating a CAP Draft](${readmeUrl}#creating-a-cap-draft).`,
               '',
@@ -160,29 +182,31 @@ jobs:
             // draft conversion fails, no marker is left behind and a rerun or
             // reopened event will retry the whole sequence instead of short-circuiting
             // on the marker with the PR left unlocked or not a draft.
-            await github.rest.issues.lock({
-              owner,
-              repo,
-              issue_number: pull_number,
-              lock_reason: 'resolved',
-            });
+            if (!hasDiscussion) {
+              await github.rest.issues.lock({
+                owner,
+                repo,
+                issue_number: pull_number,
+                lock_reason: 'resolved',
+              });
 
-            // Convert the PR to a draft so it is clearly not ready to merge while
-            // the idea is discussed. There is no REST endpoint for this, so use the
-            // GraphQL convertPullRequestToDraft mutation. Already-draft PRs are left
-            // as-is. node_id is the PR's GraphQL global ID from the event payload.
-            if (context.payload.pull_request.draft) {
-              core.info('PR is already a draft; skipping draft conversion.');
-            } else {
-              await github.graphql(
-                `mutation($pullRequestId: ID!) {
-                  convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
-                    pullRequest { isDraft }
-                  }
-                }`,
-                { pullRequestId: context.payload.pull_request.node_id }
-              );
-              core.info(`Converted PR #${pull_number} to a draft.`);
+              // Convert the PR to a draft so it is clearly not ready to merge while
+              // the idea is discussed. There is no REST endpoint for this, so use the
+              // GraphQL convertPullRequestToDraft mutation. Already-draft PRs are left
+              // as-is. node_id is the PR's GraphQL global ID from the event payload.
+              if (context.payload.pull_request.draft) {
+                core.info('PR is already a draft; skipping draft conversion.');
+              } else {
+                await github.graphql(
+                  `mutation($pullRequestId: ID!) {
+                    convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+                      pullRequest { isDraft }
+                    }
+                  }`,
+                  { pullRequestId: context.payload.pull_request.node_id }
+                );
+                core.info(`Converted PR #${pull_number} to a draft.`);
+              }
             }
 
             // Post the guidance comment last; its marker records that the sequence
@@ -194,4 +218,8 @@ jobs:
               body,
             });
 
-            core.info(`Locked PR #${pull_number} and posted the CAP proposal guidance.`);
+            core.info(
+              hasDiscussion
+                ? `Posted the CAP proposal guidance on PR #${pull_number}.`
+                : `Locked PR #${pull_number} and posted the CAP proposal guidance.`
+            );

--- a/cap-template.md
+++ b/cap-template.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: <Person accountable for the CAP - name/email address/github alias>
     Authors: <List of comma separated name/email address/github alias>
     Consulted: <List of comma separated name/email address/github alias>
-Status: Pre-Draft
+Status: Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 Discussion: <link to where discussion for this CAP is taking place, typically the mailing list>
 Protocol version: TBD

--- a/cap-template.md
+++ b/cap-template.md
@@ -7,7 +7,7 @@ Working Group:
     Owner: <Person accountable for the CAP - name/email address/github alias>
     Authors: <List of comma separated name/email address/github alias>
     Consulted: <List of comma separated name/email address/github alias>
-Status: Draft
+Status: Pre-Draft
 Created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 Discussion: <link to where discussion for this CAP is taking place, typically the mailing list>
 Protocol version: TBD

--- a/core/README.md
+++ b/core/README.md
@@ -218,8 +218,7 @@ Introduce your idea on the [stellar-dev mailing list](https://groups.google.com/
 
 [GitHub Discussions]: https://github.com/stellar/stellar-protocol/discussions
 
-- New ideas start as a discussion, not a pull request. A PR that adds a new CAP before the idea has
-  been discussed will be locked and marked as a draft, with a pointer back to this process.
+- New ideas start as a discussion, not a pull request.
 - Make sure to gather feedback and alternative ideas — it's useful before putting together a
   formal draft!
 - Consider contacting experts in a particular area for feedback while you're hashing out the

--- a/core/README.md
+++ b/core/README.md
@@ -3,8 +3,6 @@
 ## CAP Status Terms
 
 ### Primary Workflow
-- **Pre-Draft** — A CAP whose idea is being discussed and whose PR has not yet been merged. A
-  maintainer moves it to **Draft** when assigning its CAP number and merging.
 - **Draft** — A CAP that is currently open for consideration and actively being discussed.
 - **Awaiting Decision** — A mature and ready CAP that is ready for final deliberation by the CAP
   Core Team. After a maximum of three meetings, a vote will take place that will set the CAP's
@@ -234,7 +232,6 @@ repository. You should make sure to adhere to the following:
 - Your CAP should be named `cap-TBD.md`
 - Do not self-assign, reference, or request a CAP number. Leave the CAP number in the preamble as
   `To Be Assigned`. A CAP number will be assigned by a maintainer just before merge.
-- Set the status in the preamble to `Pre-Draft`. A maintainer moves it to `Draft` on merge.
 - Do not add the proposal to the `core/README.md` as it increases the chance of conflicts at merge
   time. The proposal will be added to the readme by a maintainer.
 - If your CAP requires images or other supporting files, they should be included in a sub-directory

--- a/core/README.md
+++ b/core/README.md
@@ -218,6 +218,8 @@ Introduce your idea on the [stellar-dev mailing list](https://groups.google.com/
 
 [GitHub Discussions]: https://github.com/stellar/stellar-protocol/discussions
 
+- New ideas start as a discussion, not a pull request. A PR that adds a new CAP before the idea has
+  been discussed will be locked and marked as a draft, with a pointer back to this process.
 - Make sure to gather feedback and alternative ideas — it's useful before putting together a
   formal draft!
 - Consider contacting experts in a particular area for feedback while you're hashing out the
@@ -229,12 +231,18 @@ repository. You should make sure to adhere to the following:
 
 - Make sure to place the draft in the `core/` folder.
 - Your CAP should be named `cap-TBD.md`
+- Do not self-assign, reference, or request a CAP number. Leave the CAP number in the preamble as
+  `TBD`. A CAP number will be assigned by a maintainer.
+- Do not add the proposal to the `core/README.md` as it increases the chance of conflicts at merge
+  time. The proposal will be added to the readme by a maintainer.
 - If your CAP requires images or other supporting files, they should be included in a sub-directory
   of the `contents` folder for that CAP, such as `contents/cap-TBD/`. Links
   should be relative, for example a link to an image from your CAP would be
   `../contents/cap-TBD/image.png`.
 
-Finally, submit a PR of your draft via your fork of this repository.
+Finally, submit a PR of your draft via your fork of this repository. Once the idea has been
+discussed and the proposal is ready for a maintainer to review and merge, mark the PR as ready for
+review and ask in your discussion for it to be merged.
 
 #### Additional Tips
 - Use `TBD` for the protocol version. Don't assign a protocol version to the CAP — this will be
@@ -248,8 +256,8 @@ From there, the following process will happen.
 #### CAP gets merged
 If you properly followed the steps above, your PR will get merged.
 
-The CAP and associated files will get renamed based on the latest
-CAP draft number before merging.
+A maintainer will assign the CAP number, and the CAP and associated files will get renamed based on
+that number before merging.
 
 #### Assembling a working group
 

--- a/core/README.md
+++ b/core/README.md
@@ -3,6 +3,8 @@
 ## CAP Status Terms
 
 ### Primary Workflow
+- **Pre-Draft** — A CAP whose idea is being discussed and whose PR has not yet been merged. A
+  maintainer moves it to **Draft** when assigning its CAP number and merging.
 - **Draft** — A CAP that is currently open for consideration and actively being discussed.
 - **Awaiting Decision** — A mature and ready CAP that is ready for final deliberation by the CAP
   Core Team. After a maximum of three meetings, a vote will take place that will set the CAP's
@@ -231,7 +233,8 @@ repository. You should make sure to adhere to the following:
 - Make sure to place the draft in the `core/` folder.
 - Your CAP should be named `cap-TBD.md`
 - Do not self-assign, reference, or request a CAP number. Leave the CAP number in the preamble as
-  `TBD`. A CAP number will be assigned by a maintainer just before merge.
+  `To Be Assigned`. A CAP number will be assigned by a maintainer just before merge.
+- Set the status in the preamble to `Pre-Draft`. A maintainer moves it to `Draft` on merge.
 - Do not add the proposal to the `core/README.md` as it increases the chance of conflicts at merge
   time. The proposal will be added to the readme by a maintainer.
 - If your CAP requires images or other supporting files, they should be included in a sub-directory

--- a/core/README.md
+++ b/core/README.md
@@ -231,7 +231,7 @@ repository. You should make sure to adhere to the following:
 - Make sure to place the draft in the `core/` folder.
 - Your CAP should be named `cap-TBD.md`
 - Do not self-assign, reference, or request a CAP number. Leave the CAP number in the preamble as
-  `TBD`. A CAP number will be assigned by a maintainer.
+  `TBD`. A CAP number will be assigned by a maintainer just before merge.
 - Do not add the proposal to the `core/README.md` as it increases the chance of conflicts at merge
   time. The proposal will be added to the readme by a maintainer.
 - If your CAP requires images or other supporting files, they should be included in a sub-directory


### PR DESCRIPTION
### What

Add a `New CAP Proposal` workflow that mirrors `New SEP Proposal` for PRs adding a new file under `core/`, locking the PR, converting it to a draft, and pointing the author at the CAP process redirecting them to start a discussion first. Add some notes to `core/README.md` to amplify that ideas start as a discussion, and a maintainers assign the CAP number just before merge.

### Why

Maintainers have handled new CAPs this way for a long time. The core/README.md already captures much of this process, the same as SEPs, but core/README.md didn't say cleary who assigns CAP numbers. The workflow is mirrored off the workflow we've been using for SEPs. The changes to the readme don't really introduce any new process just amplify it so it's even more clearer to hopefully both humans and agents when folks use agents to prepare CAPs.