### PR TITLE
CAP-0087: refine cost types and rationale

### DIFF
--- a/core/cap-0087.md
+++ b/core/cap-0087.md
@@ -149,11 +149,11 @@ index 80c0d7f..846022d 100644
 +    MlDsa65DecodeSignature = 90,
 +    // Cost of decoding an ML-DSA-87 signature
 +    MlDsa87DecodeSignature = 91,
-+    // Cost of verifying an ML-DSA-44 signature, linear in message length
++    // Cost of verifying an ML-DSA-44 signature, linear in message + context length
 +    VerifyMlDsa44Sig = 92,
-+    // Cost of verifying an ML-DSA-65 signature, linear in message length
++    // Cost of verifying an ML-DSA-65 signature, linear in message + context length
 +    VerifyMlDsa65Sig = 93,
-+    // Cost of verifying an ML-DSA-87 signature, linear in message length
++    // Cost of verifying an ML-DSA-87 signature, linear in message + context length
 +    VerifyMlDsa87Sig = 94
  };
 ```

--- a/core/cap-0087.md
+++ b/core/cap-0087.md
@@ -48,11 +48,8 @@ accounts (see [CAP-0046-03] and the custom account interface) to authenticate
 with post-quantum signatures, and allows contracts to verify ML-DSA-signed
 attestations produced by external systems. As with secp256r1 ([CAP-0051]),
 performing the verification on the guest side is not practical: ML-DSA
-verification involves expanding a large matrix from a seed via SHAKE-128,
-number-theoretic transforms, and matrix-vector products over a 23-bit prime
-field — the instruction cost of a guest-side implementation exceeds
-reasonable network limits, and a host implementation is both significantly
-cheaper and easier to get right once.
+verification is computationally expensive, and a host implementation is
+both significantly cheaper and easier to get right once.
 
 This proposal deliberately covers contract-level signature verification only.
 It does not change the transaction signature scheme of the Stellar network,
@@ -73,13 +70,7 @@ This CAP is aligned with the following Stellar Network Goals:
 This CAP adds three host functions to the Soroban environment's exported
 interface, `verify_sig_ml_dsa_44`, `verify_sig_ml_dsa_65` and
 `verify_sig_ml_dsa_87`, implementing the FIPS 204 external verification
-interface `ML-DSA.Verify` for the three standardized parameter sets. Each
-function accepts an encoded verifying (public) key, a message, an encoded
-signature, and a context string (0–255 bytes), and traps if the signature is
-malformed or verification fails. Verification is deterministic and requires
-no randomness. Six new `ContractCostType` metering entries are introduced —
-a constant-cost verifying-key decoding type and a message-length-linear
-verification type per parameter set.
+interface `ML-DSA.Verify` for the three standardized parameter sets.
 
 ## Specification
 
@@ -100,7 +91,7 @@ Three new functions with export names `A`, `B` and `C` in the crypto module
     ],
     "return": "Void",
     "docs": "Verifies an ML-DSA-44 (FIPS 204) signature using the external interface ML-DSA.Verify. `public_key` must be a 1312-byte encoded verifying key, `signature` a 2420-byte encoded signature, and `context` a domain-separation string of 0-255 bytes (pass empty bytes if unused). Traps with Object/UnexpectedSize if any input length is wrong, or with Crypto/InvalidInput if the signature is malformed or verification fails.",
-    "min_supported_protocol": 29
+    "min_supported_protocol": 30
 },
 {
     "export": "B",
@@ -113,7 +104,7 @@ Three new functions with export names `A`, `B` and `C` in the crypto module
     ],
     "return": "Void",
     "docs": "Verifies an ML-DSA-65 (FIPS 204) signature using the external interface ML-DSA.Verify. `public_key` must be a 1952-byte encoded verifying key, `signature` a 3309-byte encoded signature, and `context` a domain-separation string of 0-255 bytes (pass empty bytes if unused). Traps with Object/UnexpectedSize if any input length is wrong, or with Crypto/InvalidInput if the signature is malformed or verification fails.",
-    "min_supported_protocol": 29
+    "min_supported_protocol": 30
 },
 {
     "export": "C",
@@ -126,21 +117,24 @@ Three new functions with export names `A`, `B` and `C` in the crypto module
     ],
     "return": "Void",
     "docs": "Verifies an ML-DSA-87 (FIPS 204) signature using the external interface ML-DSA.Verify. `public_key` must be a 2592-byte encoded verifying key, `signature` a 4627-byte encoded signature, and `context` a domain-separation string of 0-255 bytes (pass empty bytes if unused). Traps with Object/UnexpectedSize if any input length is wrong, or with Crypto/InvalidInput if the signature is malformed or verification fails.",
-    "min_supported_protocol": 29
+    "min_supported_protocol": 30
 }
 ```
 
-The `min_supported_protocol` value is 29, the protocol version this CAP is
-released in.
+The `min_supported_protocol` value is 30, the protocol version this CAP
+targets.
 
 ### XDR changes
 
 ```diff mddiffcheck.ignore=true
 diff --git a/Stellar-contract-config-setting.x b/Stellar-contract-config-setting.x
+index 80c0d7f..846022d 100644
 --- a/Stellar-contract-config-setting.x
 +++ b/Stellar-contract-config-setting.x
-@@ -293,7 +293,19 @@ enum ContractCostType {
-      // Cost of performing BN254 G1 multi-scalar multiplication (MSM)
+@@ -296,5 +296,23 @@ enum ContractCostType {
+     // Cost of performing BN254 scalar element inversion
+     Bn254FrInv = 84,
+     // Cost of performing BN254 G1 multi-scalar multiplication (MSM)
 -    Bn254G1Msm = 85
 +    Bn254G1Msm = 85,
 +    // Cost of decoding and expanding an ML-DSA-44 verifying key
@@ -149,12 +143,18 @@ diff --git a/Stellar-contract-config-setting.x b/Stellar-contract-config-setting
 +    MlDsa65DecodeVerifyingKey = 87,
 +    // Cost of decoding and expanding an ML-DSA-87 verifying key
 +    MlDsa87DecodeVerifyingKey = 88,
++    // Cost of decoding an ML-DSA-44 signature
++    MlDsa44DecodeSignature = 89,
++    // Cost of decoding an ML-DSA-65 signature
++    MlDsa65DecodeSignature = 90,
++    // Cost of decoding an ML-DSA-87 signature
++    MlDsa87DecodeSignature = 91,
 +    // Cost of verifying an ML-DSA-44 signature, linear in message length
-+    VerifyMlDsa44Sig = 89,
++    VerifyMlDsa44Sig = 92,
 +    // Cost of verifying an ML-DSA-65 signature, linear in message length
-+    VerifyMlDsa65Sig = 90,
++    VerifyMlDsa65Sig = 93,
 +    // Cost of verifying an ML-DSA-87 signature, linear in message length
-+    VerifyMlDsa87Sig = 91
++    VerifyMlDsa87Sig = 94
  };
 ```
 
@@ -187,8 +187,8 @@ All encodings are exactly as specified in FIPS 204.
 - **Context**: an application-chosen domain-separation byte string of length
   0 to 255, as defined by the FIPS 204 external interface. An empty context
   is valid and is the default for signers that do not use one.
-- **Message**: an arbitrary byte string. The full message must be provided;
-  see the design rationale for why a pre-hashed interface is not offered.
+- **Message**: an arbitrary byte string — the message over which the
+  signature was produced.
 
 #### Verification semantics
 
@@ -223,10 +223,9 @@ string for a given verifying key, per the FIPS 204 external interface of the
 pure variant.
 
 **Cost**: covers decoding and expanding the verifying key
-(`MlDsa{44,65,87}DecodeVerifyingKey`), and decoding the signature plus
-performing the verification (`VerifyMlDsa{44,65,87}Sig`, linear in the
-message length). Input byte copies are covered by the existing `MemCpy` cost
-type.
+(`MlDsa{44,65,87}DecodeVerifyingKey`), decoding the signature
+(`MlDsa{44,65,87}DecodeSignature`), and performing the verification
+(`VerifyMlDsa{44,65,87}Sig`, linear in the message length).
 
 **Error condition**: the function traps if any of the following hold.
 
@@ -254,20 +253,24 @@ than returning a boolean (see [Design Rationale](#design-rationale)).
   Type: constant.
 - `MlDsa65DecodeVerifyingKey` - Same as above for ML-DSA-65. Type: constant.
 - `MlDsa87DecodeVerifyingKey` - Same as above for ML-DSA-87. Type: constant.
-- `VerifyMlDsa44Sig` - Cost of decoding an ML-DSA-44 signature and verifying
-  it: hint and response-vector unpacking and validation, `SampleInBall`,
-  NTTs and matrix-vector products, hint application, and the SHAKE-256
-  computation of the message representative `mu`. Type: linear w.r.t. the
-  message byte length (the SHAKE-256 absorption of the message is the only
-  input-dependent component; everything else is fixed by the parameter set).
+- `MlDsa44DecodeSignature` - Cost of decoding an ML-DSA-44 signature: hint
+  and response-vector unpacking and validation. Type: constant.
+- `MlDsa65DecodeSignature` - Same as above for ML-DSA-65. Type: constant.
+- `MlDsa87DecodeSignature` - Same as above for ML-DSA-87. Type: constant.
+- `VerifyMlDsa44Sig` - Cost of verifying an ML-DSA-44 signature:
+  `SampleInBall`, NTTs and matrix-vector products, hint application, and
+  the SHAKE-256 computation of the message representative `mu`. Type:
+  linear w.r.t. the message byte length (the SHAKE-256 absorption of the
+  message is the only input-dependent component; everything else is fixed
+  by the parameter set).
 - `VerifyMlDsa65Sig` - Same as above for ML-DSA-65. Type: linear w.r.t. the
   message byte length.
 - `VerifyMlDsa87Sig` - Same as above for ML-DSA-87. Type: linear w.r.t. the
   message byte length.
 
-Each parameter set receives its own pair of cost types because the fixed
+Each parameter set receives its own set of cost types because the fixed
 work scales with the matrix dimensions `k × l` (16, 30 and 56 polynomial
-products respectively), rather than a single dimension. Final calibration 
+products respectively), rather than a single dimension. Final calibration
 parameters are TBD; see [Resource Utilization](#resource-utilization).
 
 ## Design Rationale
@@ -301,8 +304,9 @@ sampling, hint operations — in the style of the BLS12-381 host functions
 themselves. This was rejected for the following reasons:
 
 - **No composability demand.** Unlike the BLS12-381 functions, from which
-  many distinct protocols are built, ML-DSA verification is a single fixed algorithm; 
-  there has not been strong requirement signals for its internals from established protocols.
+  many distinct protocols are built, ML-DSA verification is a single fixed
+  algorithm; there have not been strong requirement signals for its
+  internals from established protocols.
 - **The shared layer is too thin.** In practice the generic module-lattice
   algebra (polynomial vectors/matrices and their arithmetic) is a small
   fraction of the scheme. The NTT (with scheme-specific moduli and twiddle
@@ -357,18 +361,24 @@ be substituted for `M`. The message length is accounted for by the linear
 term of the verification cost types.
 
 FIPS 204 does define a digest-style interface — the pre-hashed variant
-HashML-DSA (§5.4, Algorithms 4–5) — which takes `PH(M)` (a pre-hash of the
-message) plus an identifier of the pre-hash function, and is then verified
-through the *same* `ML-DSA.Verify_internal`. It is omitted here by choice:
+HashML-DSA (§5.4, Algorithms 4–5) — which takes the full message `M` plus
+an identifier of the pre-hash function `PH`, computes `PH(M)` internally,
+and is then verified through the *same* `ML-DSA.Verify_internal`. It is
+omitted here by choice:
 
 - FIPS 204 states the pure variant is generally preferred (§5.4);
-- HashML-DSA's message binding additionally depends on the collision
-  resistance of a caller-chosen pre-hash function whereas the pure variant 
-  carries no such external assumption
+- the full message is still a required input to HashML-DSA, so it offers no
+  payload reduction; the only difference is that the caller may choose the
+  pre-hash function (that choice does not affect the SHAKE-128/256 hashing
+  internal to ML-DSA, which is fixed by the standard);
+- that pre-hash must come from the approved list and be chosen at a
+  security strength matching the ML-DSA parameter set, so message binding
+  comes to depend on the collision resistance of a caller-chosen function —
+  an external assumption the pure variant does not carry.
 
-It can be added later — as a separate external function that performs the
-`0x01 || len(ctx) || ctx || OID` formatting from a caller-supplied digest —
-if signer ecosystems converge on it.
+It can be added later as a separate external function implementing
+`HashML-DSA.Verify` (FIPS 204 Algorithm 5), taking the full message and an
+identifier of the pre-hash function, if signer ecosystems converge on it.
 
 ### Exposing the external interface rather than the internal interface
 
@@ -387,10 +397,11 @@ interface out of the host and into the sdk/caller:
 - **There is no context parameter to validate.** `ML-DSA.Verify_internal`
   takes only `(pk, M', sigma)` (Algorithm 8); the context is not a distinct
   input but bytes the caller has already folded into `M'`. The internal
-  interface cannot check the context since `M'` is deliberately variant-agnostic. 
-  The `|ctx| <= 255` bound is a property of the external encoding. Exposing the
-  internal interface therefore removes the notion of a context field entirely 
-  and makes the whole `M'` layout the caller's responsibility.
+  interface cannot check the context since `M'` is deliberately
+  variant-agnostic. The `|ctx| <= 255` bound is a property of the external
+  encoding. Exposing the internal interface therefore removes the notion of
+  a context field entirely and makes the whole `M'` layout the caller's
+  responsibility.
 - **The pre-hash OID encoding becomes a contract-side footgun.** A contract
   doing pre-hashing must reproduce the exact DER-encoded OID and byte layout
   of Algorithm 4; a subtle error silently verifies a non-standard scheme.
@@ -408,14 +419,17 @@ variant can be considered if there is a specific need for fallible verification.
 
 ### Choice of the cost types
 
-The decode/verify split mirrors the existing
-`ComputeEd25519PubKey`/`VerifyEd25519Sig` decomposition and follows the
-selection criteria of [CAP-0046-10]: the two components are distinct,
-non-overlapping units of work with different scaling behavior. Key decoding
-is dominated by the SHAKE-128 expansion of the `k × l` matrix `A_hat` and
-its NTT-domain precomputation — constant per parameter set and independent
-of the message. Verification proper (signature decoding, `SampleInBall`,
-NTTs, matrix-vector products, hint application, and the `mu` computation) is
+The split mirrors the existing `ComputeEd25519PubKey`/`VerifyEd25519Sig`
+decomposition and follows the selection criteria of [CAP-0046-10]: the
+three components are distinct, non-overlapping units of work with
+different scaling behavior. Key decoding is dominated by the SHAKE-128
+expansion of the `k × l` matrix `A_hat` and its NTT-domain precomputation
+— constant per parameter set and independent of the message. Signature
+decoding — hint and response-vector unpacking and their validity checks —
+is likewise constant per parameter set, and is metered on its own because
+a structurally invalid signature is rejected there, before any
+verification work is charged. Verification proper (`SampleInBall`, NTTs,
+matrix-vector products, hint application, and the `mu` computation) is
 constant except for the SHAKE-256 absorption of the message, making it a
 clean linear model in message length. Separating key decoding also leaves
 room for a future optimization in which expanded verifying keys are cached

--- a/core/cap-0087.md
+++ b/core/cap-0087.md
@@ -225,7 +225,7 @@ pure variant.
 **Cost**: covers decoding and expanding the verifying key
 (`MlDsa{44,65,87}DecodeVerifyingKey`), decoding the signature
 (`MlDsa{44,65,87}DecodeSignature`), and performing the verification
-(`VerifyMlDsa{44,65,87}Sig`, linear in the message length).
+(`VerifyMlDsa{44,65,87}Sig`, linear in the combined message and context length).
 
 **Error condition**: the function traps if any of the following hold.
 


### PR DESCRIPTION
Refinements to CAP-0087:

- Bump `min_supported_protocol` to 30.
- Add separate signature-decoding cost types.
- Correct the HashML-DSA rationale.

Plus editorial cleanup.
